### PR TITLE
Typo, whitespace, and 80-column limit formatting fixes.

### DIFF
--- a/src/main/com/iabtechlab/openrtb/v2/openrtb.proto
+++ b/src/main/com/iabtechlab/openrtb/v2/openrtb.proto
@@ -125,7 +125,8 @@ message BidRequest {
   repeated string bcat = 12;
 
   // The taxonomy in use for bcat.
-  // Refer to the enum com.iabtechlab.adcom.v1.enums.CategoryTaxonomy for values.
+  // Refer to the enum com.iabtechlab.adcom.v1.enums.CategoryTaxonomy for
+  // values.
   optional int32 cattax = 21 [default = 1];
 
   // Block list of advertisers by their domains (e.g., "ford.com").
@@ -208,47 +209,47 @@ message BidRequest {
       // nodes. These nodes define the identity of an entity participating in
       // the supply chain of a bid request.
       message SupplyChainNode {
-	// The canonical domain name of the SSP, Exchange, Header Wrapper, etc
-	// system that bidders connect to. This may be the operational domain
-	// of the system, if that is different than the parent corporate
-	// domain, to facilitate WHOIS and reverse IP lookups to establish
-	// clear ownership of the delegate system. This should be the same
-	// value as used to identify sellers in an ads.txt file if one exists.
-	optional string asi = 1;
+        // The canonical domain name of the SSP, Exchange, Header Wrapper, etc
+        // system that bidders connect to. This may be the operational domain
+        // of the system, if that is different than the parent corporate
+        // domain, to facilitate WHOIS and reverse IP lookups to establish
+        // clear ownership of the delegate system. This should be the same
+        // value as used to identify sellers in an ads.txt file if one exists.
+        optional string asi = 1;
 
-	// The identifier associated with the seller or reseller account within
-	// the advertising system. This must contain the same value used in
-	// transactions (i.e. OpenRTB bid requests) in the field specified by
-	// the SSP/exchange. Typically, in OpenRTB, this is publisher.id. For
-	// OpenDirect it is typically the publisher’s organization ID. Should
-	// be limited to 64 characters in length.
-	optional string sid = 2;
+        // The identifier associated with the seller or reseller account within
+        // the advertising system. This must contain the same value used in
+        // transactions (i.e. OpenRTB bid requests) in the field specified by
+        // the SSP/exchange. Typically, in OpenRTB, this is publisher.id. For
+        // OpenDirect it is typically the publisher’s organization ID. Should
+        // be limited to 64 characters in length.
+        optional string sid = 2;
 
         // The OpenRTB RequestId of the request as issued by this seller.
         optional string rid = 3;
 
-	// The name of the company (the legal entity) that is paid for
-	// inventory transacted under the given seller_id. This value is
-	// optional and should NOT be included if it exists in the advertising
-	// system’s sellers.json file.
-	optional string name = 4;
+        // The name of the company (the legal entity) that is paid for
+        // inventory transacted under the given seller_id. This value is
+        // optional and should NOT be included if it exists in the advertising
+        // system’s sellers.json file.
+        optional string name = 4;
 
-	// The business domain name of the entity represented by this node.
-	// This value is optional and should NOT be included if it exists in
-	// the advertising system’s sellers.json file.
-	optional string domain = 5;
+        // The business domain name of the entity represented by this node.
+        // This value is optional and should NOT be included if it exists in
+        // the advertising system’s sellers.json file.
+        optional string domain = 5;
 
-	// Indicates whether this node will be involved in the flow of payment
-	// for the inventory. When set to 1, the advertising system in the asi
-	// field pays the seller in the sid field, who is responsible for
-	// paying the previous node in the chain. When set to 0, this node is
-	// not involved in the flow of payment for the inventory. For version
-	// 1.0 of SupplyChain, this property should always be 1. It is
-	// explicitly required to be included as it is expected that future
-	// versions of the specification will introduce non-payment handling
-	// nodes. Implementers should ensure that they support this field and
-	// propagate it onwards when constructing SupplyChain objects in bid
-	// requests sent to a downstream advertising system.
+        // Indicates whether this node will be involved in the flow of payment
+        // for the inventory. When set to 1, the advertising system in the asi
+        // field pays the seller in the sid field, who is responsible for
+        // paying the previous node in the chain. When set to 0, this node is
+        // not involved in the flow of payment for the inventory. For version
+        // 1.0 of SupplyChain, this property should always be 1. It is
+        // explicitly required to be included as it is expected that future
+        // versions of the specification will introduce non-payment handling
+        // nodes. Implementers should ensure that they support this field and
+        // propagate it onwards when constructing SupplyChain objects in bid
+        // requests sent to a downstream advertising system.
         optional bool hp = 6;
 
         // Extensions.
@@ -461,7 +462,8 @@ message BidRequest {
       repeated int32 btype = 5 [packed = true];
 
       // Blocked creative attributes.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.Creative.Attribute for generic values.
+      // Refer to enum com.iabtechlab.adcom.v1.enums.Creative.Attribute for
+      // generic values.
       repeated int32 battr = 6 [packed = true];
 
       // Ad position on screen.
@@ -477,12 +479,14 @@ message BidRequest {
       optional bool topframe = 8;
 
       // Directions in which the banner may expand.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.ExpandableDirection for generic values.
+      // Refer to enum com.iabtechlab.adcom.v1.enums.ExpandableDirection for
+      // generic values.
       repeated int32 expdir = 9 [packed = true];
 
       // List of supported API frameworks for this impression. If an API is not
       // explicitly listed, it is assumed not to be supported.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.APIFramework for generic values.
+      // Refer to enum com.iabtechlab.adcom.v1.enums.APIFramework for generic
+      // values.
       repeated int32 api = 10 [packed = true];
 
       // Unique identifier for this banner object. Recommended when Banner
@@ -534,9 +538,9 @@ message BidRequest {
         // Relative height when expressing size as a ratio.
         optional int32 hratio = 4;
 
-	// The minimum width in device independent pixels (DIPS) at which the
-	// ad will be displayed when the size is expressed as a ratio.
-	optional int32 wmin = 5;
+        // The minimum width in device independent pixels (DIPS) at which the
+        // ad will be displayed when the size is expressed as a ratio.
+        optional int32 wmin = 5;
 
         // Extensions.
         extensions 100 to 9999;
@@ -573,7 +577,8 @@ message BidRequest {
 
       // Indicates the start delay in seconds for pre-roll, mid-roll, or
       // post-roll ad placements.
-      // Refer to enum com.iabtechlab.adcom.v1.StartDelayMode for generic values.
+      // Refer to enum com.iabtechlab.adcom.v1.StartDelayMode for generic
+      // values.
       // RECOMMENDED by the OpenRTB specification.
       optional int32 startdelay = 8;
 
@@ -593,7 +598,8 @@ message BidRequest {
 
       // Array of supported video bid response protocols.
       // At least one supported protocol must be specified.
-      // Refer to enum com.iabtechlab.adcom.v1.Creative.AudioVideoType for generic values.
+      // Refer to enum com.iabtechlab.adcom.v1.Creative.AudioVideoType for
+      // generic values.
       repeated int32 protocols = 21 [packed = true];
 
       // Width of the video player in device independent pixels (DIPS).
@@ -622,18 +628,21 @@ message BidRequest {
       repeated int32 rqddurs = 32 [packed = true];
 
       // Video placement type for the impression.
-      // Refer to enum com.iabtechlab.adcom.v1.VideoPlacementSubtype for generic values.
+      // Refer to enum com.iabtechlab.adcom.v1.VideoPlacementSubtype for generic
+      // values.
       optional int32 placement = 26 [deprecated = true];
 
       // Video placement type for the impression.
-      // Refer to enum com.iabtechlab.adcom.v1.VideoPlcmtSubtype for generic values.
+      // Refer to enum com.iabtechlab.adcom.v1.VideoPlcmtSubtype for generic
+      // values.
       optional int32 plcmt = 35;
 
       // Indicates if the impression must be linear, nonlinear, etc. If none
       // specified, assume all are allowed. Note that this field describes the
       // expected VAST response and not whether a placement is in-stream,
       // out-stream, etc. For that, see plcmt.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.LinearityMode for generic values.
+      // Refer to enum com.iabtechlab.adcom.v1.enums.LinearityMode for generic
+      // values.
       optional int32 linearity = 2;
 
       // Indicates if the player will allow the video to be skipped,
@@ -665,7 +674,8 @@ message BidRequest {
       optional double mincpmpersec = 34;
 
       // Blocked creative attributes.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.Creative.Attribute for generic values.
+      // Refer to enum com.iabtechlab.adcom.v1.enums.Creative.Attribute for
+      // generic values.
       repeated int32 battr = 10 [packed = true];
 
       // Maximum extended ad duration if extension is allowed. If blank or 0,
@@ -690,20 +700,24 @@ message BidRequest {
       // As a result, this array may be converted to an integer in a future
       // version of the specification. It is strongly advised to use only
       // the first element of this array in preparation for this change.
-      // Refer to enum com.iabtechlab.adcom.v1.PlaybackMethod for generic values.
+      // Refer to enum com.iabtechlab.adcom.v1.PlaybackMethod for generic
+      // values.
       repeated int32 playbackmethod = 15 [packed = true];
 
       // The event that causes playback to end.
-      // Refer to enum com.iabtechlab.adcom.v1.PlaybackCessationMode for generic values.
+      // Refer to enum com.iabtechlab.adcom.v1.PlaybackCessationMode for generic
+      // values.
       optional int32 playbackend = 27;
 
       // Supported delivery methods (e.g., streaming, progressive). If none
       // specified, assume all are supported.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.DeliveryMethod for generic values.
+      // Refer to enum com.iabtechlab.adcom.v1.enums.DeliveryMethod for generic
+      // values.
       repeated int32 delivery = 16 [packed = true];
 
       // Ad position on screen.
-      // Refer to enum com.iabtechlab.adcom.v1.PlacementPosition for generic values.
+      // Refer to enum com.iabtechlab.adcom.v1.PlacementPosition for generic
+      // values.
       optional int32 pos = 17;
 
       // Array of Banner objects (Section 3.2.3) if companion ads are available.
@@ -711,7 +725,8 @@ message BidRequest {
 
       // List of supported API frameworks for this impression. If an API is not
       // explicitly listed, it is assumed not to be supported.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.APIFramework for generic values.
+      // Refer to enum com.iabtechlab.adcom.v1.enums.APIFramework for generic
+      // values.
       repeated int32 api = 19 [packed = true];
 
       // Supported VAST companion ad types. Recommended if companion Banner
@@ -771,13 +786,15 @@ message BidRequest {
       optional int32 poddur = 25;
 
       // Array of supported audio protocols.
-      // Refer to enum com.iabtechlab.adcom.v1.Creative.AudioVideoType for generic values.
+      // Refer to enum com.iabtechlab.adcom.v1.Creative.AudioVideoType for
+      // generic values.
       // RECOMMENDED by the OpenRTB specification.
       repeated int32 protocols = 4 [packed = true];
 
       // Indicates the start delay in seconds for pre-roll, mid-roll, or
       // post-roll ad placements.
-      // Refer to enum com.iabtechlab.adcom.v1.StartDelayMode for generic values.
+      // Refer to enum com.iabtechlab.adcom.v1.StartDelayMode for generic
+      // values.
       // RECOMMENDED by the OpenRTB specification.
       optional int32 startdelay = 5;
 
@@ -813,7 +830,8 @@ message BidRequest {
       optional double mincpmpersec = 30;
 
       // Blocked creative attributes.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.Creative.Attribute for generic values.
+      // Refer to enum com.iabtechlab.adcom.v1.enums.Creative.Attribute for
+      // generic values.
       repeated int32 battr = 7 [packed = true];
 
       // Maximum extended ad duration if extension is allowed. If blank or 0,
@@ -831,7 +849,8 @@ message BidRequest {
 
       // Supported delivery methods (e.g., streaming, progressive). If none
       // specified, assume all are supported.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.DeliveryMethod for generic values.
+      // Refer to enum com.iabtechlab.adcom.v1.enums.DeliveryMethod for generic
+      // values.
       repeated int32 delivery = 11 [packed = true];
 
       // Array of Banner objects (Section 3.2.6) if companion ads are available.
@@ -839,7 +858,8 @@ message BidRequest {
 
       // List of supported API frameworks for this impression. If an API is not
       // explicitly listed, it is assumed not to be supported.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.APIFramework for generic values.
+      // Refer to enum com.iabtechlab.adcom.v1.enums.APIFramework for generic
+      // values.
       repeated int32 api = 13 [packed = true];
 
       // Supported companion ad types. Recommended if companion Banner objects
@@ -851,7 +871,8 @@ message BidRequest {
       optional int32 maxseq = 21;
 
       // Type of audio feed.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.FeedType for generic values.
+      // Refer to enum com.iabtechlab.adcom.v1.enums.FeedType for generic
+      // values.
       optional int32 feed = 22;
 
       // Indicates if the ad is stitched with audio content or delivered
@@ -859,7 +880,8 @@ message BidRequest {
       optional bool stitched = 23;
 
       // Volume normalization mode.
-      // Refer to enum com.iabtechlab.adcom.v1.VolumeNormalizationMode for generic values.
+      // Refer to enum com.iabtechlab.adcom.v1.VolumeNormalizationMode for
+      // generic values.
       optional int32 nvol = 24;
 
       // Extensions.
@@ -891,15 +913,15 @@ message BidRequest {
       // node of the payload, "native", was dropped in the Native Ads
       // Specification 1.1.
       oneof request_oneof {
-	// For Native 1.0, this is a JSON-encoded string consisting of a
-	// unnamed root object, with a single subordinate object named
-	// 'native', which is the Native Markup Request object, section 4.1 of
-	// OpenRTB Native 1.0 specification.
+        // For Native 1.0, this is a JSON-encoded string consisting of a
+        // unnamed root object, with a single subordinate object named
+        // 'native', which is the Native Markup Request object, section 4.1 of
+        // OpenRTB Native 1.0 specification.
         //
-	// For Native 1.1 and higher, this is a JSON-encoded string consisting
-	// of an unnamed root object which is itself the Native Markup Request
-	// Object, section 4.1 of OpenRTB Native 1.1+.
-	string request = 1;
+        // For Native 1.1 and higher, this is a JSON-encoded string consisting
+        // of an unnamed root object which is itself the Native Markup Request
+        // Object, section 4.1 of OpenRTB Native 1.1+.
+        string request = 1;
 
         // This is an alternate field preferred for Protobuf serialization.
         NativeRequest request_native = 50;
@@ -912,11 +934,13 @@ message BidRequest {
 
       // List of supported API frameworks for this impression. If an API is not
       // explicitly listed, it is assumed not to be supported.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.APIFramework for generic values.
+      // Refer to enum com.iabtechlab.adcom.v1.enums.APIFramework for generic
+      // values.
       repeated int32 api = 3 [packed = true];
 
       // Blocked creative attributes.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.Creative.Attribute for generic values.
+      // Refer to enum com.iabtechlab.adcom.v1.enums.Creative.Attribute for
+      // generic values.
       repeated int32 battr = 4 [packed = true];
 
       // Extensions.
@@ -952,28 +976,29 @@ message BidRequest {
         // Minimum bid for this impression expressed in CPM.
         optional double bidfloor = 2 [default = 0];
 
-	// Currency specified using ISO-4217 alpha codes. This may be different
-	// from bid currency returned by bidder if this is allowed by the
-	// exchange. This field does not inherit from Imp.bidfloorcur; it is
-	// either explicitly specified or defaults to USD.
-	optional string bidfloorcur = 3 [default = "USD"];
+        // Currency specified using ISO-4217 alpha codes. This may be different
+        // from bid currency returned by bidder if this is allowed by the
+        // exchange. This field does not inherit from Imp.bidfloorcur; it is
+        // either explicitly specified or defaults to USD.
+        optional string bidfloorcur = 3 [default = "USD"];
 
-	// Optional override of the overall auction type of the bid request,
-	// where 1 = First Price, 2 = Second Price Plus, 3 = the value passed
-	// in bidfloor is the agreed upon deal price. Additional auction types
-	// can be defined by the exchange.
-        // Refer to enum com.iabtechlab.openrtb.v3.AuctionType for generic values.
+        // Optional override of the overall auction type of the bid request,
+        // where 1 = First Price, 2 = Second Price Plus, 3 = the value passed
+        // in bidfloor is the agreed upon deal price. Additional auction types
+        // can be defined by the exchange.
+        // Refer to enum com.iabtechlab.openrtb.v3.AuctionType for generic
+        // values.
         optional int32 at = 6;
 
-	// Allowed list of buyer seats (e.g., advertisers, agencies) allowed to
-	// bid on this deal. IDs of seats and the buyer's customers to which
-	// they refer must be coordinated between bidders and the exchange a
-	// priori. Omission implies no seat restrictions.
-	repeated string wseat = 4;
+        // Allowed list of buyer seats (e.g., advertisers, agencies) allowed to
+        // bid on this deal. IDs of seats and the buyer's customers to which
+        // they refer must be coordinated between bidders and the exchange a
+        // priori. Omission implies no seat restrictions.
+        repeated string wseat = 4;
 
-	// Array of advertiser domains (e.g., advertiser.com) allowed to bid on
-	// this deal. Omission implies no advertiser restrictions.
-	repeated string wadomain = 5;
+        // Array of advertiser domains (e.g., advertiser.com) allowed to bid on
+        // this deal. Omission implies no advertiser restrictions.
+        repeated string wadomain = 5;
 
         // Extensions.
         extensions 100 to 9999;
@@ -997,9 +1022,10 @@ message BidRequest {
     // Domain of the site (e.g., "mysite.foo.com").
     optional string domain = 3;
 
-    // The taxonomy in use. If no cattax field is supplied IAB Cotent Category
+    // The taxonomy in use. If no cattax field is supplied IAB Content Category
     // Taxonomy 1.0 is assumed.
-    // Refer to the enum com.iabtechlab.adcom.v1.enums.CategoryTaxonomy for values.
+    // Refer to the enum com.iabtechlab.adcom.v1.enums.CategoryTaxonomy for
+    // values.
     optional int32 cattax = 16 [default = 1];
 
     // Array of IAB content categories of the site. The taxonomy to be used is
@@ -1086,7 +1112,8 @@ message BidRequest {
     optional string storeurl = 16;
 
     // The taxonomy in use.
-    // Refer to the enum com.iabtechlab.adcom.v1.enums.CategoryTaxonomy for values.
+    // Refer to the enum com.iabtechlab.adcom.v1.enums.CategoryTaxonomy for
+    // values.
     optional int32 cattax = 17 [default = 1];
 
     // Array of IAB content categories of the app. The taxonomy to be used is
@@ -1153,7 +1180,8 @@ message BidRequest {
     optional string name = 2;
 
     // The taxonomy in use.
-    // Refer to the enum com.iabtechlab.adcom.v1.enums.CategoryTaxonomy for values.
+    // Refer to the enum com.iabtechlab.adcom.v1.enums.CategoryTaxonomy for
+    // values.
     optional int32 cattax = 5 [default = 1];
 
     // Array of IAB content categories of the publisher. The taxonomy to be
@@ -1217,7 +1245,8 @@ message BidRequest {
     optional string url = 6;
 
     // The taxonomy in use.
-    // Refer to the enum com.iabtechlab.adcom.v1.enums.CategoryTaxonomy for values.
+    // Refer to the enum com.iabtechlab.adcom.v1.enums.CategoryTaxonomy for
+    // values.
     optional int32 cattax = 27 [default = 1];
 
     // Array of IAB content categories that describe the content. The taxonomy
@@ -1226,15 +1255,18 @@ message BidRequest {
     repeated string cat = 7;
 
     // Production quality.
-    // Refer to enum com.iabtechlab.adcom.v1.ProductionQuality for generic values.
+    // Refer to enum com.iabtechlab.adcom.v1.ProductionQuality for generic
+    // values.
     optional int32 prodq = 25;
 
     // Video quality.
-    // Refer to enum com.iabtechlab.adcom.v1.ProductionQuality for generic values.
+    // Refer to enum com.iabtechlab.adcom.v1.ProductionQuality for generic
+    // values.
     optional int32 videoquality = 8 [deprecated = true];
 
     // Type of content (game, video, text, etc.).
-    // Refer to enum com.iabtechlab.adcom.v1.enums.ContentContext for generic values.
+    // Refer to enum com.iabtechlab.adcom.v1.enums.ContentContext for generic
+    // values.
     optional int32 context = 20;
 
     // Content rating (e.g., MPAA).
@@ -1251,8 +1283,8 @@ message BidRequest {
     // keywords or kwarray may be present.
     optional string keywords = 9;
 
-    // Array of keywords about the content. Only one of keywords or kwarray may be
-    // present.
+    // Array of keywords about the content. Only one of keywords or kwarray may
+    // be present.
     repeated string kwarray = 12;
 
     // 0 = not live, 1 = content is live (e.g., stream, live blog).
@@ -1305,7 +1337,8 @@ message BidRequest {
       optional string name = 2;
 
       // The taxonomy in use.
-      // Refer to the enum com.iabtechlab.adcom.v1.enums.CategoryTaxonomy for values.
+      // Refer to the enum com.iabtechlab.adcom.v1.enums.CategoryTaxonomy for
+      // values.
       optional int32 cattax = 5 [default = 1];
 
       // Array of IAB content categories that describe the content producer.
@@ -1370,7 +1403,8 @@ message BidRequest {
     optional string ipv6 = 9;
 
     // The general type of device.
-    // Refer to enum com.iabtechlab.adcom.v1.enums.DeviceType for generic values.
+    // Refer to enum com.iabtechlab.adcom.v1.enums.DeviceType for generic
+    // values.
     optional int32 devicetype = 18;
 
     // Device make (e.g., "Apple").
@@ -1433,7 +1467,8 @@ message BidRequest {
     optional string mccmnc = 30;
 
     // Network connection type.
-    // Refer to enum com.iabtechlab.adcom.v1.enums.ConnectionType for generic values.
+    // Refer to enum com.iabtechlab.adcom.v1.enums.ConnectionType for generic
+    // values.
     optional int32 connectiontype = 17;
 
     // ID sanctioned for advertiser use in the clear (i.e., not hashed).
@@ -1478,7 +1513,8 @@ message BidRequest {
     optional double lon = 2;
 
     // Source of location data; recommended when passing lat/lon.
-    // Refer to enum com.iabtechlab.adcom.v1.enums.LocationType for generic values.
+    // Refer to enum com.iabtechlab.adcom.v1.enums.LocationType for generic
+    // values.
     optional int32 type = 9;
 
     // Estimated location accuracy in meters; recommended when lat/lon are
@@ -1495,7 +1531,8 @@ message BidRequest {
 
     // Service or provider used to determine geolocation from IP address if
     // applicable (i.e., type = 2).
-    // Refer to enum com.iabtechlab.adcom.v1.enums.LocationService for generic values.
+    // Refer to enum com.iabtechlab.adcom.v1.enums.LocationService for generic
+    // values.
     optional int32 ipservice = 13;
 
     // Country using ISO-3166-1 Alpha-3.
@@ -1599,11 +1636,12 @@ message BidRequest {
         // The identifier for the user.
         optional string id = 1;
 
-	// Type of user agent the ID is from.  It is highly recommended to set
-	// this, as many DSPs separate app-native IDs from browser-based IDs
-	// and require a type value for ID resolution.
-        // Refer to enum com.iabtechlab.adcom.v1.enums.AgentType for generic values.
-	optional int32 atype = 2;
+        // Type of user agent the ID is from.  It is highly recommended to set
+        // this, as many DSPs separate app-native IDs from browser-based IDs
+        // and require a type value for ID resolution.
+        // Refer to enum com.iabtechlab.adcom.v1.enums.AgentType for generic
+        // values.
+        optional int32 atype = 2;
 
         // Extensions.
         extensions 100 to 9999;
@@ -1753,7 +1791,8 @@ message BidRequest {
     optional string model = 6;
 
     // The source of data used to create this object.
-    // Refer to enum com.iabtechlab.adcom.v1.enums.UserAgentSource for generic values.
+    // Refer to enum com.iabtechlab.adcom.v1.enums.UserAgentSource for generic
+    // values.
     optional int32 source = 7 [default = 0];
 
     // Placeholder for vendor specific extensions to this object.
@@ -1764,10 +1803,10 @@ message BidRequest {
     // software component, and the user agent's execution platform or operating
     // system.
     message BrandVersion {
-      // A brand identifier, for example, "Chrome" or "Windows". The value may be
-      // sourced from the User-Agent Client Hints headers, representing either
-      // the user agent brand (from the Sec-CH-UA-Full-Version header) or the
-      // platform brand (from the Sec-CH-UA-Platform header).
+      // A brand identifier, for example, "Chrome" or "Windows". The value may
+      // be sourced from the User-Agent Client Hints headers, representing
+      // either the user agent brand (from the Sec-CH-UA-Full-Version header) or
+      // theplatform brand (from the Sec-CH-UA-Platform header).
       optional string brand = 1;
 
       // A sequence of version components, in descending hierarchical order
@@ -1792,7 +1831,9 @@ message BidRequest {
     optional double multiplier = 1;
 
     // The source type of the quantity measurement, ie. publisher.
-    // Refer to enum com.iabtechlab.adcom.v1.enums.DOOHMultiplierMeasurementSourceType for generic values.
+    // Refer to enum
+    // com.iabtechlab.adcom.v1.enums.DOOHMultiplierMeasurementSourceType for
+    // generic values.
     // RECOMMENDED by the OpenRTB specification.
     optional int32 sourcetype = 2;
 
@@ -1855,7 +1896,8 @@ message BidRequest {
     // Information on how often and what triggers an ad slot being refreshed.
     message RefSettings {
       // The type of the declared auto refresh.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.AutoRefreshTrigger for generic values.
+      // Refer to enum com.iabtechlab.adcom.v1.enums.AutoRefreshTrigger for
+      // generic values.
       // RECOMMENDED by the OpenRTB specification.
       optional int32 reftype = 1 [default = 0];
 
@@ -1971,13 +2013,13 @@ message BidResponse {
       optional string lurl = 23;
 
       oneof adm_oneof {
-	// Optional means of conveying ad markup in case the bid wins;
-	// supersedes the win notice if markup is included in both.
-	// Substitution macros (Section 4.4) may be included.
+        // Optional means of conveying ad markup in case the bid wins;
+        // supersedes the win notice if markup is included in both.
+        // Substitution macros (Section 4.4) may be included.
         //
-	// For native ad bids, exactly one of {adm, adm_native} should be used;
-	// this is the OpenRTB-compliant field for JSON serialization.
-	string adm = 6;
+        // For native ad bids, exactly one of {adm, adm_native} should be used;
+        // this is the OpenRTB-compliant field for JSON serialization.
+        string adm = 6;
 
         // Native ad response.
         //
@@ -2020,7 +2062,8 @@ message BidResponse {
       optional string tactic = 24;
 
       // The taxonomy in use.
-      // Refer to the enum com.iabtechlab.adcom.v1.enums.CategoryTaxonomy for values.
+      // Refer to the enum com.iabtechlab.adcom.v1.enums.CategoryTaxonomy for
+      // values.
       optional int32 cattax = 30 [default = 1];
 
       // IAB content categories of the creative. The taxonomy to be used is
@@ -2029,20 +2072,24 @@ message BidResponse {
       repeated string cat = 15;
 
       // Set of attributes describing the creative.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.Creative.Attribute for generic values.
+      // Refer to enum com.iabtechlab.adcom.v1.enums.Creative.Attribute for
+      // generic values.
       repeated int32 attr = 11 [packed = true];
 
       // List of supported APIs for the markup. If an API is not explicitly
       // listed, it is assumed to be unsupported.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.APIFramework for generic values.
+      // Refer to enum com.iabtechlab.adcom.v1.enums.APIFramework for generic
+      // values.
       repeated int32 apis = 31 [packed = true];
 
       // API required by the markup if applicable.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.APIFramework for generic values.
+      // Refer to enum com.iabtechlab.adcom.v1.enums.APIFramework for generic
+      // values.
       optional int32 api = 18 [deprecated = true];
 
       // Video response protocol of the markup if applicable.
-      // Refer to enum com.iabtechlab.adcom.v1.Creative.AudioVideoType for generic values.
+      // Refer to enum com.iabtechlab.adcom.v1.Creative.AudioVideoType for
+      // generic values.
       optional int32 protocol = 19;
 
       // Creative media rating per QAG guidelines.
@@ -2091,7 +2138,8 @@ message BidResponse {
       // Indicates that the bid response is only eligible for a specific
       // position within a video or audio ad pod (e.g. first position, last
       // position, or any).
-      // Refer to enum com.iabtechlab.adcom.v1.enums.SlotPositionInPod for generic values.
+      // Refer to enum com.iabtechlab.adcom.v1.enums.SlotPositionInPod for
+      // generic values.
       optional int32 slotinpod = 28 [default = 0];
 
       // Extensions.
@@ -2129,11 +2177,13 @@ message NativeRequest {
   optional int32 context = 7;
 
   // A more detailed context in which the ad appears.
-  // Refer to enum com.iabtechlab.adcom.v1.enums.DisplayContextType for generic values.
+  // Refer to enum com.iabtechlab.adcom.v1.enums.DisplayContextType for generic
+  // values.
   optional int32 contextsubtype = 8;
 
   // The design/format/layout of the ad unit being offered.
-  // Refer to enum com.iabtechlab.adcom.v1.enums.DisplayPlacementType for generic values.
+  // Refer to enum com.iabtechlab.adcom.v1.enums.DisplayPlacementType for
+  // generic values.
   // RECOMMENDED by the OpenRTB Native specification.
   optional int32 plcmttype = 9;
 
@@ -2239,11 +2289,13 @@ message NativeRequest {
 
     // OpenRTB Native 1.0: The Image object to be used for all image elements
     // of the Native ad such as Icons, Main Image, etc.
-    // RECOMMENDED sizes and aspect ratios are included in com.iabtechlab.adcom.v1.NativeImageAssetType.
+    // RECOMMENDED sizes and aspect ratios are included in
+    // com.iabtechlab.adcom.v1.NativeImageAssetType.
     message Image {
       // Type ID of the image element supported by the publisher.
       // The publisher can display this information in an appropriate format.
-      // Refer to enum com.iabtechlab.adcom.v1.NativeImageAssetType for generic values.
+      // Refer to enum com.iabtechlab.adcom.v1.NativeImageAssetType for generic
+      // values.
       optional int32 type = 1;
 
       // Width of the image in pixels.
@@ -2284,7 +2336,8 @@ message NativeRequest {
     message Data {
       // Type ID of the element supported by the publisher. The publisher can
       // display this information in an appropriate format.
-      // Refer to enum com.iabtechlab.adcom.v1.NativeDataAssetType for generic values.
+      // Refer to enum com.iabtechlab.adcom.v1.NativeDataAssetType for generic
+      // values.
       // REQUIRED by the OpenRTB Native specification.
       optional int32 type = 1;
 
@@ -2309,7 +2362,8 @@ message NativeRequest {
     optional int32 event = 1;
 
     // Array of types of tracking available for the given event.
-    // Refer to enum com.iabtechlab.adcom.v1.enums.EventTrackingMethod for generic values.
+    // Refer to enum com.iabtechlab.adcom.v1.enums.EventTrackingMethod for
+    // generic values.
     // REQUIRED by the OpenRTB Native specification.
     repeated int32 methods = 2;
 
@@ -2449,7 +2503,8 @@ message NativeResponse {
     // (per ImageType enum) be provided for image type 3 (MAIN_IMAGE).
     message Image {
       // The type of image element being submitted from the ImageType enum.
-      // Refer to enum com.iabtechlab.adcom.v1.NativeImageAssetType for generic values.
+      // Refer to enum com.iabtechlab.adcom.v1.NativeImageAssetType for generic
+      // values.
       // REQUIRED for assetsurl or dcourl responses,
       // not required to embedded asset responses.
       // Implemented in 1.2
@@ -2481,13 +2536,15 @@ message NativeResponse {
     // Stars, Downloads, etc. It is also generic for future of native elements
     // not contemplated at the time of the writing of this document.
     message Data {
-      // The type of data element being submitted from the com.iabtechlab.adcom.v1.NativeDataAssetType enum.
-      // Refer to enum com.iabtechlab.adcom.v1.NativeDataAssetType for generic values.
+      // The type of data element being submitted from the
+      // com.iabtechlab.adcom.v1.NativeDataAssetType enum.
+      // Refer to that enum for generic values.
       // REQUIRED in 1.2 for assetsurl or dcourl responses.
       optional int32 type = 3;
 
       // The length of the data element being submitted. Where applicable, must
-      // comply with the recommended maximum lengths in the com.iabtechlab.adcom.v1.NativeDataAssetType enum.
+      // comply with the recommended maximum lengths in the
+      // com.iabtechlab.adcom.v1.NativeDataAssetType enum.
       // REQUIRED in 1.2 for assetsurl or dcourl responses.
       optional int32 len = 4;
 
@@ -2550,7 +2607,8 @@ message NativeResponse {
     optional int32 event = 1;
 
     // Type of tracking requested.
-    // Refer to enum com.iabtechlab.adcom.v1.enums.EventTrackingMethod for generic values.
+    // Refer to enum com.iabtechlab.adcom.v1.enums.EventTrackingMethod for
+    // generic values.
     // REQUIRED if embedded asset is being used.
     optional int32 method = 2;
 


### PR DESCRIPTION
The typo was Cotent: replaced with Content.
Whitespace was replacing tabs with spaces, so that indentation doesn't break in editors with different tab-width set.