### PR TITLE
Move refresh object time description into the time field

### DIFF
--- a/2.6.md
+++ b/2.6.md
@@ -2951,7 +2951,7 @@ Information on how often and what triggers an ad slot being refreshed.
   <tr>
     <td><code>min_int</code></td>
     <td>integer; recommended</td>
-    <td>The minimum refresh interval in seconds. This applies to all refresh types. This is the (uninterrupted) ad creative will be rendered before refreshing to the next creative. If the field is absent, the exposure time is unknown. This field does not account for viewability or external factors such as a user leaving a page.
+    <td>The minimum refresh interval in seconds. This applies to all refresh types. This is the (uninterrupted) time the ad creative will be rendered before refreshing to the next creative. If the field is absent, the exposure time is unknown. This field does not account for viewability or external factors such as a user leaving a page.
 </td>
  </td>
  <tr>

--- a/2.6.md
+++ b/2.6.md
@@ -2905,8 +2905,6 @@ This object should be included if the ad supported content is a Digital Out-Of-H
 |ext         |object             |Placeholder for exchange-specific extensions to OpenRTB.                                                                                                                                                                                 |
 ### 3.2.33 - Object: Refresh <a name="objectrefresh"></a>
 
-The minimum exposure time, in seconds per view, that the (uninterrupted) ad creative will be rendered before refreshing to the next creative. If the field is absent, the exposure time is unknown. This field does not account for viewability or external factors such as a user leaving a page.
-
 <table>
   <tr>
     <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
@@ -2953,7 +2951,8 @@ Information on how often and what triggers an ad slot being refreshed.
   <tr>
     <td><code>min_int</code></td>
     <td>integer; recommended</td>
-    <td>The minimum refresh interval in seconds. This applies to all refresh types.</td>
+    <td>The minimum refresh interval in seconds. This applies to all refresh types. This is the (uninterrupted) ad creative will be rendered before refreshing to the next creative. If the field is absent, the exposure time is unknown. This field does not account for viewability or external factors such as a user leaving a page.
+</td>
  </td>
  <tr>
     <td><code>ext</code></td>


### PR DESCRIPTION
The time description was applied to the whole object, this moves it into the time field