### PR TITLE
Remove publisher limitation

### DIFF
--- a/2.6.md
+++ b/2.6.md
@@ -3086,7 +3086,7 @@ Note that this only indicates that the interest group auction is supported, not 
   <tr>
     <td><code>biddable <b>PROVISIONAL</b></code></td>
     <td>integer <br>default 0</td>
-    <td>Indicates whether the bidder is allowed to participate in the interest group auction. Depending on account settings and other factors, a bidder might be disallowed from participating in an auction or submitting interest group bids, even though an interest group auction may ultimately decide the winning ad. The seller sets this. Example, the publisher intends to enable IG, but the seller (SSP) has not onboarded this buyer for IG auctions. This value should not be filled out by the publisher. Buyers should only expect sellers to honor corresponding Interest Group Intent signals when this field is 1.
+    <td>Indicates whether the bidder is allowed to participate in the interest group auction. Depending on account settings and other factors, a bidder might be disallowed from participating in an auction or submitting interest group bids, even though an interest group auction may ultimately decide the winning ad. The seller sets this. Example, the publisher intends to enable IG, but the seller (SSP) has not onboarded this buyer for IG auctions. Buyers should only expect sellers to honor corresponding Interest Group Intent signals when this field is 1.
     <br>
     <br>
     0 = no, 1 = yes


### PR DESCRIPTION
SSPs are often buyers on each other's exchanges and publishers often make ortb2.6 requests directly to ssps or dsps. Some DSPs, such as Microsoft, may act more like an SSP in certain contexts. The problem this sentence seems to be solving of 'don't relay this field' or 'make sure you edit this field for the recipient' should be expressed another way.

This sentence just often won't be true when the publisher is a component seller, which is already supported by prebid
https://github.com/prebid/prebid.github.io/pull/4658/files

I wouldn't mind clarifying language that the field is only in the context of the recipient of the request and should not be relayed to other entities.