### PR TITLE
Block / allow ad categories and apps at the impression level

### DIFF
--- a/2.6.md
+++ b/2.6.md
@@ -211,7 +211,7 @@ THE STANDARDS, THE SPECIFICATIONS, THE MEASUREMENT GUIDELINES, AND ANY OTHER MAT
 - [7.9 - Digital Out-Of-Home](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/main/implementation.md#79---digital-out-of-home-)
 - [7.10 - Updated Video Signals](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/main/implementation.md#710---updated-video-signals)
 
-  
+
 ## [Appendix A. Additional Information](#appendixa)
 
 ## [Appendix B. Specification Change Log](#appendixb)
@@ -277,7 +277,7 @@ Some optional attributes are denoted "recommended." As that term is used herein 
 *Example of how Required, Recommended and Optional attributes are presented.*
 
 **IMPORTANT:** Since **recommended** attributes are not required, they may not be available from all supply sources. It is suggested that all parties to OpenRTB trasnaction develop an integration checklist to identify which attributes the supply side supports in the bid request, and which attributes the demand side requires for ad decisioning.
-	
+
 # 1. Introduction <a name="intro"></a>
 
 ## 1.1 - Mission / Overview <a name="mission"></a>
@@ -375,9 +375,9 @@ The following terms are used throughout this document specifically in the contex
 The following figure illustrates the OpenRTB interactions between an exchange and its bidders. Ad requests originate at publisher sites or applications. For each inbound ad request, bid requests are broadcast to bidders, responses are evaluated under prevailing auction rules, and a winner is selected. The winning bidder is notified of the auction win via a win notice. Ad markup can either be included in the bid prospectively or in response to the win notice. A separate billing notice is also available to accommodate varying policies enacted by exchanges which are beyond the scope of the OpenRTB specification (e.g., billing on device delivery, viewability, etc.). The win notice informs the bidder’s pricing algorithms of a success, whereas the billing notice indicates that spend should actually be applied. A loss notification is also available to inform the bidder of the reason their bid did not win.
 
 The URLs for win, billing, and loss notices and the ad markup itself can contain any of several standard macros that enable the exchange to communicate critical data to the bidder (e.g., clearing price).
- 
+
 ![](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/864a56706b106eda94c03abefaa01dd43544864c/assets/Figure1%20OpenRTB.png)
- 
+
 *Figure 2: Reference Model - Request Sequence.*
 
 This specification focuses on the real-time interactions of bid request and response and the win, billing, and loss notices. Related specifications include:
@@ -459,7 +459,7 @@ This means:
 For example, if a new field or object is introduced in a future version of OpenRTB 2.6, exchanges should immediately start transmitting it to bidders, if the exchange chooses to implement support for that field. Bidders should start consuming it at their discretion, if it is relevant to them. Neither party needs to explicitly negotiate an "upgrade" to the latest release, but rather should discuss specific fields of interest as they become available.
 
 New minor versions of OpenRTB 2.6 may introduce additional optional ways of handling things. For example, burl field was introduced in OpenRTB 2.5. Use of `burl` (instead of including a pixel in markup in `adm` field) is a breaking change for a specific exchange <> bidder integration, but this is a result of a decision between these parties to switch impression counting methodology and not a result of OpenRTB 2.5 itself. Partners should discuss such situations before making breaking changes to their integrations.
-  
+
 ## 2.7 - Privacy <a name="privacy"></a>
 
 Without limiting the scope of the Disclaimer, the OpenRTB specification does include several features to support implementer’s communication of information regarding consumer privacy, including, but not limited to:
@@ -488,7 +488,7 @@ RTB transactions are initiated when an exchange or other supply source sends a b
 ## 3.1 - Object Model <a name="objectmodel"></a>
 
 Following is the object model for the bid request. The top-level object (i.e., in JSON the unnamed outer object) is denoted as `BidRequest` in the model. Of its direct subordinates, only `Imp` is technically required since it is fundamental to describing the impression being sold and it requires at least one of `Banner` (which may allow multiple formats), `Video`, `Audio`, and `Native` to define the type of impression (i.e., whichever one or more the publisher is willing to accept; although a bid will be for exactly one of those specified). An impression can optionally be subject to a private marketplace.
- 
+
 ![](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/a29f4b1060c04813270dbf13607bba0403409068/assets/ORTB%20ERD.png)
 
 *Figure 3: Bid Request object model.*
@@ -1025,6 +1025,31 @@ The presence of `Banner` (Section 3.2.6), `Video` (Section 3.2.7), and/or `Nativ
     <td>Details about ad slots being refreshed automatically. (Section 3.2.33)</td>
     </td>
   </tr>
+	<tr>
+    <td><code>acat</code></td>
+    <td>string array</td>
+    <td>Allowed advertiser categories using the specified category taxonomy. <br>The taxonomy to be used is defined by the <code>cattax</code> field. If no <code>cattax</code> field is supplied IAB Content Taxonomy 1.0 is assumed. Only one of <code>acat</code> or <code>bcat</code> should be present.</td>
+  </tr>
+  <tr>
+    <td><code>bcat</code></td>
+    <td>string array</td>
+    <td>Blocked advertiser categories using the specified category taxonomy. <br>The taxonomy to be used is defined by the <code>cattax</code> field. If no <code>cattax</code> field is supplied IAB Content Taxonomy 1.0 is assumed. Only one of <code>acat</code> or <code>bcat</code> should be present.</td>
+  </tr>
+  <tr>
+    <td><code>cattax</code></td>
+    <td>integer; default 1</td>
+    <td>The taxonomy in use for bcat. Refer to the AdCOM 1.0 list <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_categorytaxonomies">List: Category Taxonomies</a> for values.</td>
+  </tr>
+  <tr>
+    <td><code>bapp</code></td>
+    <td>string array</td>
+    <td>Block list of applications by their app store IDs. See <a href="https://iabtechlab.com/wp-content/uploads/2020/08/IAB-Tech-Lab-OTT-store-assigned-App-Identification-Guidelines-2020.pdf">OTT/CTV Store Assigned App Identification Guidelines</a> for more details about expected strings for CTV app stores. For mobile apps in Google Play Store, these should be bundle or package names (e.g. com.foo.mygame). For apps in Apple App Store, these should be a numeric ID.</td>
+  </tr>
+	<tr>
+    <td><code>aapp</code></td>
+    <td>string array</td>
+    <td>Approved list of applications by their app store IDs. See <a href="https://iabtechlab.com/wp-content/uploads/2020/08/IAB-Tech-Lab-OTT-store-assigned-App-Identification-Guidelines-2020.pdf">OTT/CTV Store Assigned App Identification Guidelines</a> for more details about expected strings for CTV app stores. For mobile apps in Google Play Store, these should be bundle or package names (e.g. com.foo.mygame). For apps in Apple App Store, these should be a numeric ID.</td>
+  </tr>
   <tr>
     <td><code>ext</code></td>
     <td>object</td>
@@ -1032,7 +1057,7 @@ The presence of `Banner` (Section 3.2.6), `Video` (Section 3.2.7), and/or `Nativ
     </td>
     </td>
   </tr>
-  
+
 </table>
 
 
@@ -1105,9 +1130,9 @@ The presence of a `Banner` as a subordinate of the `Imp` object indicates that t
     <td>integer array</td>
     <td>Blocked banner ad types.<br>
 	Values:<br>
-1 = XHTML Text Ad,<br> 
-2 = XHTML Banner Ad,<br> 
-3 = JavaScript Ad,<br> 
+1 = XHTML Text Ad,<br>
+2 = XHTML Banner Ad,<br>
+3 = JavaScript Ad,<br>
 4 = iframe.<br></td>
   </tr>
   <tr>
@@ -2112,7 +2137,7 @@ This object defines the producer of the content in which the ad will be shown. T
   </tr>
     <td><code>cat</code></td>
     <td>string array</td>
-    <td>Array of IAB Tech Lab content categories that describe the content producer. 
+    <td>Array of IAB Tech Lab content categories that describe the content producer.
 The taxonomy to be used is defined by the cattax field. If no cattax field is supplied Content Category Taxonomy 1.0 is assumed.</td>
    </tr>
    <tr>
@@ -2824,7 +2849,7 @@ Structured user agent information, which can be used when a client supports [Use
   </tr>
 </table>
 
-* or an equivalent JavaScript accessor from [NavigatorUAData interface](https://wicg.github.io/ua-client-hints/#navigatoruadata). This header or accessor are only available for browsers that support [User-Agent Client Hints](https://wicg.github.io/ua-client-hints/). 
+* or an equivalent JavaScript accessor from [NavigatorUAData interface](https://wicg.github.io/ua-client-hints/#navigatoruadata). This header or accessor are only available for browsers that support [User-Agent Client Hints](https://wicg.github.io/ua-client-hints/).
 
 ### 3.2.30 - Object: BrandVersion <a name="objectbrandversion"></a>
 
@@ -2939,7 +2964,7 @@ This object should be included if the ad supported content is a Digital Out-Of-H
 
 ### 3.2.34 - Object: RefSettings <a name="objectrefsettings"></a>
 
-Information on how often and what triggers an ad slot being refreshed. 
+Information on how often and what triggers an ad slot being refreshed.
 
 <table>
   <tr>
@@ -2975,7 +3000,7 @@ RTB responses contain bids that reference specific impressions within a bid requ
 
 ## 4.1 - Object Model <a name="4.2objectmodel"></a>
 
-Following is the object model for the bid response. The top-level object (i.e., in JSON the unnamed outer object) is denoted as `BidResponse` in the model. A bid response may contain bids from multiple “seats” (i.e., the buying entity upstream from the actual bidder). In fact, a response may contain multiple bids from the same seat; typically but not necessarily from different campaigns. This can improve the seat’s chances of winning since most exchanges enforce various block lists on behalf of their publishers. 
+Following is the object model for the bid response. The top-level object (i.e., in JSON the unnamed outer object) is denoted as `BidResponse` in the model. A bid response may contain bids from multiple “seats” (i.e., the buying entity upstream from the actual bidder). In fact, a response may contain multiple bids from the same seat; typically but not necessarily from different campaigns. This can improve the seat’s chances of winning since most exchanges enforce various block lists on behalf of their publishers.
 
 ![](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/864a56706b106eda94c03abefaa01dd43544864c/assets/Figure3.png)
 
@@ -3431,7 +3456,7 @@ Except where the value "AUDIT" applies, as above, the macro is replaced by:
   - The bid was not allowed into the auction, e.g., because of blocks on the seat, advertiser, etc.
   - Per the loss code, price was not the deciding factor in the loss.
   - As dictated by exchange privacy controls, e.g., if price data is not shared to bidders that did not meet the desired floor, or if the exchange supports a publisher or winning bidder election not to share price data with the other bidders.
- 
+
 - The minimum price required to tie with the winning bid, when your bid lost to another in the auction.
 - The minimum price required to tie with the next-closest bid, or the floor if there was only one bid, when your bid won the auction.
 
@@ -4049,7 +4074,7 @@ Following is an example of a bid response with the ad served on win notice. The 
 
 
 ### 6.3.4 - Example 4 – Native Markup Returned Inline <a name="nativemarkupreturnedinline"></a>
-	
+
 Following is an example of a bid response that returns a native ad inline to be served. The `adm` attribute contains an encoded string of a native ad request that conforms to the Dynamic Native Ads API and specifically the same version as that used for the request string. Alternatively, the `adm` attribute could have been omitted in favor of returning the native ad markup in the response to the win notice `nurl`.
 
 ```javascript
@@ -4074,7 +4099,7 @@ Following is an example of a bid response that returns a native ad inline to be 
 
 # [7. Implementation Notes](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/main/implementation.md#7-implementation-notes-)
 
-- [7.1 - No-Bid Signaling](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/main/implementation.md#71-no-bid-signaling-) 
+- [7.1 - No-Bid Signaling](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/main/implementation.md#71-no-bid-signaling-)
 
 - [7.2 - Impression Expiration](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/main/implementation.md#72-impression-expiration-)
 
@@ -4094,57 +4119,57 @@ Following is an example of a bid response that returns a native ad inline to be 
 
 - [7.10 - Digital Out-Of-Home](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/OOH-Ammends/implementation.md#79---digital-out-of-home-)
 
-	
+
 # Appendix A. Additional Information <a name="appendixa"></a>
-	
+
 - Creative Commons / Attribution License
-	
+
  	creativecommons.org/licenses/by/3.0
-	
+
 - IAB (Interactive Advertising Bureau)
-	
+
  	www.iab.com
-	
+
 - IAB Quality Assurance Guidelines (QAG):
-	
+
  	www.iab.com/guidelines/iab-quality-assurance-guidelines-qag-taxonomy/
-	
+
 - JavaScript Object Notation (JSON)
-	
+
  	www.json.org
-	
+
 - MMA (Mobile Marketing Association)
-	
+
  	mmaglobal.com
-	
+
 - OpenRTB Project on Github
-	
+
  	github.com/openrtb/OpenRTB/
-	
+
 - Apache Avro
-	
+
  	avro.apache.org
-	
+
  	Protocol Buffers (Protobuf)
-	
+
 code.google.com/p/protobuf
-	
+
 - Google Metro Codes
-	
+
  	code.google.com/apis/adwords/docs/appendix/metrocodes.html
-	
+
 - U.N. Code for Trade and Transport Locations:
-	
+
  	www.unece.org/cefact/locode/service/location.htm
-	
-	
+
+
 # Appendix B. Specification Change Log <a name="appendixb"></a>
-	
+
 This appendix serves as an index of specification changes across 2.x versions. These changes pertain only to the substance of the specification and not routine document formatting, organization, or content without technical impact.
 
 **<strong>Please refer to GitHub [Releases](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/releases) page for release notes for ORTB2.6-202303 onward</strong>**
 
-	
+
 **Version 2.6-202210 (Base 2.6 version) to 2.6-202211:**
 <table>
   <tr>
@@ -4178,8 +4203,8 @@ This appendix serves as an index of specification changes across 2.x versions. T
 </table>
 
 **Version 2.5 to 2.6:**
-	
-	
+
+
 <table>
   <tr>
     <td><strong>Section&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
@@ -4270,12 +4295,12 @@ This appendix serves as an index of specification changes across 2.x versions. T
   </td>
   </tr>
 </table>
-	
 
-	
+
+
 **Version 2.4 to 2.5:**
-	
-	
+
+
 <table>
   <tr>
     <td><strong>Section&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
@@ -4360,6 +4385,3 @@ This appendix serves as an index of specification changes across 2.x versions. T
   </td>
   </tr>
 </table>
-	
-	
-


### PR DESCRIPTION
Providing aCat / bCat and aApp / bApp at the impression level. Multiple impressions bundled into a single bid request is common in Asia, where there are typically more ads per screen view.  There is a desire to allow finer control over the ads permitted in each impression.