### PR TITLE
Moved inventorypartnerdomain to the intended location

### DIFF
--- a/2.6.md
+++ b/2.6.md
@@ -1700,7 +1700,12 @@ This object should be included if the ad supported content is a website as oppos
     <td><code>kwarray</code></td>
     <td>string array</td>
     <td>Array of keywords about the site. Only one of <code>keywords</code> or <code>kwarray</code> may be present.</td>
- <tr>
+  <tr>
+  <tr>
+    <td><code>inventorypartnerdomain</code></td>
+    <td>string</td>
+    <td>A domain to be used for inventory authorization in the case of inventory sharing arrangements between a site owner and content owner. This field is typically used by authorization crawlers to establish the domain of the content owner, who has the right to monetize some portion of ad inventory within the site. The content owner's domain should be listed in the site owner's ads.txt file as an <code>inventorypartnerdomain</code>. Authorization for supply from the <code>inventorypartnerdomain</code> will be published in the ads.txt file on the root of that domain. Refer to <a href="https://iabtechlab.com/wp-content/uploads/2022/04/Ads.txt-1.1.pdf">the ads.txt 1.1 spec</a> for more details.</td>
+  </tr>
   </tr>
     <td><code>ext</code></td>
     <td>object</td>
@@ -1801,7 +1806,12 @@ This object should be included if the ad supported content is a non-browser appl
     <td><code>kwarray</code></td>
     <td>string array</td>
     <td>Array of keywords about the app. Only one of <code>keywords</code> or <code>kwarray</code> may be present.</td>
- <tr>
+  <tr>
+  <tr>
+    <td><code>inventorypartnerdomain</code></td>
+    <td>string</td>
+    <td>A domain to be used for inventory authorization in the case of inventory sharing arrangements between an app owner and content owner. This field is typically used by authorization crawlers to establish the domain of the content owner, who has the right to monetize some portion of ad inventory within the app. The content owner's domain should be listed in the app owner's app-ads.txt file as an <code>inventorypartnerdomain</code>. Authorization for supply from the <code>inventorypartnerdomain</code> will be published in the ads.txt file on the root of that domain. Refer to <a href="https://iabtechlab.com/wp-content/uploads/2022/04/Ads.txt-1.1.pdf">the ads.txt 1.1 spec</a> for more details.</td>
+  </tr>
   </tr>
     <td><code>ext</code></td>
     <td>object</td>
@@ -1849,11 +1859,6 @@ This object describes the entity who directly supplies inventory to and is paid 
     <td><code>domain</code></td>
     <td>string</td>
     <td>Highest level domain of the seller (e.g., "seller.com").</td>
-  </tr>
-  <tr>
-    <td><code>inventorypartnerdomain</code></td>
-    <td>string</td>
-    <td>A domain to be used for inventory authorization in the case of inventory sharing arrangements between a site owner and content owner. This field is typically used by authorization crawlers to establish the domain of the content owner, who has the right to monetize some portion of ad inventory within the site. The content owner's domain should be listed in the site owner's ads.txt file as an <code>inventorypartnerdomain</code>. Authorization for supply from the <code>inventorypartnerdomain</code> will be published in the ads.txt file on the root of that domain. Refer to <a href="https://iabtechlab.com/wp-content/uploads/2022/04/Ads.txt-1.1.pdf">the ads.txt 1.1 spec</a> for more details.</td>
   </tr>
   <tr>
     <td><code>ext</code></td>
@@ -2019,11 +2024,6 @@ This object describes the content in which the impression will appear, which may
     <td><code>channel</code></td>
     <td>object</td>
     <td>Details about the channel (Section 3.2.24) the content is on.</td>
-  </tr>
-  <tr>
-    <td><code>inventorypartnerdomain</code></td>
-    <td>string</td>
-    <td>A domain to be used for inventory authorization in the case of inventory sharing arrangements between an app owner and content owner. This field is typically used by authorization crawlers to establish the domain of the content owner, who has the right to monetize some portion of ad inventory within the app. The content owner's domain should be listed in the app owner's app-ads.txt file as an <code>inventorypartnerdomain</code>. Authorization for supply from the <code>inventorypartnerdomain</code> will be published in the ads.txt file on the root of that domain. Refer to <a href="https://iabtechlab.com/wp-content/uploads/2022/04/Ads.txt-1.1.pdf">the ads.txt 1.1 spec</a> for more details.</td>
   </tr>
   <tr>
     <td><code>ext</code></td>


### PR DESCRIPTION
Moved from mistaken location (Content and Publisher objects) to intended location (App and Site objects).