### PR TITLE
Add inventorypartnerdomain to app/site

### DIFF
--- a/2.6.md
+++ b/2.6.md
@@ -1819,22 +1819,27 @@ This object describes the entity who directly supplies inventory to and is paid 
     <td><code>name</code></td>
     <td>string</td>
     <td>Seller name (may be aliased at the seller's request).</td>
- </tr>
+  </tr>
   <tr>
     <td><code>cattax</code></td>
     <td>integer; default 1</td>
     <td>The taxonomy in use. Refer to the AdCOM <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_categorytaxonomies">List: Category Taxonomies</a> for values.</td>
-   <tr>
+  <tr>
   </tr>
     <td><code>cat</code></td>
     <td>string array</td>
     <td>Array of IAB Tech Lab content categories of the publisher. The taxonomy to be used is defined by the cattax field. If no cattax field is supplied Content Category Taxonomy 1.0 is assumed.</td>
-   </tr>
-   <tr>
+  </tr>
+  <tr>
     <td><code>domain</code></td>
     <td>string</td>
     <td>Highest level domain of the seller (e.g., "seller.com").</td>
-</tr>
+  </tr>
+  <tr>
+    <td><code>inventorypartnerdomain</code></td>
+    <td>string</td>
+    <td>A domain to be used for inventory authorization in the case of inventory sharing arrangements between a site owner and content owner. This field is typically used by authorization crawlers to establish the domain of the content owner, who has the right to monetize some portion of ad inventory within the site. The content owner's domain should be listed in the site owner's ads.txt file as an <code>inventorypartnerdomain</code>. Authorization for supply from the <code>inventorypartnerdomain</code> will be published in the ads.txt file on the root of that domain. Refer to <a href="https://iabtechlab.com/wp-content/uploads/2022/04/Ads.txt-1.1.pdf">the ads.txt 1.1 spec</a> for more details.</td>
+  </tr>
   <tr>
     <td><code>ext</code></td>
     <td>object</td>
@@ -1864,7 +1869,7 @@ This object describes the content in which the impression will appear, which may
     <td><code>episode</code></td>
     <td>integer</td>
     <td>Episode number.</td>
- </tr>
+  </tr>
   <tr>
     <td><code>title</code></td>
     <td>string</td>
@@ -1874,7 +1879,7 @@ This object describes the content in which the impression will appear, which may
     <td><code>series</code></td>
     <td>string</td>
     <td>Content series.<br>*Video Examples:* “The Office” (television), “Star Wars” (movie), or “Arby ‘N’ The Chief” (made for web).<br>*Non-Video Example:* “Ecocentric” (Time Magazine blog).</td>
-</tr>
+  </tr>
   <tr>
     <td><code>season</code></td>
     <td>string</td>
@@ -1884,13 +1889,13 @@ This object describes the content in which the impression will appear, which may
     <td><code>artist</code></td>
     <td>string</td>
     <td>Artist credited with the content.</td>
-   <tr>
   </tr>
+  <tr>
     <td><code>genre</code></td>
     <td>string</td>
     <td>Genre that best describes the content (e.g., rock, pop, etc).</td>
-   </tr>
-   <tr>
+  </tr>
+  <tr>
     <td><code>album</code></td>
     <td>string</td>
     <td>Album to which the content belongs; typically for audio.</td>
@@ -1904,18 +1909,18 @@ This object describes the content in which the impression will appear, which may
     <td><code>producer</code></td>
     <td>object</td>
     <td>Details about the content <code>Producer</code> (Section 3.2.17).</td>
-   <tr>
   </tr>
+  <tr>
     <td><code>url</code></td>
     <td>string</td>
     <td>URL of the content, for buy-side contextualization or review.</td>
-   </tr>
-   <tr>
+  </tr>
+  <tr>
     <td><code>cattax</code></td>
     <td>integer; default 1</td>
     <td>The taxonomy in use. Refer to list <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_categorytaxonomies">List: Category Taxonomies</a> in AdCOM 1.0 for values.</td>
-  <tr>
   </tr>
+  <tr>
     <td><code>cat</code></td>
     <td>string array</td>
     <td>Array of IAB Tech Lab content categories that describe the content. The taxonomy to be used is defined by the cattax field. If no cattax field is supplied Content Category Taxonomy 1.0 is assumed.</td>
@@ -1924,28 +1929,28 @@ This object describes the content in which the impression will appear, which may
     <td><code>prodq</code></td>
     <td>integer</td>
     <td>Production quality. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--production-qualities-">List: Production Qualities</a> in AdCOM 1.0.</td>
-   <tr>
   </tr>
+  <tr>
     <td><code>context</code></td>
     <td>integer</td>
     <td>Type of content (game, video, text, etc.). Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--content-contexts-">List: Content Contexts</a> in AdCOM 1.0.</td>
-   </tr>
-   <tr>
+  </tr>
+  <tr>
     <td><code>contentrating</code></td>
     <td>string</td>
     <td>Content rating (e.g., MPAA).</td>
-<tr>
   </tr>
+  <tr>
     <td><code>userrating</code></td>
     <td>string</td>
     <td>User rating of the content (e.g., number of stars, likes, etc.).</td>
-   </tr>
-   <tr>
+  </tr>
+  <tr>
     <td><code>qagmediarating</code></td>
     <td>integer</td>
     <td>Media rating per IQG guidelines. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--media-ratings-">List: Media Ratings</a> in AdCOM 1.0.</td>
-  <tr>
   </tr>
+  <tr>
     <td><code>keywords</code></td>
     <td>string</td>
     <td>Comma separated list of keywords describing the content. Only one of <code>keywords</code> or <code>kwarray</code> may be present.</td>
@@ -1954,23 +1959,23 @@ This object describes the content in which the impression will appear, which may
     <td><code>kwarry</code></td>
     <td>string array</td>
     <td>Array of keywords about the site. Only one of <code>keywords</code> or <code>kwarray</code> may be present.</td>
-   <tr>
   </tr>
+  <tr>
     <td><code>livestream</code></td>
     <td>integer</td>
     <td>0 = not live, 1 = content is live (e.g., stream, live blog).</td>
-   </tr>
-   <tr>
+  </tr>
+  <tr>
     <td><code>sourcerelationship</code></td>
     <td>integer</td>
     <td>0 = indirect, 1 = direct.</td>
- <tr>
   </tr>
+  <tr>
     <td><code>len</code></td>
     <td>integer</td>
     <td>Length of content in seconds; appropriate for video or audio.</td>
- <tr>
   </tr>
+  <tr>
     <td><code>language</code></td>
     <td>string</td>
     <td>Content language using ISO-639-1-alpha-2. Only one of <code>language</code> or <code>langb</code> should be present.</td>
@@ -1979,33 +1984,36 @@ This object describes the content in which the impression will appear, which may
     <td><code>langb</code></td>
     <td>string</td>
     <td>Content language using IETF BCP 47. Only one of <code>language</code> or <code>langb</code> should be present.</td>
-   <tr>
   </tr>
+  <tr>
     <td><code>embeddable</code></td>
     <td>integer</td>
     <td>Indicator of whether the content is embeddable (e.g., an embeddable video player), where 0 = no, 1 = yes.</td>
-   </tr>
-   <tr>
+  </tr>
+  <tr>
     <td><code>data</code></td>
     <td>object array</td>
     <td>Additional content data. Each <code>Data</code> object (Section 3.2.21) represents a different data source.</td>
- <tr>
   </tr>
+  <tr>
     <td><code>network</code></td>
     <td>object</td>
     <td>Details about the network (Section 3.2.23) the content is on.</td>
- <tr>
   </tr>
+  <tr>
     <td><code>channel</code></td>
     <td>object</td>
     <td>Details about the channel (Section 3.2.24) the content is on.</td>
- <tr>
   </tr>
+  <tr>
+    <td><code>inventorypartnerdomain</code></td>
+    <td>string</td>
+    <td>A domain to be used for inventory authorization in the case of inventory sharing arrangements between an app owner and content owner. This field is typically used by authorization crawlers to establish the domain of the content owner, who has the right to monetize some portion of ad inventory within the app. The content owner's domain should be listed in the app owner's app-ads.txt file as an <code>inventorypartnerdomain</code>. Authorization for supply from the <code>inventorypartnerdomain</code> will be published in the ads.txt file on the root of that domain. Refer to <a href="https://iabtechlab.com/wp-content/uploads/2022/04/Ads.txt-1.1.pdf">the ads.txt 1.1 spec</a> for more details.</td>
+  </tr>
+  <tr>
     <td><code>ext</code></td>
     <td>object</td>
     <td>Placeholder for exchange-specific extensions to OpenRTB.</td>
-     </td>
-     </td>
   </tr>
 </table>
 


### PR DESCRIPTION
Added the inventorypartnerdomain field in the App and Site objects. Propose adding these directly to the mainline, as opposed to an extension, because this is a core usecase. Better to mainline early than wait, because migration will be harder once there's more industry adoption.

Also did some minor repair/reformat of the <tr> tags in the table for the App fields.