### PR TITLE
Update 2.6.md

### DIFF
--- a/2.6.md
+++ b/2.6.md
@@ -8,7 +8,7 @@ Stanislav Belov, Software Engineer, Google; Allen Dove, CTO, Magnite; Steven Kat
 
 ### IAB Tech Lab Lead:
 
-Hillary Slattery, Director of Product, IAB Tech Lab
+Hillary Slattery, Sr. Director of Product, IAB Tech Lab
 
 ### License <a name="license"></a>
 
@@ -2763,19 +2763,15 @@ Extended identifiers support in the OpenRTB specification allows buyers to use a
 <tr>
     <td><code>inserter</code></td>
     <td>string</td>
-    <td>The canonical domain name of the entity (publisher, publisher monetization company, SSP, Exchange, Header Wrapper, etc) that caused the ID array element to be added. This may be the operational domain of the system, if that is different from the parent corporate domain, to facilitate WHOIS and reverse IP lookups to establish clear ownership of the delegate system.<br>
+    <td>The canonical domain name of the entity (publisher, publisher monetization company, SSP, Exchange, Header Wrapper, etc.) that caused the ID array element to be added. This may be the operational domain of the system, if that is different from the parent corporate domain, to facilitate WHOIS and reverse IP lookups to establish clear ownership of the delegate system.<br>
     </br>This should be the same value as used to identify sellers in an ads.txt file if one exists.<br>
-</br>For ad tech intermediaries, this would be their domain as used in ads.txt.  For publishers, this would match the domain in the <code>site</code> or <code>app</code> object.
+</br>For ad tech intermediaries, this would be the domain as used in ads.txt. For publishers, this would match the domain in the <code>site</code> or <code>app</code> object.
 </td>
  </tr>
   <tr>
     <td><code>source</code></td>
     <td>string</td>
-    <td>Canonical domain of the ID.<br>
-</br><b>EXAMPLES FOR PUBLIC COMMENT PERIOD ONLY</b>
-<li>Examples of a universal ID include “id5.io”, “liveramp.com”, “unifiedid.com”.</li>
-<li>Examples of a device ID include “apple.com”, “samsung.com”, “roku.com”.</li>
-    </td>
+    <td>Canonical domain of the ID.</td>
   </tr>
 <tr>
     <td><code>matcher</code></td>
@@ -2784,7 +2780,6 @@ Extended identifiers support in the OpenRTB specification allows buyers to use a
 </br>In some cases, this may be the same value as inserter.<br>
 </br>When blank, it is assumed that the <code>matcher</code> is equal to the <code>source</code><br>
 </br>May be omitted when mm=0, 1, or 2.<br>
-    </br><b>EXAMPLES FOR PUBLIC COMMENT ONLY: LiveIntent, Transunion, LiveRamp</b></br>
 </td>
  </tr>
 <tr>


### PR DESCRIPTION
Removing examples for Public Comment period from `matcher` and `source` attributes