### PR TITLE
Clarify $.id uniqueness

### DIFF
--- a/2.6.md
+++ b/2.6.md
@@ -680,7 +680,7 @@ The following table summarizes the objects in the Bid Request model and serves a
 
 ### 3.2.1 - Object: BidRequest <a name="objectbidrequest"></a>
 
-The top-level bid request object contains a globally unique bid request or auction ID. This `id` attribute is required as is at least one impression object (Section 3.2.4). Other attributes in this top-level object establish rules and restrictions that apply to all impressions being offered.
+The top-level bid request object contains an exchange unique bid request or auction ID. This `id` attribute is required as is at least one impression object (Section 3.2.4). Other attributes in this top-level object establish rules and restrictions that apply to all impressions being offered.
 
 There are also several subordinate objects that provide detailed data to potential buyers. Among these are the `Site`, `App` and `DOOH`objects, which describe the type of published media in which the impression(s) appear. These objects are highly recommended, but only one applies to a given bid request depending on whether the media is browser-based web content, a non-browser application, or Digital Out of Home inventory respectively.
 
@@ -695,7 +695,7 @@ There are also several subordinate objects that provide detailed data to potenti
   <tr>
     <td><code>id</code></td>
     <td>string; required</td>
-    <td>Globally unique ID of the bid request, provided by the exchange. Pass-through seller platforms receiving this id should generate a new id when sending requests to multiple entities.</td>
+    <td>ID of the bid request, assigned by the exchange, and unique for the exchange’s subsequent tracking of the responses. The exchange may use different values for different recipients.</td>
   </tr>
   <tr>
     <td><code>imp</code></td>

--- a/2.6.md
+++ b/2.6.md
@@ -695,7 +695,7 @@ There are also several subordinate objects that provide detailed data to potenti
   <tr>
     <td><code>id</code></td>
     <td>string; required</td>
-    <td>Unique ID of the bid request, provided by the exchange.</td>
+    <td>Unique ID of the bid request, provided by the exchange. Pass-through seller platforms receiving this id should generate a new id when sending requests to multiple entities.</td>
   </tr>
   <tr>
     <td><code>imp</code></td>

--- a/2.6.md
+++ b/2.6.md
@@ -695,7 +695,7 @@ There are also several subordinate objects that provide detailed data to potenti
   <tr>
     <td><code>id</code></td>
     <td>string; required</td>
-    <td>Unique ID of the bid request, provided by the exchange. Pass-through seller platforms receiving this id should generate a new id when sending requests to multiple entities.</td>
+    <td>Globally unique ID of the bid request, provided by the exchange. Pass-through seller platforms receiving this id should generate a new id when sending requests to multiple entities.</td>
   </tr>
   <tr>
     <td><code>imp</code></td>


### PR DESCRIPTION
Described as globally unique in text above the table; this PR adds guidance for passthrough platforms and copies the information from the paragraph above the table into the table