### PR TITLE
Adding optional parameters already extensively used by mobile platforms

### DIFF
--- a/2.6.md
+++ b/2.6.md
@@ -803,6 +803,11 @@ There are also several subordinate objects that provide detailed data to potenti
     <td>A Regs object (Section 3.2.3) that specifies any industry, legal, or governmental regulations in force for this request.</td>
   </tr>
   <tr>
+    <td><code>acat</code></td>
+    <td>string array</td>
+    <td>Allow list of category of apps permitted for the offered ad opportunity</td>
+  </tr>
+  <tr>
     <td><code>ext</code></td>
     <td>object</td>
     <td>Placeholder for exchange-specific extensions to OpenRTB.</td>

--- a/2.6.md
+++ b/2.6.md
@@ -775,7 +775,12 @@ There are also several subordinate objects that provide detailed data to potenti
   <tr>
     <td><code>bcat</code></td>
     <td>string array</td>
-    <td>Blocked advertiser categories using the specified category taxonomy. <br>The taxonomy to be used is defined by the <code>cattax</code> field. If no <code>cattax</code> field is supplied IAB Content Taxonomy 1.0 is assumed.</td>
+    <td>Blocked advertiser categories using the specified category taxonomy. <br>The taxonomy to be used is defined by the <code>cattax</code> field. If no <code>cattax</code> field is supplied IAB Content Taxonomy 1.0 is assumed.<br />Only one of acat/bcat should be present.</td>
+  </tr>
+  <tr>
+    <td><code>acat</code></td>
+    <td>string array</td>
+    <td>Allowed advertiser categories using the specified category taxonomy. <br>The taxonomy to be used is defined by the <code>cattax</code> field. If no <code>cattax</code> field is supplied IAB Content Taxonomy 1.0 is assumed.<br />Only one of acat/bcat should be present.</td>
   </tr>
   <tr>
     <td><code>cattax</code></td>
@@ -2191,6 +2196,11 @@ This object provides information pertaining to the device through which the user
     <td>Device model (e.g., “iPhone”).</td>
    </tr>
    <tr>
+    <td><code>brand</code></td>
+    <td>string</td>
+    <td>Brand of the device; Many device manufacturers subdivide their devices into brands (eg. Xiaomi, Poco, Mi, Redmi).</td>
+   </tr>
+   <tr>
     <td><code>os</code></td>
     <td>string</td>
     <td>Device operating system (e.g., “iOS”).</td>
@@ -2301,16 +2311,7 @@ This object provides information pertaining to the device through which the user
     <td>MAC address of the device; hashed via MD5.</td>
  <tr>
    </tr>
-    <td><code>brand</code></td>
-    <td>string</td>
-    <td>Brand of the device; Many mobile device manufacturers subdivide their devices into brands (eg. Samsung Galaxy S-Series, Samsung Galaxy A-Series), each of which may have different capabilities and limitations.</td>
  <tr>
-   </tr>
-    <td><code>os</code></td>
-    <td>string</td>
-    <td>Operating system of the device; Different device operating systems have different capabilities, and each OS may require different methods of interaction and measurement. Examples include “android”, “iOS” and “harmonyos”.</td>
- <tr>
-  </tr>
     <td><code>ext</code></td>
     <td>object</td>
     <td>Placeholder for exchange-specific extensions to OpenRTB.</td>

