### PR TITLE
Add case to instream implementation for plcmt

### DIFF
--- a/implementation.md
+++ b/implementation.md
@@ -1537,7 +1537,7 @@ Here is an example ad request:
 	
 <strong> Case 3: muted pre-roll </strong>
 	
-If a publisher or player would like to send both the legacy value for In-stream to support DSPs that have no other way to identify pre-roll, mid-roll, or post-roll and the updated definition of Accompanying Content because the video begins muted it should send the legacy value of placement=1 using the legacy <code>placement</code> attribute and the updated value of plcmt=2 using the <code>plcmt</code> attribute attributes in the video object. 
+If a publisher or player would like to send both the legacy value for In-stream to support DSPs that have no other way to identify pre-roll, mid-roll, or post-roll and the updated definition of Accompanying Content because the video begins muted it should send the legacy value of placement=1 using the legacy <code>placement</code> attribute and the updated value of plcmt=2 using the <code>plcmt</code> attribute in the video object. 
 
 Here is an example ad request: 
 

--- a/implementation.md
+++ b/implementation.md
@@ -1537,12 +1537,26 @@ Here is an example ad request:
 	
 <strong> Case 3: muted pre-roll </strong>
 	
-If a publisher or player would like to send both the legacy value for In-stream to support DSPs that have no other way to identify pre-roll, mid-roll, or post-roll and the updated definition of Accompanying Content because the video begins muted it should send the legacy value of <code>placement=1</code> using the legacy <code>placement</code> attribute and the updated value of <code>plcmt=2</code> using the <code>plcmt</code> attribute in the video object. Muted pre-roll that only has <code>video.placement = 1</code> without the additional field of <code>video.plcmt = 2</code> is not declared accurately. 
+If a publisher or player would like to send both the legacy value for In-stream to support DSPs that have no other way to identify pre-roll, mid-roll, or post-roll and the updated definition of Accompanying Content because the video begins muted it should send the legacy value of <code>placement=1</code> using the legacy <code>placement</code> attribute and the updated value of <code>plcmt=2</code> using the <code>plcmt</code> attribute in the video object. 
+
+Muted pre-roll that only has <code>video.placement = 1</code> without the additional field of <code>video.plcmt = 2</code> is not declared accurately. 
 
 Here is an example ad request: 
 
 	"video": {
 	“placement”: “1”
 	“plcmt”: “2” 
+	}
+
+Here is an example invalid ad request: 
+
+	"video": {
+	“placement”: “1”
+	}
+
+If providers are unable to pass `plcmt`, here is an alternative valid ad request until they are able to transition to the first example: 
+
+	"video": {
+	“placement”: “3”
 	}
 

--- a/implementation.md
+++ b/implementation.md
@@ -1537,7 +1537,7 @@ Here is an example ad request:
 	
 <strong> Case 3: muted pre-roll </strong>
 	
-If a publisher or player would like to send both the legacy value for In-stream to support DSPs that have no other way to identify pre-roll, mid-roll, or post-roll and the updated definition of Accompanying Content because the video begins muted it should send the legacy value of placement=1 using the legacy <code>placement</code> attribute and the updated value of plcmt=2 using the <code>plcmt</code> attribute in the video object. 
+If a publisher or player would like to send both the legacy value for In-stream to support DSPs that have no other way to identify pre-roll, mid-roll, or post-roll and the updated definition of Accompanying Content because the video begins muted it should send the legacy value of placement=1 using the legacy <code>placement</code> attribute and the updated value of <code>plcmt=2</code> using the <code>plcmt</code> attribute in the video object. Muted pre-roll that only has <code>video.placement = 1</code> without the additional field of <code>video.plcmt = 2</code> is not declared accurately. 
 
 Here is an example ad request: 
 

--- a/implementation.md
+++ b/implementation.md
@@ -1537,7 +1537,7 @@ Here is an example ad request:
 	
 <strong> Case 3: muted pre-roll </strong>
 	
-If a publisher or player would like to send both the legacy value for In-stream to support DSPs that have no other way to identify pre-roll, mid-roll, or post-roll and the updated definition of Accompanying Content because the video begins muted it should send the legacy value of placement=1 using the legacy <code>placement</code> attribute and the updated value of <code>plcmt=2</code> using the <code>plcmt</code> attribute in the video object. Muted pre-roll that only has <code>video.placement = 1</code> without the additional field of <code>video.plcmt = 2</code> is not declared accurately. 
+If a publisher or player would like to send both the legacy value for In-stream to support DSPs that have no other way to identify pre-roll, mid-roll, or post-roll and the updated definition of Accompanying Content because the video begins muted it should send the legacy value of <code>placement=1</code> using the legacy <code>placement</code> attribute and the updated value of <code>plcmt=2</code> using the <code>plcmt</code> attribute in the video object. Muted pre-roll that only has <code>video.placement = 1</code> without the additional field of <code>video.plcmt = 2</code> is not declared accurately. 
 
 Here is an example ad request: 
 

--- a/implementation.md
+++ b/implementation.md
@@ -1539,7 +1539,7 @@ Here is an example ad request:
 	
 If a publisher or player would like to send both the legacy value for In-stream to support DSPs that have no other way to identify pre-roll, mid-roll, or post-roll and the updated definition of Accompanying Content because the video begins muted it should send the legacy value of <code>placement=1</code> using the legacy <code>placement</code> attribute and the updated value of <code>plcmt=2</code> using the <code>plcmt</code> attribute in the video object. 
 
-Muted pre-roll that only has <code>video.placement = 1</code> without the additional field of <code>video.plcmt = 2</code> is not declared accurately. 
+Muted pre-roll that only has <code>video.placement = 1</code> without the additional field of <code>video.plcmt = 2</code> is not declared accurately. This guidance does not condone known inappropriate labels.
 
 Here is an example ad request: 
 

--- a/implementation.md
+++ b/implementation.md
@@ -1533,4 +1533,16 @@ Here is an example ad request:
 	“placement”: “3”
 	“plcmt”: “4” 
 	}
+	
+	
+<strong> Case 3: muted pre-roll </strong>
+	
+If a publisher or player would like to send both the legacy value for In-stream to support DSPs that have no other way to identify pre-roll, mid-roll, or post-roll and the updated definition of Accompanying Content because the video begins muted it should send the legacy value of placement=1 using the legacy <code>placement</code> attribute and the updated value of plcmt=2 using the <code>plcmt</code> attribute attributes in the video object. 
+
+Here is an example ad request: 
+
+	"video": {
+	“placement”: “1”
+	“plcmt”: “2” 
+	}
 


### PR DESCRIPTION
Attempt to clarify correct way to declare muted pre-roll during the transition period while some dsps don't yet support plcmt yet need to distinguish preroll from outstream. 