### PR TITLE
Added a comment block about claiming an extension range.

### DIFF
--- a/src/main/com/iabtechlab/openrtb/v2/openrtb.proto
+++ b/src/main/com/iabtechlab/openrtb/v2/openrtb.proto
@@ -22,7 +22,7 @@ package com.iabtechlab.openrtb.v2;
 
 // OpenRTB extensions ("ext" fields in the spec & JSON representation) are
 // represented here by Protocol Buffer extensions. This proto only reserves the
-// range of IDs 500-9999 at every extensible object. Beware that upstream
+// range of IDs 500-max at every extensible object. Beware that upstream
 // authors of a message may reserve extension IDs for their own use, so an
 // author is not free to propagate a message adding their own extensions.
 
@@ -36,6 +36,7 @@ package com.iabtechlab.openrtb.v2;
 // 1-499: IAB defined extensions
 // 500-999: Prototype space (intentionally unclaimed)
 // 1000-1999: Google
+// 2000-2999: Amazon
 
 // OpenRTB 2.0: The top-level bid request object contains a globally unique bid
 // request or auction ID. This id attribute is required as is at least one


### PR DESCRIPTION
This includes the IAB block (0-499) the prototype block (500-599) and the Google allocated block.