### PR TITLE
[Protobuf] bid_response.ext.(igb|igs): Removed oneof and added repeated

### DIFF
--- a/src/main/com/iabtechlab/openrtb/v2/openrtb.proto
+++ b/src/main/com/iabtechlab/openrtb/v2/openrtb.proto
@@ -2815,15 +2815,13 @@ message BidResponse {
     // response from the buyer to the seller.
     string impid = 1;
 
-    oneof interestgroupauction_oneof {
-      // One or more InterestGroupAuctionBuyer objects. Required and mutually
-      // exclusive with igs.
-      InterestGroupAuctionBuyer igb = 2;
+    // One or more InterestGroupAuctionBuyer objects. Required and mutually
+    // exclusive with igs.
+    repeated InterestGroupAuctionBuyer igb = 2;
 
-      // One or more InterestGroupAuctionSeller objects. Required and mutually
-      // exclusive with igb.
-      InterestGroupAuctionSeller igs = 3;
-    }
+    // One or more InterestGroupAuctionSeller objects. Required and mutually
+    // exclusive with igb.
+    repeated InterestGroupAuctionSeller igs = 3;
   } // InterestGroupAuctionIntent
 
   // Information provided by the buyer and necessary for the seller to build the


### PR DESCRIPTION
Similar to https://github.com/InteractiveAdvertisingBureau/openrtb2.x/pull/131 , these two are marked as repeated in the specificaiton.

This gets a bit odd as they're also exclusive, which was enforced by the oneof; but oneofs can't be repeated. The exclusive constraint will need to be programatically provided, instead of provided by the protocol.