### PR TITLE
Add content to imp[].video

### DIFF
--- a/2.6.md
+++ b/2.6.md
@@ -1357,6 +1357,11 @@ The presence of a `Video` as a subordinate of the `Imp` object indicates that th
     <td>An array of `DurFloors` objects (Section 3.2.35) indicating the floor prices for video creatives of various durations that the buyer may bid with.</td>
   </tr>
   <tr>
+    <td><code>content</code></td>
+    <td>object</td>
+    <td>Details about the Content (Section 3.2.16) being streamed in the player that will render the ad. Applicable for plcmt Instream and Accompanying Content.</td>
+  </tr>
+  <tr>
     <td><code>ext</code></td>
     <td>object</td>
     <td>Placeholder for exchange-specific extensions to OpenRTB.</td>


### PR DESCRIPTION
I am an engineer at JW Player, and I serve as Vice-Chair of Video at Prebid.

Given that multiple video players can be active simultaneously on a page, there needs to be a way to specify which content is tied to impressions that qualify as `plcmt` `instream` and `accompanying content`. This is most important for signals that can be used for contextual targeting, defined in `content.data[].segment[]`.

Without this change, `content` can only be defined at the `site/app` level, which can result in misleading bid requests being sent to Buyers. For example, a site can have a main Hero player rendering premium content, as well as a floating side player rendering low quality content. If the publisher wishes to auction all of the available inventory on the page, he will surely populate `site.content` with the metadata of the premium content, allowing the impressions associated to the lower quality content to be inflated.

This limitation also adds complexity for publishers. If a site has multiple video players that are rendering content and the publisher has targeting segments and metadata for each media being rendered, then the Publisher has to create a bid request for each player on the page in order for the targeting segments and metadata to be sent to the Buyers. To improve page performance, it would be in the Publisher's best interest to create 1 bid request with multiple `imp` objects instead.