### PR TITLE
Updated bid_response.ext.igi to be repeated.

### DIFF
--- a/src/main/com/iabtechlab/openrtb/v2/openrtb.proto
+++ b/src/main/com/iabtechlab/openrtb/v2/openrtb.proto
@@ -2421,7 +2421,7 @@ message BidResponse {
     // for a given ad slot. Must include at least a buyer object (igb, in the
     // bid response from the buyer to the seller) or seller object (igs, from
     // the seller to the publisher), but not both.
-    InterestGroupAuctionIntent igi = 2;
+    repeated InterestGroupAuctionIntent igi = 2;
 
     extensions 500 to max;
   }


### PR DESCRIPTION
The field is listed ambiguously in https://github.com/InteractiveAdvertisingBureau/openrtb/blob/develop/extensions/community_extensions/Protected%20Audience%20Support.md , but the examples in the lower part of the doc show igi being an array of objects, instead of a single object.