### PR TITLE
Fix #45: Example with User Object improperly inside Site Object

### DIFF
--- a/2.6.md
+++ b/2.6.md
@@ -3629,10 +3629,10 @@ Following is a basic example of a bid request for a banner ad. Some optional par
         "IAB3-1"
       ],
       "domain": "foobar.com"
-    },
-    "user": {
-      "id": "55816b39711f9b5acf3b90e313ed29e51665623f"
     }
+  },
+  "user": {
+    "id": "55816b39711f9b5acf3b90e313ed29e51665623f"
   }
 }
 ```


### PR DESCRIPTION
Moves `user` outside of `site` object in section `6.2.1 - Example 1 – Simple Banner`, so that it reflects the spec.
Fixes #45 