### PR TITLE
Add 'etime' to the 'imp' object

### DIFF
--- a/2.6.md
+++ b/2.6.md
@@ -967,6 +967,11 @@ The presence of `Banner` (Section 3.2.6), `Video` (Section 3.2.7), and/or `Nativ
     <td>Advisory as to the number of seconds that may elapse between the auction and the actual impression.</td>
   </tr>
   <tr>
+    <td><code>etime</code></td>
+    <td>integer</td>
+    <td>The minimum exposure time, in seconds per view, that the (uninterrupted) player will display the creative before refreshing to the next creative. If the field is absent, the exposure time is unknown. If 0, the exposure time is indefinite.</td>
+  </tr>
+  <tr>
     <td><code>ext</code></td>
     <td>object</td>
     <td>Placeholder for exchange-specific extensions to OpenRTB.</td>


### PR DESCRIPTION
This field is submitted separately from #14 since it can serve the "ad refresh" use case as well.