### PR TITLE
[Protobuf] Fledge igi.pbs as value instead of string

### DIFF
--- a/src/main/com/iabtechlab/openrtb/v2/openrtb.proto
+++ b/src/main/com/iabtechlab/openrtb/v2/openrtb.proto
@@ -1,6 +1,8 @@
 edition = "2023";
 
 import "google/protobuf/any.proto";
+import "google/protobuf/struct.proto";
+
 option java_outer_classname = "OpenRtb";
 package com.iabtechlab.openrtb.v2;
 
@@ -2855,7 +2857,7 @@ message BidResponse {
     // add to its auction config perBuyerSignals attribute map, keyed by the
     // Interest Group buyer Origin. Per PA API spec, the value may be any valid
     // JSON serializable value.
-    string pbs = 4;
+    .google.protobuf.Value pbs = 4;
 
     // The buyer’s priority signals, an object mapping string keys to Javascript
     // numbers. If specified, the seller will add to its auction config


### PR DESCRIPTION
Similar to https://github.com/InteractiveAdvertisingBureau/openrtb2.x/pull/131 and https://github.com/InteractiveAdvertisingBureau/openrtb2.x/pull/132 but backwards from previous justifications.

In practice this is a json tree that's not wrapped in a string. The examples in https://github.com/InteractiveAdvertisingBureau/openrtb/blob/develop/extensions/community_extensions/Protected%20Audience%20Support.md show this as a string containing json (which is also valid but more recursive than normal). In practice this is more often passed as a json tree inlined in the document itself.