--- a/2.6.md
+++ b/2.6.md
@@ -1021,19 +1021,6 @@ The presence of `Banner` (Section 3.2.6), `Video` (Section 3.2.7), and/or `Nativ
     </td>
   </tr>
   <tr>
-    <td><code>ainteractiontype</code></td>
-    <td>integer array</td>
-    <td>This is a list of the methods of interaction a placement permits.
-    The methods of interaction currently defined have been assigned these values;<br />
-    <br />
-    1 = Click to OPEN a WEBSITE<br />
-    2 = Click to DOWNLOAD an APP<br />
-    3 = Click to REDIRECT to an APP<br />
-    4 = Click to REDIRECT to a QuickApp<br />
-    10 = Click to REDIRECT to a MiniApp<br />
-    </td>
-  </tr>
-  <tr>
     <td><code>ext</code></td>
     <td>object</td>
     <td>Placeholder for exchange-specific extensions to OpenRTB.</td>
@@ -2308,6 +2295,16 @@ This object provides information pertaining to the device through which the user
     <td>string; DEPRECATED</td>
     <td>MAC address of the device; hashed via MD5.</td>
  <tr>
+   </tr>
+    <td><code>brand</code></td>
+    <td>string</td>
+    <td>Brand of the device; Many mobile device manufacturers subdivide their devices into brands (eg. Samsung Galaxy S-Series, Samsung Galaxy A-Series), each of which may have different capabilities and limitations.</td>
+ <tr>
+   </tr>
+    <td><code>os</code></td>
+    <td>string</td>
+    <td>Operating system of the device; Different device operating systems have different capabilities, and each OS may require different methods of interaction and measurement. Examples include “android”, “iOS” and “harmonyos”.</td>
+ <tr>
   </tr>
     <td><code>ext</code></td>
     <td>object</td>
@@ -3298,19 +3295,6 @@ Values:<br>
     <td>integer; default 0</td>
     <td>Indicates that the bid response is only eligible for a specific position within a video or audio ad pod (e.g. first position, last position, or any). Refer to List: <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_slotpositioninpod">Slot Position in Pod</a> in AdCOM 1.0 for guidance on the use of this field.</td>
 </tr>
-  <tr>
-    <td><code>interactiontype</code></td>
-    <td>integer</td>
-    <td>This is the method of interaction required by an ad.
-    The methods of interaction currently defined have been assigned these values;<br />
-    <br />
-    1 = Click to OPEN a WEBSITE<br />
-    2 = Click to DOWNLOAD an APP<br />
-    3 = Click to REDIRECT to an APP<br />
-    4 = Click to REDIRECT to a QuickApp<br />
-    10 = Click to REDIRECT to a MiniApp<br />
-    </td>
-  </tr> 
   <tr>
     <td><code>ext</code></td>
     <td>object</td>

--- a/2.6.md
+++ b/2.6.md
@@ -808,11 +808,6 @@ There are also several subordinate objects that provide detailed data to potenti
     <td>A Regs object (Section 3.2.3) that specifies any industry, legal, or governmental regulations in force for this request.</td>
   </tr>
   <tr>
-    <td><code>acat</code></td>
-    <td>string array</td>
-    <td>Allow list of category of apps permitted for the offered ad opportunity</td>
-  </tr>
-  <tr>
     <td><code>ext</code></td>
     <td>object</td>
     <td>Placeholder for exchange-specific extensions to OpenRTB.</td>

--- a/2.6.md
+++ b/2.6.md
@@ -1021,6 +1021,19 @@ The presence of `Banner` (Section 3.2.6), `Video` (Section 3.2.7), and/or `Nativ
     </td>
   </tr>
   <tr>
+    <td><code>ainteractiontype</code></td>
+    <td>integer array</td>
+    <td>This is a list of the methods of interaction a placement permits.
+    The methods of interaction currently defined have been assigned these values;<br />
+    <br />
+    1 = Click to OPEN a WEBSITE<br />
+    2 = Click to DOWNLOAD an APP<br />
+    3 = Click to REDIRECT to an APP<br />
+    4 = Click to REDIRECT to a QuickApp<br />
+    10 = Click to REDIRECT to a MiniApp<br />
+    </td>
+  </tr>
+  <tr>
     <td><code>ext</code></td>
     <td>object</td>
     <td>Placeholder for exchange-specific extensions to OpenRTB.</td>
@@ -3285,6 +3298,19 @@ Values:<br>
     <td>integer; default 0</td>
     <td>Indicates that the bid response is only eligible for a specific position within a video or audio ad pod (e.g. first position, last position, or any). Refer to List: <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_slotpositioninpod">Slot Position in Pod</a> in AdCOM 1.0 for guidance on the use of this field.</td>
 </tr>
+  <tr>
+    <td><code>interactiontype</code></td>
+    <td>integer</td>
+    <td>This is the method of interaction required by an ad.
+    The methods of interaction currently defined have been assigned these values;<br />
+    <br />
+    1 = Click to OPEN a WEBSITE<br />
+    2 = Click to DOWNLOAD an APP<br />
+    3 = Click to REDIRECT to an APP<br />
+    4 = Click to REDIRECT to a QuickApp<br />
+    10 = Click to REDIRECT to a MiniApp<br />
+    </td>
+  </tr> 
   <tr>
     <td><code>ext</code></td>
     <td>object</td>


### PR DESCRIPTION
The following proposed changes **are already widely adopted and in use** by mobile advertising platforms.

- These parameters are already in use in all kinds of mobile ads, including native, banner and video.
- Mobile specialists such as Ocean Engine, Kuaishou Technology, Meitu, Tecent, Baidu and Xiaomi are using those parameters in almost all of their bid requests and bid responses.
- This allows publishers to limit ads based on user experience decisions.
- These proposed changes will align OpenRTB 2.6.x with this real world usage.