### PR TITLE
[Protobuf] The great flattening!

### DIFF
--- a/src/main/com/iabtechlab/openrtb/v2/openrtb.proto
+++ b/src/main/com/iabtechlab/openrtb/v2/openrtb.proto
@@ -222,98 +222,98 @@ message BidRequest {
 
       extensions 500 to max;
     }
+  }  // Source
 
-    // This object is composed of a set of nodes where each node represents a
-    // specific entity that participates in the transacting of inventory. The
-    // entire chain of nodes from beginning to end represents all entities who
-    // are involved in the direct flow of payment for inventory. Detailed
-    // implementation examples can be found here:
-    // https://github.com/InteractiveAdvertisingBureau/openrtb/blob/master/supplychainobject.md.
-    message SupplyChain {
-      // Flag indicating whether the chain contains all nodes involved in the
-      // transaction leading back to the owner of the site, app or other medium
-      // of the inventory, where 0 = no, 1 = yes.
-      bool complete = 1;
+  // This object is composed of a set of nodes where each node represents a
+  // specific entity that participates in the transacting of inventory. The
+  // entire chain of nodes from beginning to end represents all entities who
+  // are involved in the direct flow of payment for inventory. Detailed
+  // implementation examples can be found here:
+  // https://github.com/InteractiveAdvertisingBureau/openrtb/blob/master/supplychainobject.md.
+  message SupplyChain {
+    // Flag indicating whether the chain contains all nodes involved in the
+    // transaction leading back to the owner of the site, app or other medium
+    // of the inventory, where 0 = no, 1 = yes.
+    bool complete = 1;
 
-      // Array of SupplyChainNode objects in the order of the chain. In a
-      // complete supply chain, the first node represents the initial
-      // advertising system and seller ID involved in the transaction, i.e. the
-      // owner of the site, app, or other medium. In an incomplete supply chain,
-      // it represents the first known node. The last node represents the entity
-      // sending this bid request.
-      repeated SupplyChainNode nodes = 2;
+    // Array of SupplyChainNode objects in the order of the chain. In a
+    // complete supply chain, the first node represents the initial
+    // advertising system and seller ID involved in the transaction, i.e. the
+    // owner of the site, app, or other medium. In an incomplete supply chain,
+    // it represents the first known node. The last node represents the entity
+    // sending this bid request.
+    repeated SupplyChainNode nodes = 2;
 
-      // Version of the supply chain specification in use, in the format of
-      // "major.minor". For example, for version 1.0 of the spec, use the string
-      // "1.0".
-      string ver = 3;
+    // Version of the supply chain specification in use, in the format of
+    // "major.minor". For example, for version 1.0 of the spec, use the string
+    // "1.0".
+    string ver = 3;
 
-      // Placeholder for exchange-specific extensions to OpenRTB.
-      Ext ext = 99;
+    // Placeholder for exchange-specific extensions to OpenRTB.
+    Ext ext = 99;
 
-      message Ext {
-        extensions 500 to max;
-      }
+    message Ext {
+      extensions 500 to max;
+    }
+  }  // SupplyChain
 
-      // This object is associated with a SupplyChain object as an array of
-      // nodes. These nodes define the identity of an entity participating in
-      // the supply chain of a bid request. Detailed implementation examples
-      // can be found here:
-      // https://github.com/InteractiveAdvertisingBureau/openrtb/blob/master/supplychainobject.md.
-      // The SupplyChainNode object contains the following attributes.
-      message SupplyChainNode {
-        // The canonical domain name of the SSP, Exchange, Header Wrapper, etc
-        // system that bidders connect to. This may be the operational domain of
-        // the system, if that is different than the parent corporate domain, to
-        // facilitate WHOIS and reverse IP lookups to establish clear ownership
-        // of the delegate system. This should be the same value as used to
-        // identify sellers in an ads.txt file if one exists.
-        string asi = 1;
+  // This object is associated with a SupplyChain object as an array of
+  // nodes. These nodes define the identity of an entity participating in
+  // the supply chain of a bid request. Detailed implementation examples
+  // can be found here:
+  // https://github.com/InteractiveAdvertisingBureau/openrtb/blob/master/supplychainobject.md.
+  // The SupplyChainNode object contains the following attributes.
+  message SupplyChainNode {
+    // The canonical domain name of the SSP, Exchange, Header Wrapper, etc
+    // system that bidders connect to. This may be the operational domain of
+    // the system, if that is different than the parent corporate domain, to
+    // facilitate WHOIS and reverse IP lookups to establish clear ownership
+    // of the delegate system. This should be the same value as used to
+    // identify sellers in an ads.txt file if one exists.
+    string asi = 1;
 
-        // The identifier associated with the seller or reseller account within
-        // the advertising system. This must contain the same value used in
-        // transactions (i.e. OpenRTB bid requests) in the field specified by
-        // the SSP/exchange. Typically, in OpenRTB, this is publisher.id. For
-        // OpenDirect it is typically the publisher's organization ID. Should be
-        // limited to 64 characters in length.
-        string sid = 2;
+    // The identifier associated with the seller or reseller account within
+    // the advertising system. This must contain the same value used in
+    // transactions (i.e. OpenRTB bid requests) in the field specified by
+    // the SSP/exchange. Typically, in OpenRTB, this is publisher.id. For
+    // OpenDirect it is typically the publisher's organization ID. Should be
+    // limited to 64 characters in length.
+    string sid = 2;
 
-        // The OpenRTB RequestId of the request as issued by this seller.
-        string rid = 3;
+    // The OpenRTB RequestId of the request as issued by this seller.
+    string rid = 3;
 
-        // The name of the company (the legal entity) that is paid for inventory
-        // transacted under the given seller_id. This value is optional and
-        // should NOT be included if it exists in the advertising system's
-        // sellers.json file.
-        string name = 4;
+    // The name of the company (the legal entity) that is paid for inventory
+    // transacted under the given seller_id. This value is optional and
+    // should NOT be included if it exists in the advertising system's
+    // sellers.json file.
+    string name = 4;
 
-        // The business domain name of the entity represented by this node. This
-        // value is optional and should NOT be included if it exists in the
-        // advertising system's sellers.json file.
-        string domain = 5;
+    // The business domain name of the entity represented by this node. This
+    // value is optional and should NOT be included if it exists in the
+    // advertising system's sellers.json file.
+    string domain = 5;
 
-        // Indicates whether this node will be involved in the flow of payment
-        // for the inventory. When set to 1, the advertising system in the asi
-        // field pays the seller in the sid field, who is responsible for paying
-        // the previous node in the chain. When set to 0, this node is not
-        // involved in the flow of payment for the inventory. For version 1.0 of
-        // SupplyChain, this property should always be 1. It is explicitly
-        // required to be included as it is expected that future versions of the
-        // specification will introduce non-payment handling nodes. Implementers
-        // should ensure that they support this field and propagate it onwards
-        // when constructing SupplyChain objects in bid requests sent to a
-        // downstream advertising system.
-        bool hp = 6;
+    // Indicates whether this node will be involved in the flow of payment
+    // for the inventory. When set to 1, the advertising system in the asi
+    // field pays the seller in the sid field, who is responsible for paying
+    // the previous node in the chain. When set to 0, this node is not
+    // involved in the flow of payment for the inventory. For version 1.0 of
+    // SupplyChain, this property should always be 1. It is explicitly
+    // required to be included as it is expected that future versions of the
+    // specification will introduce non-payment handling nodes. Implementers
+    // should ensure that they support this field and propagate it onwards
+    // when constructing SupplyChain objects in bid requests sent to a
+    // downstream advertising system.
+    bool hp = 6;
 
-        // Placeholder for exchange-specific extensions to OpenRTB.
-        Ext ext = 99;
+    // Placeholder for exchange-specific extensions to OpenRTB.
+    Ext ext = 99;
 
-        message Ext {
-          extensions 500 to max;
-        }
-      } // SupplyChainNode
-    } // SupplyChain
-  } // Source
+    message Ext {
+      extensions 500 to max;
+    }
+  }  // SupplyChainNode
 
   // This object describes an ad placement or impression being auctioned. A
   // single bid request can include multiple Imp objects, a use case for which
@@ -450,820 +450,819 @@ message BidRequest {
 
       extensions 500 to max;
     }
-
-    // This object is associated with an impression as an array of metrics.
-    // These metrics can offer insight into the impression to assist with
-    // decisioning such as average recent viewability, click-through rate, etc.
-    // Each metric is identified by its type, reports the value of the metric,
-    // and optionally identifies the source or vendor measuring the value.
-    message Metric {
-      // Type of metric being presented using exchange curated string names
-      // which should be published to bidders a priori.
-      // REQUIRED by the OpenRTB specification.
-      string type = 1;
-
-      // Number representing the value of the metric. Probabilities must be in
-      // the range 0.0 - 1.0.
-      // REQUIRED by the OpenRTB specification.
-      double value = 2;
-
-      // Source of the value using exchange curated string names which should be
-      // published to bidders a priori. If the exchange itself is the source
-      // versus a third party, "EXCHANGE" is recommended.
-      // RECOMMENDED by the OpenRTB specification.
-      string vendor = 3;
-
-      // Placeholder for exchange-specific extensions to OpenRTB.
-      Ext ext = 99;
-
-      message Ext {
-        extensions 500 to max;
-      }
-    } // Metric
-
-    // This object represents the most general type of impression. Although the
-    // term "banner" may have very specific meaning in other contexts, here it
-    // can be many things including a simple static image, an expandable ad
-    // unit, or even in-banner video (refer to the Video object in Section 3.2.7
-    // for the more generalized and full featured video ad units). An array of
-    // Banner objects can also appear within the Video to describe optional
-    // companion ads defined in the VAST specification.
-    //
-    // The presence of a Banner as a subordinate of the Imp object indicates
-    // that this impression is offered as a banner type impression. At the
-    // publisher's discretion, that same impression may also be offered as
-    // video, audio, and/or native by also including as Imp subordinates the
-    // objects of those types. However, any given bid for the impression must
-    // conform to one of the offered types.
-    message Banner {
-      // Array of format objects (Section 3.2.10) representing the banner sizes
-      // permitted. If none are specified, then use of the h and w attributes is
-      // highly recommended.
-      repeated Format format = 15;
-
-      // Width in device independent pixels (DIPS); recommended if no Format
-      // objects are specified.
-      int32 w = 1;
-
-      // Height in device independent pixels (DIPS); recommended if no Format
-      // objects are specified.
-      int32 h = 2;
-
-      // Blocked banner ad types.
-      // Refer to enum BannerAdType for values.
-      repeated int32 btype = 5;
-
-      // Blocked creative attributes.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.Creative.Attribute for
-      // values.
-      repeated int32 battr = 6;
-
-      // Ad position on screen.
-      // Refer to enum com.iabtechlab.adcom.v1.PlacementPosition for values.
-      int32 pos = 4;
-
-      // Content MIME types supported. Popular MIME types may include,
-      // "image/jpeg" and "image/gif".
-      repeated string mimes = 7;
-
-      // Indicates if the banner is in the top frame as opposed to an iframe,
-      // where 0 = no, 1 = yes.
-      bool topframe = 8;
-
-      // Directions in which the banner may expand.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.ExpandableDirection for
-      // values.
-      repeated int32 expdir = 9;
-
-      // List of supported API frameworks for this impression. If an API is not
-      // explicitly listed, it is assumed not to be supported.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.APIFramework for values.
-      repeated int32 api = 10;
-
-      // Unique identifier for this banner object. Recommended when Banner
-      // objects are used with a Video object (Section 3.2.7) to represent an
-      // array of companion ads. Values usually start at 1 and increase with
-      // each object; should be unique within an impression.
-      string id = 3;
-
-      // Relevant only for Banner objects used with a Video object (Section
-      // 3.2.7) in an array of companion ads. Indicates the companion banner
-      // rendering mode relative to the associated video, where 0 = concurrent,
-      // 1 = end-card.
-      bool vcm = 16;
-
-      // NOTE: Deprecated in favor of the format array.
-      // Maximum width in device independent pixels (DIPS).
-      int32 wmax = 11 [deprecated = true];
-
-      // NOTE: Deprecated in favor of the format array.
-      // Maximum height in device independent pixels (DIPS).
-      int32 hmax = 12 [deprecated = true];
-
-      // NOTE: Deprecated in favor of the format array.
-      // Minimum width in device independent pixels (DIPS).
-      int32 wmin = 13 [deprecated = true];
-
-      // NOTE: Deprecated in favor of the format array.
-      // Minimum height in device independent pixels (DIPS).
-      int32 hmin = 14 [deprecated = true];
-
-      // Placeholder for exchange-specific extensions to OpenRTB.
-      Ext ext = 99;
-
-      message Ext {
-        extensions 500 to max;
-      }
-
-      // This object represents an allowed size (i.e., height and width
-      // combination) or Flex Ad parameters for a banner impression. These are
-      // typically used in an array where multiple sizes are permitted. It is
-      // recommended that either the w/h pair or the wratio/hratio/wmin set
-      // (i.e., for Flex Ads) be specified.
-      message Format {
-        // Width in device independent pixels (DIPS).
-        int32 w = 1;
-
-        // Height in device independent pixels (DIPS).
-        int32 h = 2;
-
-        // Relative width when expressing size as a ratio.
-        int32 wratio = 3;
-
-        // Relative height when expressing size as a ratio.
-        int32 hratio = 4;
-
-        // The minimum width in device independent pixels (DIPS) at which the ad
-        // will be displayed when the size is expressed as a ratio.
-        int32 wmin = 5;
-
-        // Placeholder for exchange-specific extensions to OpenRTB.
-        Ext ext = 99;
-
-        message Ext {
-          extensions 500 to max;
-        }
-      } // Format
-    } // Banner
-
-    // This object represents a video impression. Many of the fields are
-    // non-essential for minimally viable transactions, but are included to
-    // offer fine control when needed. Video in OpenRTB generally assumes
-    // compliance with the VAST standard. As such, the notion of companion ads
-    // is supported by optionally including an array of Banner objects (refer to
-    // the Banner object in Section 3.2.6) that define these companion ads.
-    //
-    // The presence of a Video as a subordinate of the Imp object indicates that
-    // this impression is offered as a video type impression. At the publisher's
-    // discretion, that same impression may also be offered as Banner, Audio,
-    // and/or Native by also including as Imp subordinates objects of those
-    // types. However, any given bid for the impression must conform to one of
-    // the offered types.
-    message Video {
-      // Content MIME types supported (e.g., "video/mp4").
-      // REQUIRED by the OpenRTB specification: at least 1 element.
-      repeated string mimes = 1;
-
-      // Minimum video ad duration in seconds. This field is mutually exclusive
-      // with rqddurs; only one of minduration and rqddurs may be in a bid
-      // request.
-      // RECOMMENDED by the OpenRTB specification.
-      int32 minduration = 3 [default = 0];
-
-      // Maximum video ad duration in seconds. This field is mutually exclusive
-      // with rqddurs; only one of maxduration and rqddurs may be in a bid
-      // request.
-      // RECOMMENDED by the OpenRTB specification.
-      int32 maxduration = 4;
-
-      // Indicates the start delay in seconds for pre-roll, mid-roll, or
-      // post-roll ad placements.
-      // Refer to enum com.iabtechlab.adcom.v1.StartDelayMode for values.
-      // RECOMMENDED by the OpenRTB specification.
-      int32 startdelay = 8;
-
-      // Indicates the maximum number of ads that may be served into a "dynamic"
-      // video ad pod (where the precise number of ads is not predetermined by
-      // the seller). See Section 7.6 for more details.
-      int32 maxseq = 28;
-
-      // Indicates the total amount of time in seconds that advertisers may fill
-      // for a "dynamic" video ad pod (See Section 7.6 for more details), or the
-      // dynamic portion of a "hybrid" ad pod. This field is required only for
-      // the dynamic portion(s) of video ad pods. This field refers to the
-      // length of the entire ad break, whereas minduration/maxduration/rqddurs
-      // are constraints relating to the slots that make up the pod.
-      int32 poddur = 29;
-
-      // Array of supported video bid response protocols.
-      // Refer to enum com.iabtechlab.adcom.v1.Creative.AudioVideoType for
-      // values.
-      repeated int32 protocols = 21;
-
-      // Width of the video player in device independent pixels (DIPS).
-      // RECOMMENDED by the OpenRTB specification.
-      int32 w = 6;
-
-      // Height of the video player in device independent pixels (DIPS).
-      // RECOMMENDED by the OpenRTB specification.
-      int32 h = 7;
-
-      // Unique identifier indicating that an impression opportunity belongs to
-      // a video ad pod. If multiple impression opportunities within a bid
-      // request share the same podid, this indicates that those impression
-      // opportunities belong to the same video ad pod.
-      string podid = 30;
-
-      // The sequence (position) of the video ad pod within a content stream.
-      // Refer to in AdCOM 1.0 for guidance on the use of this field.
-      int32 podseq = 31 [default = 0];
-
-      // Precise acceptable durations for video creatives in seconds. This field
-      // specifically targets the Live TV use case where non-exact ad durations
-      // would result in undesirable ‘dead air'. This field is mutually
-      // exclusive with minduration and maxduration; if rqddurs is specified,
-      // minduration and maxduration must not be specified and vice versa.
-      repeated int32 rqddurs = 32;
-
-      // Deprecated as of OpenRTB 2.6-202303. Use plcmt instead.
-      // Refer to enum com.iabtechlab.adcom.v1.VideoPlacementSubtype for values.
-      int32 placement = 26 [deprecated = true];
-
-      // Video placement type for the impression.
-      // Refer to enum com.iabtechlab.adcom.v1.VideoPlcmtSubtype for values.
-      int32 plcmt = 35;
-
-      // Indicates if the impression must be linear, nonlinear, etc. If none
-      // specified, assume all are allowed. Note that this field describes the
-      // expected VAST response and not whether a placement is in-stream,
-      // out-stream, etc. For that, see plcmt.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.LinearityMode for values.
-      int32 linearity = 2;
-
-      // Indicates if the player will allow the video to be skipped, where 0 =
-      // no, 1 = yes. If a bidder sends markup/creative that is itself
-      // skippable, the Bid object should include the attr array with an element
-      // of 16 indicating skippable video. Refer to List: Creative Attributes in
-      // AdCOM 1.0.
-      bool skip = 23;
-
-      // Videos of total duration greater than this number of seconds can be
-      // skippable; only applicable if the ad is skippable.
-      int32 skipmin = 24;
-
-      // Number of seconds a video must play before skipping is enabled; only
-      // applicable if the ad is skippable.
-      int32 skipafter = 25;
-
-      // Deprecated as of OpenRTB 2.6. Use slotinpod.
-      // If multiple ad impressions are offered in the same bid request, the
-      // sequence number will allow for the coordinated delivery of multiple
-      // creatives.
-      int32 sequence = 9 [default = 0, deprecated = true];
-
-      // For video ad pods, this value indicates that the seller can guarantee
-      // delivery against the indicated slot position in the pod. Refer to List:
-      // Slot Position in Pod in AdCOM 1.0 guidance on the use of this field.
-      int32 slotinpod = 33 [default = 0];
-
-      // Minimum CPM per second. This is a price floor for the "dynamic" portion
-      // of a video ad pod, relative to the duration of bids an advertiser may
-      // submit.
-      double mincpmpersec = 34;
-
-      // Blocked creative attributes.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.Creative.Attribute for
-      // values.
-      repeated int32 battr = 10;
-
-      // Maximum extended video ad duration, if extension is allowed. If blank
-      // or 0, extension is not allowed. If -1, extension is allowed, and there
-      // is no time limit imposed. If greater than 0, then the value represents
-      // the number of seconds of extended play supported beyond the maxduration
-      // value.
-      int32 maxextended = 11;
-
-      // Minimum bit rate in Kbps (kilobits per second).
-      int32 minbitrate = 12;
-
-      // Maximum bit rate in Kbps (kilobits per second).
-      int32 maxbitrate = 13;
-
-      // Indicates if letter-boxing of 4:3 content into a 16:9 window is
-      // allowed, where 0 = no, 1 = yes.
-      bool boxingallowed = 14 [default = true];
-
-      // Playback methods that may be in use. If none are specified, any method
-      // may be used. Only one method is typically used in practice. As a
-      // result, this array may be converted to an integer in a future version
-      // of the specification. It is strongly advised to use only the first
-      // element of this array in preparation for this change.
-      // Refer to enum com.iabtechlab.adcom.v1.PlaybackMethod for values.
-      repeated int32 playbackmethod = 15;
-
-      // The event that causes playback to end.
-      // Refer to enum com.iabtechlab.adcom.v1.PlaybackCessationMode for values.
-      int32 playbackend = 27;
-
-      // Supported delivery methods (e.g., streaming, progressive). If none
-      // specified, assume all are supported.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.DeliveryMethod for values.
-      repeated int32 delivery = 16;
-
-      // Ad position on screen.
-      // Refer to enum com.iabtechlab.adcom.v1.PlacementPosition for values.
-      int32 pos = 17;
-
-      // Array of Banner objects (Section 3.2.6) if companion ads are available.
-      repeated Banner companionad = 18;
-
-      // List of supported API frameworks for this impression. If an API is not
-      // explicitly listed, it is assumed not to be supported.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.APIFramework for values.
-      repeated int32 api = 19;
-
-      // Supported VAST companion ad types. Recommended if companion Banner
-      // objects are included via the companionad array. If one of these banners
-      // will be rendered as an end-card, this can be specified using the vcm
-      // attribute with the particular banner (Section 3.2.6).
-      // Refer to enum com.iabtechlab.adcom.v1.CompanionType for values.
-      repeated int32 companiontype = 20;
-
-      // Indicates pod deduplication settings that will be applied to bid
-      // responses.
-      // PROVISIONAL in the OpenRTB specification.
-      repeated int32 poddedupe = 37;
-
-      // An array of DurFloors objects (Section 3.2.35) indicating the floor
-      // prices for video creatives of various durations that the buyer may bid
-      // with.
-      repeated DurFloors durfloors = 36;
-
-      // Deprecated; use protocols.
-      // Refer to enum com.iabtechlab.adcom.v1.Creative.AudioVideoType for
-      // values.
-      int32 protocol = 5 [deprecated = true];
-
-      // Placeholder for exchange-specific extensions to OpenRTB.
-      Ext ext = 99;
-
-      message Ext {
-        extensions 500 to max;
-      }
-
-      // Retired fields.
-      reserved 22;
-    } // Video
-
-    // This object represents an audio type impression. Many of the fields are
-    // non-essential for minimally viable transactions, but are included to
-    // offer fine control when needed. Audio in OpenRTB generally assumes
-    // compliance with the VAST standard. As such, the notion of companion ads
-    // is supported by optionally including an array of Banner objects (refer to
-    // the Banner object in Section 3.2.6) that define these companion ads.
-    //
-    // The presence of a Audio as a subordinate of the Imp object indicates that
-    // this impression is offered as an audio type impression. At the
-    // publisher's discretion, that same impression may also be offered as
-    // Banner, Video, and/or Native by also including as Imp subordinates
-    // objects of those types. However, any given bid for the impression must
-    // conform to one of the offered types.
-    message Audio {
-      // Content MIME types supported (e.g., "audio/mp4").
-      // REQUIRED by the OpenRTB specification: at least 1 element.
-      repeated string mimes = 1;
-
-      // Minimum audio ad duration in seconds. This field is mutually exclusive
-      // with rqddurs; only one of minduration and rqddurs may be in a bid
-      // request.
-      // RECOMMENDED by the OpenRTB specification.
-      int32 minduration = 2 [default = 0];
-
-      // Maximum audio ad duration in seconds. This field is mutually exclusive
-      // with rqddurs; only one of maxduration and rqddurs may be in a bid
-      // request.
-      // RECOMMENDED by the OpenRTB specification.
-      int32 maxduration = 3;
-
-      // Indicates the total amount of time that advertisers may fill for a
-      // "dynamic" audio ad pod, or the dynamic portion of a "hybrid" ad pod.
-      // This field is required only for the dynamic portion(s) of audio ad
-      // pods. This field refers to the length of the entire ad break, wheras
-      // minduration/maxduration/rqddurs are constraints relating to the slots
-      // that make up the pod.
-      int32 poddur = 25;
-
-      // Array of supported audio protocols.
-      // Refer to enum com.iabtechlab.adcom.v1.Creative.AudioVideoType for
-      // values.
-      // RECOMMENDED by the OpenRTB specification.
-      repeated int32 protocols = 4;
-
-      // Indicates the start delay in seconds for pre-roll, mid-roll, or
-      // post-roll ad placements.
-      // Refer to enum com.iabtechlab.adcom.v1.StartDelayMode for values.
-      // RECOMMENDED by the OpenRTB specification.
-      int32 startdelay = 5;
-
-      // Precise acceptable durations for audio creatives in seconds. This field
-      // specifically targets the live audio/radio use case where non-exact ad
-      // durations would result in undesirable 'dead air'. This field is
-      // mutually exclusive with minduraiton and maxduration; if rqddurs is
-      // specified, minduration and maxduration must not be specified and vice
-      // versa.
-      repeated int32 rqddurs = 26;
-
-      // Unique identifier indicating that an impression opportunity belongs to
-      // an audio ad pod. If multiple impression opportunities within a bid
-      // request share the same podid, this indicates that those impression
-      // opportunities belong to the same audio ad pod.
-      string podid = 27;
-
-      // The sequence (position) of the audio ad pod within a content stream.
-      int32 podseq = 28 [default = 0];
-
-      // Deprecated as of OpenRTB 2.6. Use slotinpod.
-      int32 sequence = 6 [default = 0, deprecated = true];
-
-      // For audio ad pods, this value indicates that the seller can guarantee
-      // delivery against the indicated slot position in the pod.
-      int32 slotinpod = 29 [default = 0];
-
-      // Minimum CPM per second. This is a price floor for the "dynamic" portion
-      // of an audio ad pod, relative to the duration of bids an advertiser may
-      // submit.
-      double mincpmpersec = 30;
-
-      // Blocked creative attributes.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.Creative.Attribute for
-      // values.
-      repeated int32 battr = 7;
-
-      // Maximum extended video ad duration, if extension is allowed. If blank
-      // or 0, extension is not allowed. If -1, extension is allowed, and there
-      // is no time limit imposed. If greater than 0, then the value represents
-      // the number of seconds of extended play supported beyond the maxduration
-      // value.
-      int32 maxextended = 8;
-
-      // Minimum bit rate in Kbps (kilobits per second).
-      int32 minbitrate = 9;
-
-      // Maximum bit rate in Kbps (kilobits per second).
-      int32 maxbitrate = 10;
-
-      // Supported delivery methods (e.g., streaming, progressive). If none
-      // specified, assume all are supported.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.DeliveryMethod for values.
-      repeated int32 delivery = 11;
-
-      // Array of Banner objects (Section 3.2.6) if companion ads are available.
-      repeated Banner companionad = 12;
-
-      // List of supported API frameworks for this impression. If an API is not
-      // explicitly listed, it is assumed not to be supported.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.APIFramework for values.
-      repeated int32 api = 13;
-
-      // Supported companion ad types. Recommended if companion Banner objects
-      // are included via the companionad array.
-      // Refer to enum com.iabtechlab.adcom.v1.CompanionType for values.
-      repeated int32 companiontype = 20;
-
-      // The maximum number of ads that can be played in an ad pod.
-      int32 maxseq = 21;
-
-      // Type of audio feed.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.FeedType for values.
-      int32 feed = 22;
-
-      // Indicates if the ad is stitched with audio content or delivered
-      // independently, where 0 = no, 1 = yes.
-      bool stitched = 23;
-
-      // Volume normalization mode.
-      // Refer to enum com.iabtechlab.adcom.v1.VolumeNormalizationMode for
-      // values.
-      int32 nvol = 24;
-
-      // An array of DurFloors objects (Section 3.2.35) indicating the floor
-      // prices for audio creatives of various durations that the buyer may bid
-      // with.
-      repeated DurFloors durfloors = 31;
-
-      // Placeholder for exchange-specific extensions to OpenRTB.
-      Ext ext = 99;
-
-      message Ext {
-        extensions 500 to max;
-      }
-    } // Audio
-
-    // This object represents a native type impression. Native ad units are
-    // intended to blend seamlessly into the surrounding content (e.g., a
-    // sponsored Twitter or Facebook post). As such, the response must be
-    // well-structured to afford the publisher fine-grained control over
-    // rendering.
-    //
-    // The Native Subcommittee has developed a companion specification to
-    // OpenRTB called the Dynamic Native Ads API. It defines the request
-    // parameters and response markup structure of native ad units. This object
-    // provides the means of transporting request parameters as an opaque string
-    // so that the specific parameters can evolve separately under the auspices
-    // of the Dynamic Native Ads API. Similarly, the ad markup served will be
-    // structured according to that specification.
-    //
-    // The presence of a Native as a subordinate of the Imp object indicates
-    // that this impression is offered as a native type impression. At the
-    // publisher's discretion, that same impression may also be offered as
-    // Banner, Video, and/or Audio by also including as Imp subordinates objects
-    // of those types. However, any given bid for the impression must conform to
-    // one of the offered types.
-    message Native {
-      // Request payload complying with the Native Ad Specification. The root
-      // node of the payload, "native", was dropped in the Native Ads
-      // Specification 1.1. For Native 1.0, this is a JSON-encoded string
-      // consisting of a unnamed root object, with a single subordinate object
-      // named 'native', which is the Native Markup Request object, section 4.1
-      // of OpenRTB Native 1.0 specification. For Native 1.1 and higher, this is
-      // a JSON-encoded string consisting of an unnamed root object which is
-      // itself the Native Markup Request Object, section 4.1 of OpenRTB Native
-      // 1.1+.
-      oneof request_oneof {
-        // This is the OpenRTB-compliant field for JSON serialization.
-        string request = 1;
-
-        // This is an alternate field preferred for Protobuf serialization.
-        NativeRequest request_native = 50;
-      }
-
-      // Version of the Native Ad Specification to which request complies;
-      // highly recommended for efficient parsing.
-      // RECOMMENDED by the OpenRTB specification.
-      string ver = 2;
-
-      // List of supported API frameworks for this impression. If an API is not
-      // explicitly listed, it is assumed not to be supported.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.APIFramework for values.
-      repeated int32 api = 3;
-
-      // Blocked creative attributes.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.Creative.Attribute for
-      // values.
-      repeated int32 battr = 4;
-
-      // Placeholder for exchange-specific extensions to OpenRTB.
-      Ext ext = 99;
-
-      message Ext {
-        extensions 500 to max;
-      }
-    } // Native
-
-    // A programmatic impression is often referred to as a ‘spot' in digital
-    // out-of-home and CTV, with an impression being a unique member of the
-    // audience viewing it. Therefore, a standard means of passing a multiplier
-    // in the bid request, representing the total quantity of impressions, is
-    // required. This object includes the impression multiplier, and describes
-    // the source of the multiplier value.
-    message Qty {
-      // The quantity of billable events which will be deemed to have occurred
-      // if this item is purchased. For example, a DOOH opportunity may be
-      // considered to be 14.2 impressions. Equivalent to qtyflt in OpenRTB
-      // 3.0.
-      double multiplier = 1;
-
-      // The source type of the quantity measurement, ie. publisher.
-      // Refer to enum
-      // com.iabtechlab.adcom.v1.enums.DOOHMultiplierMeasurementSourceType for
-      // values.
-      // RECOMMENDED by the OpenRTB specification.
-      int32 sourcetype = 2;
-
-      // The top level business domain name of the measurement vendor providing
-      // the quantity measurement.
-      // REQUIRED by the OpenRTB specification if sourcetype is equal to 1.
-      string vendor = 3;
-
-      // Placeholder for exchange-specific extensions to OpenRTB.
-      Ext ext = 99;
-
-      message Ext {
-        extensions 500 to max;
-      }
-    } // Qty
-
-    message Refresh {
-      // A RefSettings object (see Section 3.2.34) describing the mechanics of
-      // how an ad placement automatically refreshes.
-      repeated RefSettings refsettings = 1;
-
-      // The number of times this ad slot had been refreshed since last page
-      // load.
-      int32 count = 2;
-
-      // Placeholder for exchange-specific extensions to OpenRTB.
-      Ext ext = 99;
-
-      message Ext {
-        extensions 500 to max;
-      }
-
-      // Information on how often and what triggers an ad slot being refreshed.
-      message RefSettings {
-        // The type of the declared auto refresh.
-        int32 reftype = 1 [default = 0];
-
-        // The minimum refresh interval in seconds. This applies to all refresh
-        // types. This is the (uninterrupted) time the ad creative will be
-        // rendered before refreshing to the next creative. If the field is
-        // absent, the exposure time is unknown. This field does not account for
-        // viewability or external factors such as a user leaving a page.
-        int32 minint = 2;
-
-        // Placeholder for exchange-specific extensions to OpenRTB.
-        Ext ext = 99;
-
-        message Ext {
-          extensions 500 to max;
-        }
-      } // RefSettings
-    } // Refresh
-
-    // This object is the private marketplace container for direct deals between
-    // buyers and sellers that may pertain to this impression. The actual deals
-    // are represented as a collection of Deal objects. Refer to Section 7.3 for
-    // more details.
-    message Pmp {
-      // Indicator of auction eligibility to seats named in the Direct Deals
-      // object, where 0 = all bids are accepted, 1 = bids are restricted to the
-      // deals specified and the terms thereof.
-      bool private_auction = 1 [default = false];
-
-      // Array of Deal (Section 3.2.12) objects that convey the specific deals
-      // applicable to this impression.
-      repeated Deal deals = 2;
-
-      // Placeholder for exchange-specific extensions to OpenRTB.
-      Ext ext = 99;
-
-      message Ext {
-        extensions 500 to max;
-      }
-
-      // This object constitutes a specific deal that was struck between a buyer
-      // and a seller. Its presence with the Pmp collection indicates that this
-      // impression is available under the terms of that deal. Refer to Section
-      // 7.3 for more details.
-      message Deal {
-        // A unique identifier for the direct deal.
-        // REQUIRED by the OpenRTB specification.
-        string id = 1;
-
-        // Minimum bid for this impression expressed in CPM.
-        double bidfloor = 2 [default = 0];
-
-        // Currency specified using ISO-4217 alpha codes. This may be different
-        // from bid currency returned by bidder if this is allowed by the
-        // exchange. This field does not inherit from Imp.bidfloorcur; it is
-        // either explicitly specified or defaults to USD.
-        string bidfloorcur = 3 [default = "USD"];
-
-        // Optional override of the overall auction type of the bid request,
-        // where 1 = First Price, 2 = Second Price Plus, 3 = the value passed in
-        // bidfloor is the agreed upon deal price. Additional auction types can
-        // be defined by the exchange.
-        // Refer to enum com.iabtechlab.openrtb.v3.AuctionType for values.
-        int32 at = 6;
-
-        // Allowed list of buyer seats (e.g., advertisers, agencies) allowed to
-        // bid on this deal. IDs of seats and the buyer's customers to which
-        // they refer must be coordinated between bidders and the exchange a
-        // priori. Omission implies no seat restrictions.
-        repeated string wseat = 4;
-
-        // Array of advertiser domains (e.g., advertiser.com) allowed to bid on
-        // this deal. Omission implies no advertiser restrictions.
-        repeated string wadomain = 5;
-
-        // Indicates that the deal is of type "guaranteed" and the bidder must
-        // bid on the deal, where 0 = not a guaranteed deal, 1 = guaranteed
-        // deal.
-        int32 guar = 7 [default = 0];
-
-        // Minimum CPM per second. This is a price floor for video or audio
-        // impression opportunities, relative to the duration of bids an
-        // advertiser may submit.
-        double mincpmpersec = 8;
-
-        // Container for floor price by duration information, to be used if a
-        // given deal is eligible for video or audio demand. An array of
-        // DurFloors objects (see Section 3.2.35).
-        repeated DurFloors durfloors = 9;
-
-        // Placeholder for exchange-specific extensions to OpenRTB.
-        Ext ext = 99;
-
-        message Ext {
-          extensions 500 to max;
-        }
-      } // Deal
-    } // Pmp
-
-    // SKAdNetwork object list attributes.
-    message SKAdNetworkList {
-      // Implies a list of SKAdNetwork IDs up to and including this value.
-      int32 max = 1;
-
-      // List of registration IDs to be excluded from the IABTL shared list.
-      repeated int32 excl = 2;
-
-      // List of string SKAdNetwork IDs not included in the IABTL shared list.
-      // The intention of addl is to be the permanent home for raw SKAdNetwork
-      // IDs, migrating away from BidRequest.imp.ext.skadn.skadnetids.
-      // Recommended that this list not exceed 10.
-      repeated string addl = 3;
-
-      // Placeholder for exchange-specific extensions to OpenRTB.
-      Ext ext = 99;
-
-      message Ext {
-        extensions 500 to max;
-      }
-    } // SKAdNetworkList
-
-    // Publisher's SKAdNetwork information to support app installation
-    // attribution for iOS 14 and later. Apple's SKAdNetwork API helps
-    // advertisers measure ad-driven app installation by sending a postback to
-    // the ad network after a successful install. Publishers will need to
-    // configure supported ad networks in their app's property list (Info.plist)
-    // to allow an install to be attributed to the ad impression.  For more info
-    // visit: https://developer.apple.com/documentation/storekit/skadnetwork
-    message SKAdNetworkRequest {
-      // Array of strings containing the supported SKAdNetwork versions. Always
-      // "2.0" or higher. Dependent on both the OS version and the SDK version.
-      repeated string versions = 5;
-
-      // Version of SKAdNetwork supported. Dependent on both the OS version and
-      // the SDK version.
-      // Note: With the release of SKAdNetwork 2.1, this field is deprecated in
-      // favor of the BidRequest.imp.ext.skadn.versions to support an array of
-      // version numbers.
-      string version = 1 [deprecated = true];
-
-      // ID of publisher app in Apple's App Store. Should match app.bundle in
-      // OpenRTB 2.x and app.storeid in AdCOM 1.x.
-      string sourceapp = 2;
-
-      // A subset of SKAdNetworkItem entries in the publisher app's Info.plist
-      // that are relevant to the DSP. Recommended that this list not exceed 10.
-      // Note: BidRequest.imp.ext.skadn.skadnetlist.addl is the preferred method
-      // to express raw SKAdNetwork IDs.
-      repeated string skadnetids = 3;
-
-      // Object containing the IABTL list definition.
-      SKAdNetworkList skadnetlist = 4;
-
-      // Custom Product Page support.
-      bool productpage = 6;
-
-      // SKOverlay support. If set, SKOverlay is supported.
-      bool skoverlay = 7;
-
-      // Placeholder for exchange-specific extensions to OpenRTB.
-      Ext ext = 99;
-
-      message Ext {
-        extensions 500 to max;
-      }
-    } // SKAdNetworkRequest
-
-    message InterestGroupAuctionSupport {
-      // Interest Group auction environment support for this impression. Note
-      // that this only indicates that the Interest Group auction is supported,
-      // not that it is guaranteed to execute. If no buyer chooses to
-      // participate in the Interest Group auction, then the Interest Group
-      // auction will be skipped and the winner of the OpenRTB (aka contextual)
-      // auction, if any, will serve instead.
-      enum AuctionEnvironment {
-        IG_AUCTION_NOT_SUPPORTED = 0;
-        ON_DEVICE_ORCHESTRATED_IG_AUCTION = 1;
-        SERVER_ORCHESTRATED_IG_AUCTION = 3;
-      }
-      int32 ae = 1 [default = 1];
-
-      // Indicates whether the buyer is allowed to participate in the Interest
-      // Group auction. Depending on account settings and other factors, a
-      // bidder might be disallowed from participating in an auction or
-      // submitting Interest Group bids, even though an Interest Group auction
-      // may ultimately decide the winning ad. The seller sets this. Example:
-      // the publisher intends to enable Interest Group, but the seller has not
-      // onboarded this buyer for Interest Group auctions. Buyers should only
-      // expect sellers to honor corresponding Interest Group Intent signals
-      // when this field is 1.
-      bool biddable = 2 [default = false];
-    } // InterestGroupAuctionSupport
-  } // Imp
+  }  // Imp
+
+  // This object is associated with an impression as an array of metrics.
+  // These metrics can offer insight into the impression to assist with
+  // decisioning such as average recent viewability, click-through rate, etc.
+  // Each metric is identified by its type, reports the value of the metric,
+  // and optionally identifies the source or vendor measuring the value.
+  message Metric {
+    // Type of metric being presented using exchange curated string names
+    // which should be published to bidders a priori.
+    // REQUIRED by the OpenRTB specification.
+    string type = 1;
+
+    // Number representing the value of the metric. Probabilities must be in
+    // the range 0.0 - 1.0.
+    // REQUIRED by the OpenRTB specification.
+    double value = 2;
+
+    // Source of the value using exchange curated string names which should be
+    // published to bidders a priori. If the exchange itself is the source
+    // versus a third party, "EXCHANGE" is recommended.
+    // RECOMMENDED by the OpenRTB specification.
+    string vendor = 3;
+
+    // Placeholder for exchange-specific extensions to OpenRTB.
+    Ext ext = 99;
+
+    message Ext {
+      extensions 500 to max;
+    }
+  }  // Metric
+
+  // This object represents the most general type of impression. Although the
+  // term "banner" may have very specific meaning in other contexts, here it
+  // can be many things including a simple static image, an expandable ad
+  // unit, or even in-banner video (refer to the Video object in Section 3.2.7
+  // for the more generalized and full featured video ad units). An array of
+  // Banner objects can also appear within the Video to describe optional
+  // companion ads defined in the VAST specification.
+  //
+  // The presence of a Banner as a subordinate of the Imp object indicates
+  // that this impression is offered as a banner type impression. At the
+  // publisher's discretion, that same impression may also be offered as
+  // video, audio, and/or native by also including as Imp subordinates the
+  // objects of those types. However, any given bid for the impression must
+  // conform to one of the offered types.
+  message Banner {
+    // Array of format objects (Section 3.2.10) representing the banner sizes
+    // permitted. If none are specified, then use of the h and w attributes is
+    // highly recommended.
+    repeated Format format = 15;
+
+    // Width in device independent pixels (DIPS); recommended if no Format
+    // objects are specified.
+    int32 w = 1;
+
+    // Height in device independent pixels (DIPS); recommended if no Format
+    // objects are specified.
+    int32 h = 2;
+
+    // Blocked banner ad types.
+    // Refer to enum BannerAdType for values.
+    repeated int32 btype = 5;
+
+    // Blocked creative attributes.
+    // Refer to enum com.iabtechlab.adcom.v1.enums.Creative.Attribute for
+    // values.
+    repeated int32 battr = 6;
+
+    // Ad position on screen.
+    // Refer to enum com.iabtechlab.adcom.v1.PlacementPosition for values.
+    int32 pos = 4;
+
+    // Content MIME types supported. Popular MIME types may include,
+    // "image/jpeg" and "image/gif".
+    repeated string mimes = 7;
+
+    // Indicates if the banner is in the top frame as opposed to an iframe,
+    // where 0 = no, 1 = yes.
+    bool topframe = 8;
+
+    // Directions in which the banner may expand.
+    // Refer to enum com.iabtechlab.adcom.v1.enums.ExpandableDirection for
+    // values.
+    repeated int32 expdir = 9;
+
+    // List of supported API frameworks for this impression. If an API is not
+    // explicitly listed, it is assumed not to be supported.
+    // Refer to enum com.iabtechlab.adcom.v1.enums.APIFramework for values.
+    repeated int32 api = 10;
+
+    // Unique identifier for this banner object. Recommended when Banner
+    // objects are used with a Video object (Section 3.2.7) to represent an
+    // array of companion ads. Values usually start at 1 and increase with
+    // each object; should be unique within an impression.
+    string id = 3;
+
+    // Relevant only for Banner objects used with a Video object (Section
+    // 3.2.7) in an array of companion ads. Indicates the companion banner
+    // rendering mode relative to the associated video, where 0 = concurrent,
+    // 1 = end-card.
+    bool vcm = 16;
+
+    // NOTE: Deprecated in favor of the format array.
+    // Maximum width in device independent pixels (DIPS).
+    int32 wmax = 11 [deprecated = true];
+
+    // NOTE: Deprecated in favor of the format array.
+    // Maximum height in device independent pixels (DIPS).
+    int32 hmax = 12 [deprecated = true];
+
+    // NOTE: Deprecated in favor of the format array.
+    // Minimum width in device independent pixels (DIPS).
+    int32 wmin = 13 [deprecated = true];
+
+    // NOTE: Deprecated in favor of the format array.
+    // Minimum height in device independent pixels (DIPS).
+    int32 hmin = 14 [deprecated = true];
+
+    // Placeholder for exchange-specific extensions to OpenRTB.
+    Ext ext = 99;
+
+    message Ext {
+      extensions 500 to max;
+    }
+  }  // Banner
+
+  // This object represents an allowed size (i.e., height and width
+  // combination) or Flex Ad parameters for a banner impression. These are
+  // typically used in an array where multiple sizes are permitted. It is
+  // recommended that either the w/h pair or the wratio/hratio/wmin set
+  // (i.e., for Flex Ads) be specified.
+  message Format {
+    // Width in device independent pixels (DIPS).
+    int32 w = 1;
+
+    // Height in device independent pixels (DIPS).
+    int32 h = 2;
+
+    // Relative width when expressing size as a ratio.
+    int32 wratio = 3;
+
+    // Relative height when expressing size as a ratio.
+    int32 hratio = 4;
+
+    // The minimum width in device independent pixels (DIPS) at which the ad
+    // will be displayed when the size is expressed as a ratio.
+    int32 wmin = 5;
+
+    // Placeholder for exchange-specific extensions to OpenRTB.
+    Ext ext = 99;
+
+    message Ext {
+      extensions 500 to max;
+    }
+  }  // Format
+
+  // This object represents a video impression. Many of the fields are
+  // non-essential for minimally viable transactions, but are included to
+  // offer fine control when needed. Video in OpenRTB generally assumes
+  // compliance with the VAST standard. As such, the notion of companion ads
+  // is supported by optionally including an array of Banner objects (refer to
+  // the Banner object in Section 3.2.6) that define these companion ads.
+  //
+  // The presence of a Video as a subordinate of the Imp object indicates that
+  // this impression is offered as a video type impression. At the publisher's
+  // discretion, that same impression may also be offered as Banner, Audio,
+  // and/or Native by also including as Imp subordinates objects of those
+  // types. However, any given bid for the impression must conform to one of
+  // the offered types.
+  message Video {
+    // Content MIME types supported (e.g., "video/mp4").
+    // REQUIRED by the OpenRTB specification: at least 1 element.
+    repeated string mimes = 1;
+
+    // Minimum video ad duration in seconds. This field is mutually exclusive
+    // with rqddurs; only one of minduration and rqddurs may be in a bid
+    // request.
+    // RECOMMENDED by the OpenRTB specification.
+    int32 minduration = 3 [default = 0];
+
+    // Maximum video ad duration in seconds. This field is mutually exclusive
+    // with rqddurs; only one of maxduration and rqddurs may be in a bid
+    // request.
+    // RECOMMENDED by the OpenRTB specification.
+    int32 maxduration = 4;
+
+    // Indicates the start delay in seconds for pre-roll, mid-roll, or
+    // post-roll ad placements.
+    // Refer to enum com.iabtechlab.adcom.v1.StartDelayMode for values.
+    // RECOMMENDED by the OpenRTB specification.
+    int32 startdelay = 8;
+
+    // Indicates the maximum number of ads that may be served into a "dynamic"
+    // video ad pod (where the precise number of ads is not predetermined by
+    // the seller). See Section 7.6 for more details.
+    int32 maxseq = 28;
+
+    // Indicates the total amount of time in seconds that advertisers may fill
+    // for a "dynamic" video ad pod (See Section 7.6 for more details), or the
+    // dynamic portion of a "hybrid" ad pod. This field is required only for
+    // the dynamic portion(s) of video ad pods. This field refers to the
+    // length of the entire ad break, whereas minduration/maxduration/rqddurs
+    // are constraints relating to the slots that make up the pod.
+    int32 poddur = 29;
+
+    // Array of supported video bid response protocols.
+    // Refer to enum com.iabtechlab.adcom.v1.Creative.AudioVideoType for
+    // values.
+    repeated int32 protocols = 21;
+
+    // Width of the video player in device independent pixels (DIPS).
+    // RECOMMENDED by the OpenRTB specification.
+    int32 w = 6;
+
+    // Height of the video player in device independent pixels (DIPS).
+    // RECOMMENDED by the OpenRTB specification.
+    int32 h = 7;
+
+    // Unique identifier indicating that an impression opportunity belongs to
+    // a video ad pod. If multiple impression opportunities within a bid
+    // request share the same podid, this indicates that those impression
+    // opportunities belong to the same video ad pod.
+    string podid = 30;
+
+    // The sequence (position) of the video ad pod within a content stream.
+    // Refer to in AdCOM 1.0 for guidance on the use of this field.
+    int32 podseq = 31 [default = 0];
+
+    // Precise acceptable durations for video creatives in seconds. This field
+    // specifically targets the Live TV use case where non-exact ad durations
+    // would result in undesirable ‘dead air'. This field is mutually
+    // exclusive with minduration and maxduration; if rqddurs is specified,
+    // minduration and maxduration must not be specified and vice versa.
+    repeated int32 rqddurs = 32;
+
+    // Deprecated as of OpenRTB 2.6-202303. Use plcmt instead.
+    // Refer to enum com.iabtechlab.adcom.v1.VideoPlacementSubtype for values.
+    int32 placement = 26 [deprecated = true];
+
+    // Video placement type for the impression.
+    // Refer to enum com.iabtechlab.adcom.v1.VideoPlcmtSubtype for values.
+    int32 plcmt = 35;
+
+    // Indicates if the impression must be linear, nonlinear, etc. If none
+    // specified, assume all are allowed. Note that this field describes the
+    // expected VAST response and not whether a placement is in-stream,
+    // out-stream, etc. For that, see plcmt.
+    // Refer to enum com.iabtechlab.adcom.v1.enums.LinearityMode for values.
+    int32 linearity = 2;
+
+    // Indicates if the player will allow the video to be skipped, where 0 =
+    // no, 1 = yes. If a bidder sends markup/creative that is itself
+    // skippable, the Bid object should include the attr array with an element
+    // of 16 indicating skippable video. Refer to List: Creative Attributes in
+    // AdCOM 1.0.
+    bool skip = 23;
+
+    // Videos of total duration greater than this number of seconds can be
+    // skippable; only applicable if the ad is skippable.
+    int32 skipmin = 24;
+
+    // Number of seconds a video must play before skipping is enabled; only
+    // applicable if the ad is skippable.
+    int32 skipafter = 25;
+
+    // Deprecated as of OpenRTB 2.6. Use slotinpod.
+    // If multiple ad impressions are offered in the same bid request, the
+    // sequence number will allow for the coordinated delivery of multiple
+    // creatives.
+    int32 sequence = 9 [default = 0, deprecated = true];
+
+    // For video ad pods, this value indicates that the seller can guarantee
+    // delivery against the indicated slot position in the pod. Refer to List:
+    // Slot Position in Pod in AdCOM 1.0 guidance on the use of this field.
+    int32 slotinpod = 33 [default = 0];
+
+    // Minimum CPM per second. This is a price floor for the "dynamic" portion
+    // of a video ad pod, relative to the duration of bids an advertiser may
+    // submit.
+    double mincpmpersec = 34;
+
+    // Blocked creative attributes.
+    // Refer to enum com.iabtechlab.adcom.v1.enums.Creative.Attribute for
+    // values.
+    repeated int32 battr = 10;
+
+    // Maximum extended video ad duration, if extension is allowed. If blank
+    // or 0, extension is not allowed. If -1, extension is allowed, and there
+    // is no time limit imposed. If greater than 0, then the value represents
+    // the number of seconds of extended play supported beyond the maxduration
+    // value.
+    int32 maxextended = 11;
+
+    // Minimum bit rate in Kbps (kilobits per second).
+    int32 minbitrate = 12;
+
+    // Maximum bit rate in Kbps (kilobits per second).
+    int32 maxbitrate = 13;
+
+    // Indicates if letter-boxing of 4:3 content into a 16:9 window is
+    // allowed, where 0 = no, 1 = yes.
+    bool boxingallowed = 14 [default = true];
+
+    // Playback methods that may be in use. If none are specified, any method
+    // may be used. Only one method is typically used in practice. As a
+    // result, this array may be converted to an integer in a future version
+    // of the specification. It is strongly advised to use only the first
+    // element of this array in preparation for this change.
+    // Refer to enum com.iabtechlab.adcom.v1.PlaybackMethod for values.
+    repeated int32 playbackmethod = 15;
+
+    // The event that causes playback to end.
+    // Refer to enum com.iabtechlab.adcom.v1.PlaybackCessationMode for values.
+    int32 playbackend = 27;
+
+    // Supported delivery methods (e.g., streaming, progressive). If none
+    // specified, assume all are supported.
+    // Refer to enum com.iabtechlab.adcom.v1.enums.DeliveryMethod for values.
+    repeated int32 delivery = 16;
+
+    // Ad position on screen.
+    // Refer to enum com.iabtechlab.adcom.v1.PlacementPosition for values.
+    int32 pos = 17;
+
+    // Array of Banner objects (Section 3.2.6) if companion ads are available.
+    repeated Banner companionad = 18;
+
+    // List of supported API frameworks for this impression. If an API is not
+    // explicitly listed, it is assumed not to be supported.
+    // Refer to enum com.iabtechlab.adcom.v1.enums.APIFramework for values.
+    repeated int32 api = 19;
+
+    // Supported VAST companion ad types. Recommended if companion Banner
+    // objects are included via the companionad array. If one of these banners
+    // will be rendered as an end-card, this can be specified using the vcm
+    // attribute with the particular banner (Section 3.2.6).
+    // Refer to enum com.iabtechlab.adcom.v1.CompanionType for values.
+    repeated int32 companiontype = 20;
+
+    // Indicates pod deduplication settings that will be applied to bid
+    // responses.
+    // PROVISIONAL in the OpenRTB specification.
+    repeated int32 poddedupe = 37;
+
+    // An array of DurFloors objects (Section 3.2.35) indicating the floor
+    // prices for video creatives of various durations that the buyer may bid
+    // with.
+    repeated DurFloors durfloors = 36;
+
+    // Deprecated; use protocols.
+    // Refer to enum com.iabtechlab.adcom.v1.Creative.AudioVideoType for
+    // values.
+    int32 protocol = 5 [deprecated = true];
+
+    // Placeholder for exchange-specific extensions to OpenRTB.
+    Ext ext = 99;
+
+    message Ext {
+      extensions 500 to max;
+    }
+
+    // Retired fields.
+    reserved 22;
+  }  // Video
+
+  // This object represents an audio type impression. Many of the fields are
+  // non-essential for minimally viable transactions, but are included to
+  // offer fine control when needed. Audio in OpenRTB generally assumes
+  // compliance with the VAST standard. As such, the notion of companion ads
+  // is supported by optionally including an array of Banner objects (refer to
+  // the Banner object in Section 3.2.6) that define these companion ads.
+  //
+  // The presence of a Audio as a subordinate of the Imp object indicates that
+  // this impression is offered as an audio type impression. At the
+  // publisher's discretion, that same impression may also be offered as
+  // Banner, Video, and/or Native by also including as Imp subordinates
+  // objects of those types. However, any given bid for the impression must
+  // conform to one of the offered types.
+  message Audio {
+    // Content MIME types supported (e.g., "audio/mp4").
+    // REQUIRED by the OpenRTB specification: at least 1 element.
+    repeated string mimes = 1;
+
+    // Minimum audio ad duration in seconds. This field is mutually exclusive
+    // with rqddurs; only one of minduration and rqddurs may be in a bid
+    // request.
+    // RECOMMENDED by the OpenRTB specification.
+    int32 minduration = 2 [default = 0];
+
+    // Maximum audio ad duration in seconds. This field is mutually exclusive
+    // with rqddurs; only one of maxduration and rqddurs may be in a bid
+    // request.
+    // RECOMMENDED by the OpenRTB specification.
+    int32 maxduration = 3;
+
+    // Indicates the total amount of time that advertisers may fill for a
+    // "dynamic" audio ad pod, or the dynamic portion of a "hybrid" ad pod.
+    // This field is required only for the dynamic portion(s) of audio ad
+    // pods. This field refers to the length of the entire ad break, wheras
+    // minduration/maxduration/rqddurs are constraints relating to the slots
+    // that make up the pod.
+    int32 poddur = 25;
+
+    // Array of supported audio protocols.
+    // Refer to enum com.iabtechlab.adcom.v1.Creative.AudioVideoType for
+    // values.
+    // RECOMMENDED by the OpenRTB specification.
+    repeated int32 protocols = 4;
+
+    // Indicates the start delay in seconds for pre-roll, mid-roll, or
+    // post-roll ad placements.
+    // Refer to enum com.iabtechlab.adcom.v1.StartDelayMode for values.
+    // RECOMMENDED by the OpenRTB specification.
+    int32 startdelay = 5;
+
+    // Precise acceptable durations for audio creatives in seconds. This field
+    // specifically targets the live audio/radio use case where non-exact ad
+    // durations would result in undesirable 'dead air'. This field is
+    // mutually exclusive with minduraiton and maxduration; if rqddurs is
+    // specified, minduration and maxduration must not be specified and vice
+    // versa.
+    repeated int32 rqddurs = 26;
+
+    // Unique identifier indicating that an impression opportunity belongs to
+    // an audio ad pod. If multiple impression opportunities within a bid
+    // request share the same podid, this indicates that those impression
+    // opportunities belong to the same audio ad pod.
+    string podid = 27;
+
+    // The sequence (position) of the audio ad pod within a content stream.
+    int32 podseq = 28 [default = 0];
+
+    // Deprecated as of OpenRTB 2.6. Use slotinpod.
+    int32 sequence = 6 [default = 0, deprecated = true];
+
+    // For audio ad pods, this value indicates that the seller can guarantee
+    // delivery against the indicated slot position in the pod.
+    int32 slotinpod = 29 [default = 0];
+
+    // Minimum CPM per second. This is a price floor for the "dynamic" portion
+    // of an audio ad pod, relative to the duration of bids an advertiser may
+    // submit.
+    double mincpmpersec = 30;
+
+    // Blocked creative attributes.
+    // Refer to enum com.iabtechlab.adcom.v1.enums.Creative.Attribute for
+    // values.
+    repeated int32 battr = 7;
+
+    // Maximum extended video ad duration, if extension is allowed. If blank
+    // or 0, extension is not allowed. If -1, extension is allowed, and there
+    // is no time limit imposed. If greater than 0, then the value represents
+    // the number of seconds of extended play supported beyond the maxduration
+    // value.
+    int32 maxextended = 8;
+
+    // Minimum bit rate in Kbps (kilobits per second).
+    int32 minbitrate = 9;
+
+    // Maximum bit rate in Kbps (kilobits per second).
+    int32 maxbitrate = 10;
+
+    // Supported delivery methods (e.g., streaming, progressive). If none
+    // specified, assume all are supported.
+    // Refer to enum com.iabtechlab.adcom.v1.enums.DeliveryMethod for values.
+    repeated int32 delivery = 11;
+
+    // Array of Banner objects (Section 3.2.6) if companion ads are available.
+    repeated Banner companionad = 12;
+
+    // List of supported API frameworks for this impression. If an API is not
+    // explicitly listed, it is assumed not to be supported.
+    // Refer to enum com.iabtechlab.adcom.v1.enums.APIFramework for values.
+    repeated int32 api = 13;
+
+    // Supported companion ad types. Recommended if companion Banner objects
+    // are included via the companionad array.
+    // Refer to enum com.iabtechlab.adcom.v1.CompanionType for values.
+    repeated int32 companiontype = 20;
+
+    // The maximum number of ads that can be played in an ad pod.
+    int32 maxseq = 21;
+
+    // Type of audio feed.
+    // Refer to enum com.iabtechlab.adcom.v1.enums.FeedType for values.
+    int32 feed = 22;
+
+    // Indicates if the ad is stitched with audio content or delivered
+    // independently, where 0 = no, 1 = yes.
+    bool stitched = 23;
+
+    // Volume normalization mode.
+    // Refer to enum com.iabtechlab.adcom.v1.VolumeNormalizationMode for
+    // values.
+    int32 nvol = 24;
+
+    // An array of DurFloors objects (Section 3.2.35) indicating the floor
+    // prices for audio creatives of various durations that the buyer may bid
+    // with.
+    repeated DurFloors durfloors = 31;
+
+    // Placeholder for exchange-specific extensions to OpenRTB.
+    Ext ext = 99;
+
+    message Ext {
+      extensions 500 to max;
+    }
+  }  // Audio
+
+  // This object represents a native type impression. Native ad units are
+  // intended to blend seamlessly into the surrounding content (e.g., a
+  // sponsored Twitter or Facebook post). As such, the response must be
+  // well-structured to afford the publisher fine-grained control over
+  // rendering.
+  //
+  // The Native Subcommittee has developed a companion specification to
+  // OpenRTB called the Dynamic Native Ads API. It defines the request
+  // parameters and response markup structure of native ad units. This object
+  // provides the means of transporting request parameters as an opaque string
+  // so that the specific parameters can evolve separately under the auspices
+  // of the Dynamic Native Ads API. Similarly, the ad markup served will be
+  // structured according to that specification.
+  //
+  // The presence of a Native as a subordinate of the Imp object indicates
+  // that this impression is offered as a native type impression. At the
+  // publisher's discretion, that same impression may also be offered as
+  // Banner, Video, and/or Audio by also including as Imp subordinates objects
+  // of those types. However, any given bid for the impression must conform to
+  // one of the offered types.
+  message Native {
+    // Request payload complying with the Native Ad Specification. The root
+    // node of the payload, "native", was dropped in the Native Ads
+    // Specification 1.1. For Native 1.0, this is a JSON-encoded string
+    // consisting of a unnamed root object, with a single subordinate object
+    // named 'native', which is the Native Markup Request object, section 4.1
+    // of OpenRTB Native 1.0 specification. For Native 1.1 and higher, this is
+    // a JSON-encoded string consisting of an unnamed root object which is
+    // itself the Native Markup Request Object, section 4.1 of OpenRTB Native
+    // 1.1+.
+    oneof request_oneof {
+      // This is the OpenRTB-compliant field for JSON serialization.
+      string request = 1;
+
+      // This is an alternate field preferred for Protobuf serialization.
+      NativeRequest request_native = 50;
+    }
+
+    // Version of the Native Ad Specification to which request complies;
+    // highly recommended for efficient parsing.
+    // RECOMMENDED by the OpenRTB specification.
+    string ver = 2;
+
+    // List of supported API frameworks for this impression. If an API is not
+    // explicitly listed, it is assumed not to be supported.
+    // Refer to enum com.iabtechlab.adcom.v1.enums.APIFramework for values.
+    repeated int32 api = 3;
+
+    // Blocked creative attributes.
+    // Refer to enum com.iabtechlab.adcom.v1.enums.Creative.Attribute for
+    // values.
+    repeated int32 battr = 4;
+
+    // Placeholder for exchange-specific extensions to OpenRTB.
+    Ext ext = 99;
+
+    message Ext {
+      extensions 500 to max;
+    }
+  }  // Native
+
+  // A programmatic impression is often referred to as a ‘spot' in digital
+  // out-of-home and CTV, with an impression being a unique member of the
+  // audience viewing it. Therefore, a standard means of passing a multiplier
+  // in the bid request, representing the total quantity of impressions, is
+  // required. This object includes the impression multiplier, and describes
+  // the source of the multiplier value.
+  message Qty {
+    // The quantity of billable events which will be deemed to have occurred
+    // if this item is purchased. For example, a DOOH opportunity may be
+    // considered to be 14.2 impressions. Equivalent to qtyflt in OpenRTB
+    // 3.0.
+    double multiplier = 1;
+
+    // The source type of the quantity measurement, ie. publisher.
+    // Refer to enum
+    // com.iabtechlab.adcom.v1.enums.DOOHMultiplierMeasurementSourceType for
+    // values. RECOMMENDED by the OpenRTB specification.
+    int32 sourcetype = 2;
+
+    // The top level business domain name of the measurement vendor providing
+    // the quantity measurement.
+    // REQUIRED by the OpenRTB specification if sourcetype is equal to 1.
+    string vendor = 3;
+
+    // Placeholder for exchange-specific extensions to OpenRTB.
+    Ext ext = 99;
+
+    message Ext {
+      extensions 500 to max;
+    }
+  }  // Qty
+
+  message Refresh {
+    // A RefSettings object (see Section 3.2.34) describing the mechanics of
+    // how an ad placement automatically refreshes.
+    repeated RefSettings refsettings = 1;
+
+    // The number of times this ad slot had been refreshed since last page
+    // load.
+    int32 count = 2;
+
+    // Placeholder for exchange-specific extensions to OpenRTB.
+    Ext ext = 99;
+
+    message Ext {
+      extensions 500 to max;
+    }
+  }  // Refresh
+
+  // Information on how often and what triggers an ad slot being refreshed.
+  message RefSettings {
+    // The type of the declared auto refresh.
+    int32 reftype = 1 [default = 0];
+
+    // The minimum refresh interval in seconds. This applies to all refresh
+    // types. This is the (uninterrupted) time the ad creative will be
+    // rendered before refreshing to the next creative. If the field is
+    // absent, the exposure time is unknown. This field does not account for
+    // viewability or external factors such as a user leaving a page.
+    int32 minint = 2;
+
+    // Placeholder for exchange-specific extensions to OpenRTB.
+    Ext ext = 99;
+
+    message Ext {
+      extensions 500 to max;
+    }
+  }  // RefSettings
+
+  // This object is the private marketplace container for direct deals between
+  // buyers and sellers that may pertain to this impression. The actual deals
+  // are represented as a collection of Deal objects. Refer to Section 7.3 for
+  // more details.
+  message Pmp {
+    // Indicator of auction eligibility to seats named in the Direct Deals
+    // object, where 0 = all bids are accepted, 1 = bids are restricted to the
+    // deals specified and the terms thereof.
+    bool private_auction = 1 [default = false];
+
+    // Array of Deal (Section 3.2.12) objects that convey the specific deals
+    // applicable to this impression.
+    repeated Deal deals = 2;
+
+    // Placeholder for exchange-specific extensions to OpenRTB.
+    Ext ext = 99;
+
+    message Ext {
+      extensions 500 to max;
+    }
+  }  // Pmp
+
+  // This object constitutes a specific deal that was struck between a buyer
+  // and a seller. Its presence with the Pmp collection indicates that this
+  // impression is available under the terms of that deal. Refer to Section
+  // 7.3 for more details.
+  message Deal {
+    // A unique identifier for the direct deal.
+    // REQUIRED by the OpenRTB specification.
+    string id = 1;
+
+    // Minimum bid for this impression expressed in CPM.
+    double bidfloor = 2 [default = 0];
+
+    // Currency specified using ISO-4217 alpha codes. This may be different
+    // from bid currency returned by bidder if this is allowed by the
+    // exchange. This field does not inherit from Imp.bidfloorcur; it is
+    // either explicitly specified or defaults to USD.
+    string bidfloorcur = 3 [default = "USD"];
+
+    // Optional override of the overall auction type of the bid request,
+    // where 1 = First Price, 2 = Second Price Plus, 3 = the value passed in
+    // bidfloor is the agreed upon deal price. Additional auction types can
+    // be defined by the exchange.
+    // Refer to enum com.iabtechlab.openrtb.v3.AuctionType for values.
+    int32 at = 6;
+
+    // Allowed list of buyer seats (e.g., advertisers, agencies) allowed to
+    // bid on this deal. IDs of seats and the buyer's customers to which
+    // they refer must be coordinated between bidders and the exchange a
+    // priori. Omission implies no seat restrictions.
+    repeated string wseat = 4;
+
+    // Array of advertiser domains (e.g., advertiser.com) allowed to bid on
+    // this deal. Omission implies no advertiser restrictions.
+    repeated string wadomain = 5;
+
+    // Indicates that the deal is of type "guaranteed" and the bidder must
+    // bid on the deal, where 0 = not a guaranteed deal, 1 = guaranteed
+    // deal.
+    int32 guar = 7 [default = 0];
+
+    // Minimum CPM per second. This is a price floor for video or audio
+    // impression opportunities, relative to the duration of bids an
+    // advertiser may submit.
+    double mincpmpersec = 8;
+
+    // Container for floor price by duration information, to be used if a
+    // given deal is eligible for video or audio demand. An array of
+    // DurFloors objects (see Section 3.2.35).
+    repeated DurFloors durfloors = 9;
+
+    // Placeholder for exchange-specific extensions to OpenRTB.
+    Ext ext = 99;
+
+    message Ext {
+      extensions 500 to max;
+    }
+  }  // Deal
+
+  // SKAdNetwork object list attributes.
+  message SKAdNetworkList {
+    // Implies a list of SKAdNetwork IDs up to and including this value.
+    int32 max = 1;
+
+    // List of registration IDs to be excluded from the IABTL shared list.
+    repeated int32 excl = 2;
+
+    // List of string SKAdNetwork IDs not included in the IABTL shared list.
+    // The intention of addl is to be the permanent home for raw SKAdNetwork
+    // IDs, migrating away from BidRequest.imp.ext.skadn.skadnetids.
+    // Recommended that this list not exceed 10.
+    repeated string addl = 3;
+
+    // Placeholder for exchange-specific extensions to OpenRTB.
+    Ext ext = 99;
+
+    message Ext {
+      extensions 500 to max;
+    }
+  }  // SKAdNetworkList
+
+  // Publisher's SKAdNetwork information to support app installation
+  // attribution for iOS 14 and later. Apple's SKAdNetwork API helps
+  // advertisers measure ad-driven app installation by sending a postback to
+  // the ad network after a successful install. Publishers will need to
+  // configure supported ad networks in their app's property list (Info.plist)
+  // to allow an install to be attributed to the ad impression.  For more info
+  // visit: https://developer.apple.com/documentation/storekit/skadnetwork
+  message SKAdNetworkRequest {
+    // Array of strings containing the supported SKAdNetwork versions. Always
+    // "2.0" or higher. Dependent on both the OS version and the SDK version.
+    repeated string versions = 5;
+
+    // Version of SKAdNetwork supported. Dependent on both the OS version and
+    // the SDK version.
+    // Note: With the release of SKAdNetwork 2.1, this field is deprecated in
+    // favor of the BidRequest.imp.ext.skadn.versions to support an array of
+    // version numbers.
+    string version = 1 [deprecated = true];
+
+    // ID of publisher app in Apple's App Store. Should match app.bundle in
+    // OpenRTB 2.x and app.storeid in AdCOM 1.x.
+    string sourceapp = 2;
+
+    // A subset of SKAdNetworkItem entries in the publisher app's Info.plist
+    // that are relevant to the DSP. Recommended that this list not exceed 10.
+    // Note: BidRequest.imp.ext.skadn.skadnetlist.addl is the preferred method
+    // to express raw SKAdNetwork IDs.
+    repeated string skadnetids = 3;
+
+    // Object containing the IABTL list definition.
+    SKAdNetworkList skadnetlist = 4;
+
+    // Custom Product Page support.
+    bool productpage = 6;
+
+    // SKOverlay support. If set, SKOverlay is supported.
+    bool skoverlay = 7;
+
+    // Placeholder for exchange-specific extensions to OpenRTB.
+    Ext ext = 99;
+
+    message Ext {
+      extensions 500 to max;
+    }
+  }  // SKAdNetworkRequest
+
+  message InterestGroupAuctionSupport {
+    // Interest Group auction environment support for this impression. Note
+    // that this only indicates that the Interest Group auction is supported,
+    // not that it is guaranteed to execute. If no buyer chooses to
+    // participate in the Interest Group auction, then the Interest Group
+    // auction will be skipped and the winner of the OpenRTB (aka contextual)
+    // auction, if any, will serve instead.
+    enum AuctionEnvironment {
+      IG_AUCTION_NOT_SUPPORTED = 0;
+      ON_DEVICE_ORCHESTRATED_IG_AUCTION = 1;
+      SERVER_ORCHESTRATED_IG_AUCTION = 3;
+    }
+    int32 ae = 1 [default = 1];
+
+    // Indicates whether the buyer is allowed to participate in the Interest
+    // Group auction. Depending on account settings and other factors, a
+    // bidder might be disallowed from participating in an auction or
+    // submitting Interest Group bids, even though an Interest Group auction
+    // may ultimately decide the winning ad. The seller sets this. Example:
+    // the publisher intends to enable Interest Group, but the seller has not
+    // onboarded this buyer for Interest Group auctions. Buyers should only
+    // expect sellers to honor corresponding Interest Group Intent signals
+    // when this field is 1.
+    bool biddable = 2 [default = false];
+  }  // InterestGroupAuctionSupport
 
   // This object should be included if the ad supported content is a website as
   // opposed to a non-browser application or Digital Out of Home (DOOH)
@@ -1350,7 +1349,7 @@ message BidRequest {
 
     // Retired fields.
     reserved 14;
-  } // Site
+  }  // Site
 
   // This object should be included if the ad supported content is a non-browser
   // application (typically in mobile) as opposed to a website. A bid request
@@ -1440,7 +1439,7 @@ message BidRequest {
 
     // Retired fields.
     reserved 14;
-  } // App
+  }  // App
 
   // This object should be included if the ad supported content is a Digital
   // Out-Of-Home screen. A bid request with a DOOH object must not contain a
@@ -1482,7 +1481,7 @@ message BidRequest {
     message Ext {
       extensions 500 to max;
     }
-  } // Dooh
+  }  // Dooh
 
   // This object describes the entity who directly supplies inventory to and is
   // paid by the exchange. This may be a publisher, intermediary exchange, ad
@@ -1514,7 +1513,7 @@ message BidRequest {
     message Ext {
       extensions 500 to max;
     }
-  } // Publisher
+  }  // Publisher
 
   // This object describes the content in which the impression will appear,
   // which may be syndicated or non-syndicated content. This object may be
@@ -1662,7 +1661,7 @@ message BidRequest {
 
     // Retired fields.
     reserved 12, 26;
-  } // Content
+  }  // Content
 
   // This object defines the producer of the content in which the ad will be
   // shown. This is particularly useful when the content is syndicated and may
@@ -1694,7 +1693,7 @@ message BidRequest {
     message Ext {
       extensions 500 to max;
     }
-  } // Producer
+  }  // Producer
 
   // This object describes the network an ad will be displayed on. A Network is
   // defined as the parent entity of the Channel object's entity for the
@@ -1723,7 +1722,7 @@ message BidRequest {
     message Ext {
       extensions 500 to max;
     }
-  } // Network
+  }  // Network
 
   // This object describes the channel an ad will be displayed on. A Channel is
   // defined as the entity that curates a content library, or stream within a
@@ -1751,7 +1750,7 @@ message BidRequest {
     message Ext {
       extensions 500 to max;
     }
-  } // Channel
+  }  // Channel
 
   // This object provides information pertaining to the device through which the
   // user is interacting. Device information includes its hardware, platform,
@@ -1919,7 +1918,7 @@ message BidRequest {
 
       extensions 500 to max;
     }
-  } // Device
+  }  // Device
 
   // This object encapsulates various methods for specifying a geographic
   // location. When subordinate to a Device object, it indicates the location of
@@ -1989,7 +1988,7 @@ message BidRequest {
     message Ext {
       extensions 500 to max;
     }
-  } // Geo
+  }  // Geo
 
   // Structured user agent information, which can be used when a client supports
   // User-Agent Client Hints. If both device.ua and device.sua are present in
@@ -2053,7 +2052,7 @@ message BidRequest {
     message Ext {
       extensions 500 to max;
     }
-  } // UserAgent
+  }  // UserAgent
 
   // Further identification based on User-Agent Client Hints, the BrandVersion
   // object is used to identify a device's browser or similar software
@@ -2075,7 +2074,7 @@ message BidRequest {
     message Ext {
       extensions 500 to max;
     }
-  } // BrandVersion
+  }  // BrandVersion
 
   // This object contains information known or derived about the human user of
   // the device (i.e., the audience for advertising). The user id is an exchange
@@ -2146,43 +2145,64 @@ message BidRequest {
 
       extensions 500 to max;
     }
+  }  // User
 
-    // Extended identifiers support in the OpenRTB specification allows buyers
-    // to use audience data in real-time bidding. This object can contain one or
-    // more UIDs from a single source or a technology provider. The exchange
-    // should ensure that business agreements allow for the sending of this
-    // data.
-    message EID {
-      // The canonical domain name of the entity (publisher, publisher
-      // monetization company, SSP, Exchange, Header Wrapper, etc.) that caused
-      // the ID array element to be added. This may be the operational domain of
-      // the system, if that is different from the parent corporate domain, to
-      // facilitate WHOIS and reverse IP lookups to establish clear ownership of
-      // the delegate system.
-      //
-      // This should be the same value as used to identify sellers in an ads.txt
-      // file if one exists.
-      //
-      // For ad tech intermediaries, this would be the domain as used in
-      // ads.txt. For publishers, this would match the domain in the site or app
-      // object.
-      string inserter = 3;
+  // Extended identifiers support in the OpenRTB specification allows buyers
+  // to use audience data in real-time bidding. This object can contain one or
+  // more UIDs from a single source or a technology provider. The exchange
+  // should ensure that business agreements allow for the sending of this
+  // data.
+  message EID {
+    // The canonical domain name of the entity (publisher, publisher
+    // monetization company, SSP, Exchange, Header Wrapper, etc.) that caused
+    // the ID array element to be added. This may be the operational domain of
+    // the system, if that is different from the parent corporate domain, to
+    // facilitate WHOIS and reverse IP lookups to establish clear ownership of
+    // the delegate system.
+    //
+    // This should be the same value as used to identify sellers in an ads.txt
+    // file if one exists.
+    //
+    // For ad tech intermediaries, this would be the domain as used in
+    // ads.txt. For publishers, this would match the domain in the site or app
+    // object.
+    string inserter = 3;
 
-      // Canonical domain of the ID.
-      string source = 1;
+    // Canonical domain of the ID.
+    string source = 1;
 
-      // Technology providing the match method as defined in mm. In some cases,
-      // this may be the same value as inserter. When blank, it is assumed that
-      // the matcher is equal to the source. May be omitted when mm=0, 1, or 2.
-      string matcher = 4;
+    // Technology providing the match method as defined in mm. In some cases,
+    // this may be the same value as inserter. When blank, it is assumed that
+    // the matcher is equal to the source. May be omitted when mm=0, 1, or 2.
+    string matcher = 4;
 
-      // Match method used by the matcher.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.MatchMethod for values.
-      int32 mm = 5;
+    // Match method used by the matcher.
+    // Refer to enum com.iabtechlab.adcom.v1.enums.MatchMethod for values.
+    int32 mm = 5;
 
-      // Array of extended ID UID objects from the given source. Refer to the
-      // Extended Identifier UIDs object (Section 3.2.28)
-      repeated UID uids = 2;
+    // Array of extended ID UID objects from the given source. Refer to the
+    // Extended Identifier UIDs object (Section 3.2.28)
+    repeated UID uids = 2;
+
+    // Placeholder for exchange-specific extensions to OpenRTB.
+    Ext ext = 99;
+
+    message Ext {
+      extensions 500 to max;
+    }
+
+    // This object contains a single user identifier provided as part of
+    // extended identifiers. The exchange should ensure that business
+    // agreements allow for the sending of this data.
+    message UID {
+      // The identifier for the user.
+      string id = 1;
+
+      // Type of user agent the match is from. It is highly recommended to set
+      // this, as many DSPs separate app-native IDs from browser-based IDs and
+      // require a type value for ID resolution.
+      // Refer to enum com.iabtechlab.adcom.v1.enums.AgentType for values.
+      int32 atype = 2;
 
       // Placeholder for exchange-specific extensions to OpenRTB.
       Ext ext = 99;
@@ -2190,29 +2210,8 @@ message BidRequest {
       message Ext {
         extensions 500 to max;
       }
-
-      // This object contains a single user identifier provided as part of
-      // extended identifiers. The exchange should ensure that business
-      // agreements allow for the sending of this data.
-      message UID {
-        // The identifier for the user.
-        string id = 1;
-
-        // Type of user agent the match is from. It is highly recommended to set
-        // this, as many DSPs separate app-native IDs from browser-based IDs and
-        // require a type value for ID resolution.
-        // Refer to enum com.iabtechlab.adcom.v1.enums.AgentType for values.
-        int32 atype = 2;
-
-        // Placeholder for exchange-specific extensions to OpenRTB.
-        Ext ext = 99;
-
-        message Ext {
-          extensions 500 to max;
-        }
-      } // UID
-    } // EID
-  } // User
+    }  // UID
+  }  // EID
 
   // The data and segment objects together allow additional data about the
   // related object (e.g., user, content) to be specified. This data may be from
@@ -2243,29 +2242,29 @@ message BidRequest {
 
       extensions 500 to max;
     }
+  }  // Data
 
-    // Segment objects are essentially key-value pairs that convey specific
-    // units of data. The parent Data object is a collection of such values from
-    // a given data provider. The specific segment names and value options must
-    // be published by the exchange a priori to its bidders.
-    message Segment {
-      // ID of the data segment specific to the data provider.
-      string id = 1;
+  // Segment objects are essentially key-value pairs that convey specific
+  // units of data. The parent Data object is a collection of such values from
+  // a given data provider. The specific segment names and value options must
+  // be published by the exchange a priori to its bidders.
+  message Segment {
+    // ID of the data segment specific to the data provider.
+    string id = 1;
 
-      // Name of the data segment specific to the data provider.
-      string name = 2;
+    // Name of the data segment specific to the data provider.
+    string name = 2;
 
-      // String representation of the data segment value.
-      string value = 3;
+    // String representation of the data segment value.
+    string value = 3;
 
-      // Placeholder for exchange-specific extensions to OpenRTB.
-      Ext ext = 99;
+    // Placeholder for exchange-specific extensions to OpenRTB.
+    Ext ext = 99;
 
-      message Ext {
-        extensions 500 to max;
-      }
-    } // Segment
-  } // Data
+    message Ext {
+      extensions 500 to max;
+    }
+  }  // Segment
 
   // This object contains any legal, governmental, or industry regulations that
   // the sender deems applicable to the request. See Section 7.5 for more
@@ -2328,35 +2327,35 @@ message BidRequest {
 
       extensions 500 to max;
     }
+  }  // Regs
 
-    message DsaRequest {
-      // Flag to indicate if DSA information should be made available. This will
-      // signal if the bid request belongs to an Online Platform/VLOP, such that
-      // a buyer should respond with DSA Transparency information based on the
-      // pubrender value. 0 = Not required, 1 = Supported, bid responses with or
-      // without DSA object will be accepted, 2 = Required, bid responses
-      // without DSA object will not be accepted, 3 = Required, bid responses
-      // without DSA object will not be accepted, Publisher is an Online
-      // Platform.
-      int32 dsarequired = 1;
+  message DsaRequest {
+    // Flag to indicate if DSA information should be made available. This will
+    // signal if the bid request belongs to an Online Platform/VLOP, such that
+    // a buyer should respond with DSA Transparency information based on the
+    // pubrender value. 0 = Not required, 1 = Supported, bid responses with or
+    // without DSA object will be accepted, 2 = Required, bid responses
+    // without DSA object will not be accepted, 3 = Required, bid responses
+    // without DSA object will not be accepted, Publisher is an Online
+    // Platform.
+    int32 dsarequired = 1;
 
-      // Flag to indicate if the publisher will render the DSA Transparency
-      // info.  This will signal if the publisher is able to and intends to
-      // render the icon and display the DSA transparency info to the end user.
-      // 0 = Publisher can't render, 1 = Publisher could render depending on
-      // adrender, 2 = Publisher will render.
-      int32 pubrender = 2;
+    // Flag to indicate if the publisher will render the DSA Transparency
+    // info.  This will signal if the publisher is able to and intends to
+    // render the icon and display the DSA transparency info to the end user.
+    // 0 = Publisher can't render, 1 = Publisher could render depending on
+    // adrender, 2 = Publisher will render.
+    int32 pubrender = 2;
 
-      // Independent of pubrender, the publisher may need the transparency data
-      // for audit purposes. 0 = do not send transparency data, 1 = optional to
-      // send transparency data, 2 = send transparency data.
-      int32 datatopub = 3;
+    // Independent of pubrender, the publisher may need the transparency data
+    // for audit purposes. 0 = do not send transparency data, 1 = optional to
+    // send transparency data, 2 = send transparency data.
+    int32 datatopub = 3;
 
-      // Array of objects of the entities that applied user parameters and the
-      // parameters they applied.
-      repeated Transparency transparency = 4;
-    } // DsaRequest
-  } // Regs
+    // Array of objects of the entities that applied user parameters and the
+    // parameters they applied.
+    repeated Transparency transparency = 4;
+  }  // DsaRequest
 
   // This object allows sellers to specify price floors for video and audio
   // creatives, whose price varies based on time. For example: 1-15 seconds at a
@@ -2388,7 +2387,7 @@ message BidRequest {
     message Ext {
       extensions 500 to max;
     }
-  } // DurFloors
+  }  // DurFloors
 }
 
 // This object is the top-level bid response object (i.e., the unnamed outer
@@ -2467,332 +2466,332 @@ message BidResponse {
     message Ext {
       extensions 500 to max;
     }
-
-    // A SeatBid object contains one or more Bid objects, each of which relates
-    // to a specific impression in the bid request via the impid attribute and
-    // constitutes an offer to buy that impression for a given price.
-    message Bid {
-      // Bidder generated bid ID to assist with logging/tracking.
-      // REQUIRED by the OpenRTB specification.
-      string id = 1;
-
-      // ID of the Imp object in the related bid request.
-      // REQUIRED by the OpenRTB specification.
-      string impid = 2;
-
-      // Bid price expressed as CPM although the actual transaction is for a
-      // unit impression only. Note that while the type indicates float,
-      // integer math is highly recommended when handling currencies (e.g.,
-      // BigDecimal in Java).
-      // REQUIRED by the OpenRTB specification.
-      double price = 3;
-
-      // Win notice URL called by the exchange if the bid wins (not necessarily
-      // indicative of a delivered, viewed, or billable ad); optional means of
-      // serving ad markup. Substitution macros (Section 4.4) may be included in
-      // both the URL and optionally returned markup.
-      string nurl = 5;
-
-      // Billing notice URL called by the exchange when a winning bid becomes
-      // billable based on exchange-specific business policy (e.g., typically
-      // delivered, viewed, etc.). Substitution macros (Section 4.4) may be
-      // included.
-      string burl = 22;
-
-      // Loss notice URL called by the exchange when a bid is known to have been
-      // lost. Substitution macros (Section 4.4) may be included.
-      // Exchange-specific policy may preclude support for loss notices or the
-      // disclosure of winning clearing prices resulting in ${AUCTION_PRICE}
-      // macros being removed (i.e., replaced with a zero-length string).
-      string lurl = 23;
-
-      // Optional means of conveying ad markup in case the bid wins; supersedes
-      // the win notice if markup is included in both. Substitution macros
-      // (Section 4.4) may be included. For native ad bids, exactly one of {adm,
-      // adm_native} should be used.
-      oneof adm_oneof {
-        // This is the OpenRTB-compliant field for JSON serialization.
-        string adm = 6;
-
-        // This is the field used for Protobuf serialization.
-        NativeResponse adm_native = 50;
-      }
-
-      // ID of a preloaded ad to be served if the bid wins.
-      string adid = 4;
-
-      // Advertiser domain for block list checking (e.g., "ford.com"). This can
-      // be an array of for the case of rotating creatives. Exchanges can
-      // mandate that only one domain is allowed.
-      repeated string adomain = 7;
-
-      // The store ID of the app in an app store (e.g., Apple App Store, Google
-      // Play). See OTT/CTV Store Assigned App Identification Guidelines for
-      // more details about expected strings for CTV app stores. For mobile apps
-      // in Google Play Store, these should be bundle or package names (e.g.
-      // com.foo.mygame). For apps in Apple App Store, these should be a numeric
-      // ID.
-      string bundle = 14;
-
-      // URL without cache-busting to an image that is representative of the
-      // content of the campaign for ad quality/safety checking.
-      string iurl = 8;
-
-      // Campaign ID to assist with ad quality checking; the collection of
-      // creatives for which iurl should be representative.
-      string cid = 9;
-
-      // Creative ID to assist with ad quality checking.
-      string crid = 10;
-
-      // Tactic ID to enable buyers to label bids for reporting to the exchange
-      // the tactic through which their bid was submitted. The specific usage
-      // and meaning of the tactic ID should be communicated between buyer and
-      // exchanges a priori.
-      string tactic = 24;
-
-      // The taxonomy in use.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.CategoryTaxonomy for
-      // values.
-      int32 cattax = 30 [default = 1];
-
-      // IAB Tech Lab content categories of the creative. The taxonomy to be
-      // used is defined by the cattax field. If no cattax field is supplied
-      // Content Taxonomy 1.0 is assumed.
-      repeated string cat = 15;
-
-      // Set of attributes describing the creative.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.Creative.Attribute for
-      // values.
-      repeated int32 attr = 11;
-
-      // List of supported APIs for the markup. If an API is not explicitly
-      // listed, it is assumed to be unsupported.
-      // Refer to enum com.iabtechlab.adcom.v1.enums.APIFramework for values.
-      repeated int32 apis = 31;
-
-      // NOTE: Deprecated in favor of apis.
-      int32 api = 18 [deprecated = true];
-
-      // Video response protocol of the markup if applicable.
-      // Refer to enum com.iabtechlab.adcom.v1.Creative.AudioVideoType for
-      // values.
-      int32 protocol = 19;
-
-      // Creative media rating per IQG guidelines.
-      // Refer to enum com.iabtechlab.adcom.v1.MediaRating for values.
-      int32 qagmediarating = 20;
-
-      // Language of the creative using ISO-639-1-alpha-2. The nonstandard code
-      // "xx" may also be used if the creative has no linguistic content (e.g.,
-      // a banner with just a company logo). Only one of language or langb
-      // should be present.
-      string language = 25;
-
-      // Language of the creative using IETF BCP 47. Only one of language or
-      // langb should be present.
-      string langb = 29;
-
-      // Reference to the deal.id from the bid request if this bid pertains to a
-      // private marketplace direct deal.
-      string dealid = 13;
-
-      // Width of the creative in device independent pixels (DIPS).
-      int32 w = 16;
-
-      // Height of the creative in device independent pixels (DIPS).
-      int32 h = 17;
-
-      // Relative width of the creative when expressing size as a ratio.
-      // Required for Flex Ads.
-      int32 wratio = 26;
-
-      // Relative height of the creative when expressing size as a ratio.
-      // Required for Flex Ads.
-      int32 hratio = 27;
-
-      // Advisory as to the number of seconds the bidder is willing to wait
-      // between the auction and the actual impression.
-      int32 exp = 21;
-
-      // Duration of the video or audio creative in seconds.
-      int32 dur = 32;
-
-      // Type of the creative markup so that it can properly be associated with
-      // the right sub-object of the BidRequest.Imp.
-      int32 mtype = 33;
-
-      // Indicates that the bid response is only eligible for a specific
-      // position within a video or audio ad pod (e.g. first position, last
-      // position, or any).
-      // Refer to enum com.iabtechlab.adcom.v1.enums.SlotPositionInPod for
-      // values.
-      int32 slotinpod = 28 [default = 0];
-
-      // Placeholder for exchange-specific extensions to OpenRTB.
-      Ext ext = 99;
-
-      message Ext {
-        // Advertiser's SKAdNetwork information.
-        SKAdNetworkResponse skadn = 1;
-
-        // Extension for DSA transparency information.
-        DsaResponse dsa = 2;
-
-        // Unique key enabling to identify and track a campaign during its
-        // lifecycle regardless of the SSP and DSP used. Note : scid contains
-        // the AdvertiserID (Global location number) + Advertiser brand +
-        // Advertiser product code + Customer Product Estimate + Ext (optional)
-        string scid = 3;
-
-        extensions 500 to max;
-      }
-
-      message DsaResponse {
-        // Advertiser Transparency: Free UNICODE text string with a name of
-        // whose behalf the ad is displayed. Maximum 100 characters.
-        string behalf = 1;
-
-        // Advertiser Transparency: Free UNICODE text string of who paid for the
-        // ad.  Must always be included even if it's the same as what is listed
-        // in the behalf attribute. Maximum 100 characters.
-        string paid = 2;
-
-        // Array of objects of the entities that applied user parameters and the
-        // parameters they applied.
-        repeated Transparency transparency = 3;
-
-        // Flag to indicate that buyer/advertiser will render their own DSA
-        // transparency information inside the creative. 0 = buyer/advertiser
-        // will not render, 1 = buyer/advertiser will render.
-        bool adrender = 4;
-      } // DsaResponse
-
-      // SKAdNetwork fidelity attributes.
-      message SKAdNetworkFidelity {
-        // The fidelity-type of the attribution to track.
-        enum Fidelity {
-          VIEW_THROUGH = 0;
-          STOREKIT_RENDERED = 1;
-        }
-        int32 fidelity = 1;
-
-        // An id unique to each ad response. Refer to Apple's documentation for
-        // the proper UUID format requirements:
-        // https://developer.apple.com/documentation/storekit/skstoreproductparameteradnetworknonce
-        string nonce = 2;
-
-        // Unix time in millis string used at the time of signature.
-        string timestamp = 3;
-
-        // SKAdNetwork signature as specified by Apple.
-        string signature = 4;
-
-        // Placeholder for exchange-specific extensions to OpenRTB.
-        Ext ext = 99;
-
-        message Ext {
-          extensions 500 to max;
-        }
-      } // SKAdNetworkFidelity
-
-      // Advertiser's SKAdNetwork information to support app installation
-      // attribution for iOS 14 and later.  Apple's SKAdNetwork API helps
-      // advertisers measure ad-driven app installation by sending a postback to
-      // the ad network after a successful install. Ad networks will need to
-      // send their network ID and signed advertiser information to allow an
-      // install to be attributed to the ad impression.  For more info visit:
-      // https://developer.apple.com/documentation/storekit/skadnetwork
-      message SKAdNetworkResponse {
-        // Version of SKAdNetwork desired. Must be 2.0 or above.
-        string version = 1;
-
-        // Ad network identifier used in signature. Should match one of the
-        // items in the skadnetids array in the request.
-        string network = 2;
-
-        // A four-digit integer that ad networks define to represent the ad
-        // campaign.  Used in SKAdNetwork 4.0+, replaces Campaign ID 'campaign'.
-        // DSPs must generate signatures in 4.0+ using the Source Identifier.
-        string sourceidentifier = 10;
-
-        // Campaign ID compatible with Apple's spec. As of 2.0, should be an
-        // integer between 1 and 100, expressed as a string.
-        string campaign = 3;
-
-        // ID of advertiser's app in Apple's app store. Should match
-        // BidResponse.seatbid.bid.bundle.
-        string itunesitem = 4;
-
-        // Custom Product Page ID (UUID).
-        string productpageid = 11;
-
-        // Supports multiple fidelity types introduced in SKAdNetwork v2.2.
-        repeated SKAdNetworkFidelity fidelities = 9;
-
-        // An id unique to each ad response. Refer to Apple's documentation for
-        // the proper UUID format requirements.
-        // Note: With the release of SKAdNetwork v2.2, this field is deprecated
-        // in favor of the BidResponse.seatbid.bid.ext.skadn.fidelities.nonce to
-        // support multiple fidelity-types.
-        string nonce = 5;
-
-        // ID of publisher's app in Apple's app store. Should match
-        // BidRequest.imp.ext.skad.sourceapp.
-        string sourceapp = 6;
-
-        // Unix time in millis used at the time of signature generation.
-        // Note: With the release of SKAdNetwork 2.2, this field is deprecated
-        // in favor of the
-        // BidResponse.seatbid.bid.ext.skadn.fidelities.timestamp to support
-        // multiple fidelity-types.
-        string timestamp = 7;
-
-        // SKAdNetwork signature as specified by Apple.
-        // Note: With the release of SKAdNetwork 2.2, this field is deprecated
-        // in favor of the
-        // BidResponse.seatbid.bid.ext.skadn.fidelities.signature to support
-        // multiple fidelity-types.
-        string signature = 8;
-
-        // SKOverlay support.
-        SKOverlay skoverlay = 12;
-
-        // Placeholder for exchange-specific extensions to OpenRTB.
-        Ext ext = 99;
-
-        message Ext {
-          extensions 500 to max;
-        }
-
-        message SKOverlay {
-          // Delay before presenting the SKOverlay in seconds.  If set to 0, the
-          // overlay will be shown immediately.  If this field is not set, the
-          // overlay will not be shown.
-          int32 delay = 1;
-
-          // Delay before presenting the SKOverlay on an endcard in seconds.  If
-          // set to 0, the overlay will be shown immediately.  If this field is
-          // not set, the overlay will not be shown.
-          int32 endcarddelay = 2;
-
-          // Whether the overlay can be dismissed by the user, where 0 = no, 1 =
-          // yes
-          bool dismissible = 3;
-
-          // Position of the Overlay. 0 = bottom, 1 = bottomRaised.
-          int32 pos = 4;
-
-          // Placeholder for exchange-specific extensions to OpenRTB.
-          Ext ext = 99;
-
-          message Ext {
-            extensions 500 to max;
-          }
-        } // SKOverlay
-      } // SKAdNetworkResponse
-    } // Bid
-  } // SeatBid
+  }  // SeatBid
+
+  // A SeatBid object contains one or more Bid objects, each of which relates
+  // to a specific impression in the bid request via the impid attribute and
+  // constitutes an offer to buy that impression for a given price.
+  message Bid {
+    // Bidder generated bid ID to assist with logging/tracking.
+    // REQUIRED by the OpenRTB specification.
+    string id = 1;
+
+    // ID of the Imp object in the related bid request.
+    // REQUIRED by the OpenRTB specification.
+    string impid = 2;
+
+    // Bid price expressed as CPM although the actual transaction is for a
+    // unit impression only. Note that while the type indicates float,
+    // integer math is highly recommended when handling currencies (e.g.,
+    // BigDecimal in Java).
+    // REQUIRED by the OpenRTB specification.
+    double price = 3;
+
+    // Win notice URL called by the exchange if the bid wins (not necessarily
+    // indicative of a delivered, viewed, or billable ad); optional means of
+    // serving ad markup. Substitution macros (Section 4.4) may be included in
+    // both the URL and optionally returned markup.
+    string nurl = 5;
+
+    // Billing notice URL called by the exchange when a winning bid becomes
+    // billable based on exchange-specific business policy (e.g., typically
+    // delivered, viewed, etc.). Substitution macros (Section 4.4) may be
+    // included.
+    string burl = 22;
+
+    // Loss notice URL called by the exchange when a bid is known to have been
+    // lost. Substitution macros (Section 4.4) may be included.
+    // Exchange-specific policy may preclude support for loss notices or the
+    // disclosure of winning clearing prices resulting in ${AUCTION_PRICE}
+    // macros being removed (i.e., replaced with a zero-length string).
+    string lurl = 23;
+
+    // Optional means of conveying ad markup in case the bid wins; supersedes
+    // the win notice if markup is included in both. Substitution macros
+    // (Section 4.4) may be included. For native ad bids, exactly one of {adm,
+    // adm_native} should be used.
+    oneof adm_oneof {
+      // This is the OpenRTB-compliant field for JSON serialization.
+      string adm = 6;
+
+      // This is the field used for Protobuf serialization.
+      NativeResponse adm_native = 50;
+    }
+
+    // ID of a preloaded ad to be served if the bid wins.
+    string adid = 4;
+
+    // Advertiser domain for block list checking (e.g., "ford.com"). This can
+    // be an array of for the case of rotating creatives. Exchanges can
+    // mandate that only one domain is allowed.
+    repeated string adomain = 7;
+
+    // The store ID of the app in an app store (e.g., Apple App Store, Google
+    // Play). See OTT/CTV Store Assigned App Identification Guidelines for
+    // more details about expected strings for CTV app stores. For mobile apps
+    // in Google Play Store, these should be bundle or package names (e.g.
+    // com.foo.mygame). For apps in Apple App Store, these should be a numeric
+    // ID.
+    string bundle = 14;
+
+    // URL without cache-busting to an image that is representative of the
+    // content of the campaign for ad quality/safety checking.
+    string iurl = 8;
+
+    // Campaign ID to assist with ad quality checking; the collection of
+    // creatives for which iurl should be representative.
+    string cid = 9;
+
+    // Creative ID to assist with ad quality checking.
+    string crid = 10;
+
+    // Tactic ID to enable buyers to label bids for reporting to the exchange
+    // the tactic through which their bid was submitted. The specific usage
+    // and meaning of the tactic ID should be communicated between buyer and
+    // exchanges a priori.
+    string tactic = 24;
+
+    // The taxonomy in use.
+    // Refer to enum com.iabtechlab.adcom.v1.enums.CategoryTaxonomy for
+    // values.
+    int32 cattax = 30 [default = 1];
+
+    // IAB Tech Lab content categories of the creative. The taxonomy to be
+    // used is defined by the cattax field. If no cattax field is supplied
+    // Content Taxonomy 1.0 is assumed.
+    repeated string cat = 15;
+
+    // Set of attributes describing the creative.
+    // Refer to enum com.iabtechlab.adcom.v1.enums.Creative.Attribute for
+    // values.
+    repeated int32 attr = 11;
+
+    // List of supported APIs for the markup. If an API is not explicitly
+    // listed, it is assumed to be unsupported.
+    // Refer to enum com.iabtechlab.adcom.v1.enums.APIFramework for values.
+    repeated int32 apis = 31;
+
+    // NOTE: Deprecated in favor of apis.
+    int32 api = 18 [deprecated = true];
+
+    // Video response protocol of the markup if applicable.
+    // Refer to enum com.iabtechlab.adcom.v1.Creative.AudioVideoType for
+    // values.
+    int32 protocol = 19;
+
+    // Creative media rating per IQG guidelines.
+    // Refer to enum com.iabtechlab.adcom.v1.MediaRating for values.
+    int32 qagmediarating = 20;
+
+    // Language of the creative using ISO-639-1-alpha-2. The nonstandard code
+    // "xx" may also be used if the creative has no linguistic content (e.g.,
+    // a banner with just a company logo). Only one of language or langb
+    // should be present.
+    string language = 25;
+
+    // Language of the creative using IETF BCP 47. Only one of language or
+    // langb should be present.
+    string langb = 29;
+
+    // Reference to the deal.id from the bid request if this bid pertains to a
+    // private marketplace direct deal.
+    string dealid = 13;
+
+    // Width of the creative in device independent pixels (DIPS).
+    int32 w = 16;
+
+    // Height of the creative in device independent pixels (DIPS).
+    int32 h = 17;
+
+    // Relative width of the creative when expressing size as a ratio.
+    // Required for Flex Ads.
+    int32 wratio = 26;
+
+    // Relative height of the creative when expressing size as a ratio.
+    // Required for Flex Ads.
+    int32 hratio = 27;
+
+    // Advisory as to the number of seconds the bidder is willing to wait
+    // between the auction and the actual impression.
+    int32 exp = 21;
+
+    // Duration of the video or audio creative in seconds.
+    int32 dur = 32;
+
+    // Type of the creative markup so that it can properly be associated with
+    // the right sub-object of the BidRequest.Imp.
+    int32 mtype = 33;
+
+    // Indicates that the bid response is only eligible for a specific
+    // position within a video or audio ad pod (e.g. first position, last
+    // position, or any).
+    // Refer to enum com.iabtechlab.adcom.v1.enums.SlotPositionInPod for
+    // values.
+    int32 slotinpod = 28 [default = 0];
+
+    // Placeholder for exchange-specific extensions to OpenRTB.
+    Ext ext = 99;
+
+    message Ext {
+      // Advertiser's SKAdNetwork information.
+      SKAdNetworkResponse skadn = 1;
+
+      // Extension for DSA transparency information.
+      DsaResponse dsa = 2;
+
+      // Unique key enabling to identify and track a campaign during its
+      // lifecycle regardless of the SSP and DSP used. Note : scid contains
+      // the AdvertiserID (Global location number) + Advertiser brand +
+      // Advertiser product code + Customer Product Estimate + Ext (optional)
+      string scid = 3;
+
+      extensions 500 to max;
+    }
+  }  // Bid
+
+  message DsaResponse {
+    // Advertiser Transparency: Free UNICODE text string with a name of
+    // whose behalf the ad is displayed. Maximum 100 characters.
+    string behalf = 1;
+
+    // Advertiser Transparency: Free UNICODE text string of who paid for the
+    // ad.  Must always be included even if it's the same as what is listed
+    // in the behalf attribute. Maximum 100 characters.
+    string paid = 2;
+
+    // Array of objects of the entities that applied user parameters and the
+    // parameters they applied.
+    repeated Transparency transparency = 3;
+
+    // Flag to indicate that buyer/advertiser will render their own DSA
+    // transparency information inside the creative. 0 = buyer/advertiser
+    // will not render, 1 = buyer/advertiser will render.
+    bool adrender = 4;
+  }  // DsaResponse
+
+  // SKAdNetwork fidelity attributes.
+  message SKAdNetworkFidelity {
+    // The fidelity-type of the attribution to track.
+    enum Fidelity {
+      VIEW_THROUGH = 0;
+      STOREKIT_RENDERED = 1;
+    }
+    int32 fidelity = 1;
+
+    // An id unique to each ad response. Refer to Apple's documentation for
+    // the proper UUID format requirements:
+    // https://developer.apple.com/documentation/storekit/skstoreproductparameteradnetworknonce
+    string nonce = 2;
+
+    // Unix time in millis string used at the time of signature.
+    string timestamp = 3;
+
+    // SKAdNetwork signature as specified by Apple.
+    string signature = 4;
+
+    // Placeholder for exchange-specific extensions to OpenRTB.
+    Ext ext = 99;
+
+    message Ext {
+      extensions 500 to max;
+    }
+  }  // SKAdNetworkFidelity
+
+  // Advertiser's SKAdNetwork information to support app installation
+  // attribution for iOS 14 and later.  Apple's SKAdNetwork API helps
+  // advertisers measure ad-driven app installation by sending a postback to
+  // the ad network after a successful install. Ad networks will need to
+  // send their network ID and signed advertiser information to allow an
+  // install to be attributed to the ad impression.  For more info visit:
+  // https://developer.apple.com/documentation/storekit/skadnetwork
+  message SKAdNetworkResponse {
+    // Version of SKAdNetwork desired. Must be 2.0 or above.
+    string version = 1;
+
+    // Ad network identifier used in signature. Should match one of the
+    // items in the skadnetids array in the request.
+    string network = 2;
+
+    // A four-digit integer that ad networks define to represent the ad
+    // campaign.  Used in SKAdNetwork 4.0+, replaces Campaign ID 'campaign'.
+    // DSPs must generate signatures in 4.0+ using the Source Identifier.
+    string sourceidentifier = 10;
+
+    // Campaign ID compatible with Apple's spec. As of 2.0, should be an
+    // integer between 1 and 100, expressed as a string.
+    string campaign = 3;
+
+    // ID of advertiser's app in Apple's app store. Should match
+    // BidResponse.seatbid.bid.bundle.
+    string itunesitem = 4;
+
+    // Custom Product Page ID (UUID).
+    string productpageid = 11;
+
+    // Supports multiple fidelity types introduced in SKAdNetwork v2.2.
+    repeated SKAdNetworkFidelity fidelities = 9;
+
+    // An id unique to each ad response. Refer to Apple's documentation for
+    // the proper UUID format requirements.
+    // Note: With the release of SKAdNetwork v2.2, this field is deprecated
+    // in favor of the BidResponse.bid.ext.skadn.fidelities.nonce to
+    // support multiple fidelity-types.
+    string nonce = 5;
+
+    // ID of publisher's app in Apple's app store. Should match
+    // BidRequest.imp.ext.skad.sourceapp.
+    string sourceapp = 6;
+
+    // Unix time in millis used at the time of signature generation.
+    // Note: With the release of SKAdNetwork 2.2, this field is deprecated
+    // in favor of the
+    // BidResponse.bid.ext.skadn.fidelities.timestamp to support
+    // multiple fidelity-types.
+    string timestamp = 7;
+
+    // SKAdNetwork signature as specified by Apple.
+    // Note: With the release of SKAdNetwork 2.2, this field is deprecated
+    // in favor of the
+    // BidResponse.bid.ext.skadn.fidelities.signature to support
+    // multiple fidelity-types.
+    string signature = 8;
+
+    // SKOverlay support.
+    SKOverlay skoverlay = 12;
+
+    // Placeholder for exchange-specific extensions to OpenRTB.
+    Ext ext = 99;
+
+    message Ext {
+      extensions 500 to max;
+    }
+  }  // SKAdNetworkResponse
+
+  message SKOverlay {
+    // Delay before presenting the SKOverlay in seconds.  If set to 0, the
+    // overlay will be shown immediately.  If this field is not set, the
+    // overlay will not be shown.
+    int32 delay = 1;
+
+    // Delay before presenting the SKOverlay on an endcard in seconds.  If
+    // set to 0, the overlay will be shown immediately.  If this field is
+    // not set, the overlay will not be shown.
+    int32 endcarddelay = 2;
+
+    // Whether the overlay can be dismissed by the user, where 0 = no, 1 =
+    // yes
+    bool dismissible = 3;
+
+    // Position of the Overlay. 0 = bottom, 1 = bottomRaised.
+    int32 pos = 4;
+
+    // Placeholder for exchange-specific extensions to OpenRTB.
+    Ext ext = 99;
+
+    message Ext {
+      extensions 500 to max;
+    }
+  }  // SKOverlay
 
   message SeatNonBid {
     // Array of 1+ NonBid objects each related to an impression. Multiple non
@@ -2809,23 +2808,23 @@ message BidResponse {
     message Ext {
       extensions 500 to max;
     }
+  }  // SeatNonBid
 
-    message NonBid {
-      // ID of the Imp object in the related bid request.
-      string impid = 1;
+  message NonBid {
+    // ID of the Imp object in the related bid request.
+    string impid = 1;
 
-      // Reason for non bid. Refer to the Non Bid Status Codes list in
-      // https://github.com/InteractiveAdvertisingBureau/openrtb/blob/main/extensions/community_extensions/seat-non-bid.md.
-      int32 statuscode = 2;
+    // Reason for non bid. Refer to the Non Bid Status Codes list in
+    // https://github.com/InteractiveAdvertisingBureau/openrtb/blob/main/extensions/community_extensions/seat-non-bid.md.
+    int32 statuscode = 2;
 
-      // Placeholder for exchange-specific extensions to OpenRTB.
-      Ext ext = 99;
+    // Placeholder for exchange-specific extensions to OpenRTB.
+    Ext ext = 99;
 
-      message Ext {
-        extensions 500 to max;
-      }
-    } // NonBid
-  } // SeatNonBid
+    message Ext {
+      extensions 500 to max;
+    }
+  }  // NonBid
 
   message InterestGroupAuctionIntent {
     // ID of the Imp object in the related bid request. Used to link Interest
@@ -2840,7 +2839,7 @@ message BidResponse {
     // One or more InterestGroupAuctionSeller objects. Required and mutually
     // exclusive with igb.
     repeated InterestGroupAuctionSeller igs = 3;
-  } // InterestGroupAuctionIntent
+  }  // InterestGroupAuctionIntent
 
   // Information provided by the buyer and necessary for the seller to build the
   // associated config.
@@ -2890,7 +2889,7 @@ message BidResponse {
     // configuration, provided the seller does not start the auction in parallel
     // with OpenRTB requests.
     int32 begid = 6;
-  } // InterestGroupAuctionBuyer
+  }  // InterestGroupAuctionBuyer
 
   // Information provided by the seller and necessary to initiate an Interest
   // Group component auction. Component seller auction configuration should be
@@ -2903,8 +2902,8 @@ message BidResponse {
 
     // Auction config for a component seller.
     google.protobuf.Any config = 2;
-  } // InterestGroupAuctionSeller
-} // BidResponse
+  }  // InterestGroupAuctionSeller
+}  // BidResponse
 
 message Transparency {
   // Domain of the entity that applied user parameters.
@@ -2936,7 +2935,7 @@ message Transparency {
     PRECISE_GEOLOCATION = 3;
   }
   repeated int32 dsaparams = 2;
-} // Transparency
+}  // Transparency
 
 // The Native Object defines the native advertising opportunity available for
 // bid via this bid request. It must be included directly in the impression
@@ -3042,7 +3041,7 @@ message NativeRequest {
       // Video object for video assets. Note that in-stream video ads are not
       // part of Native. Native ads may contain a video as the ad creative
       // itself.
-      BidRequest.Imp.Video video = 5;
+      BidRequest.Video video = 5;
 
       // Data object for brand name, description, ratings, prices etc.
       // RECOMMENDED by the OpenRTB Native specification.
@@ -3055,95 +3054,95 @@ message NativeRequest {
     message Ext {
       extensions 500 to max;
     }
+  }  // Asset
 
-    // The Title object is to be used for title element of the Native ad.
-    message Title {
-      // Maximum length of the text in the title element.
-      // RECOMMENDED that the value be either of: 25, 90, 140.
-      // REQUIRED by the OpenRTB Native specification.
-      int32 len = 1;
+  // The Title object is to be used for title element of the Native ad.
+  message Title {
+    // Maximum length of the text in the title element.
+    // RECOMMENDED that the value be either of: 25, 90, 140.
+    // REQUIRED by the OpenRTB Native specification.
+    int32 len = 1;
 
-      // Placeholder for exchange-specific extensions to OpenRTB.
-      Ext ext = 99;
+    // Placeholder for exchange-specific extensions to OpenRTB.
+    Ext ext = 99;
 
-      message Ext {
-        extensions 500 to max;
-      }
-    } // Title
+    message Ext {
+      extensions 500 to max;
+    }
+  }  // Title
 
-    // The Image object to be used for all image elements of the Native ad such
-    // as Icons, Main Image, etc. Recommended sizes and aspect ratios are
-    // included in com.iabtechlab.adcom.v1.NativeImageAssetType.
-    message Image {
-      // Type ID of the image element supported by the publisher. The publisher
-      // can display this information in an appropriate format.
-      // Refer to enum com.iabtechlab.adcom.v1.NativeImageAssetType for values.
-      int32 type = 1;
+  // The Image object to be used for all image elements of the Native ad such
+  // as Icons, Main Image, etc. Recommended sizes and aspect ratios are
+  // included in com.iabtechlab.adcom.v1.NativeImageAssetType.
+  message Image {
+    // Type ID of the image element supported by the publisher. The publisher
+    // can display this information in an appropriate format.
+    // Refer to enum com.iabtechlab.adcom.v1.NativeImageAssetType for values.
+    int32 type = 1;
 
-      // Width of the image in pixels.
-      int32 w = 2;
+    // Width of the image in pixels.
+    int32 w = 2;
 
-      // Height of the image in pixels.
-      int32 h = 3;
+    // Height of the image in pixels.
+    int32 h = 3;
 
-      // The minimum requested width of the image in pixels. This option should
-      // be used for any rescaling of images by the client. Either w or wmin
-      // should be transmitted. If only w is included, it should be considered
-      // an exact requirement.
-      // RECOMMENDED by the OpenRTB Native specification.
-      int32 wmin = 4;
+    // The minimum requested width of the image in pixels. This option should
+    // be used for any rescaling of images by the client. Either w or wmin
+    // should be transmitted. If only w is included, it should be considered
+    // an exact requirement.
+    // RECOMMENDED by the OpenRTB Native specification.
+    int32 wmin = 4;
 
-      // The minimum requested height of the image in pixels. This option should
-      // be used for any rescaling of images by the client. Either h or hmin
-      // should be transmitted. If only h is included, it should be considered
-      // an exact requirement.
-      // RECOMMENDED by the OpenRTB Native specification.
-      int32 hmin = 5;
+    // The minimum requested height of the image in pixels. This option should
+    // be used for any rescaling of images by the client. Either h or hmin
+    // should be transmitted. If only h is included, it should be considered
+    // an exact requirement.
+    // RECOMMENDED by the OpenRTB Native specification.
+    int32 hmin = 5;
 
-      // Allowlist of content MIME types supported. Popular MIME types include,
-      // but are not limited to "image/jpg" and "image/gif". Each implementing
-      // Exchange should have their own list of supported types in the
-      // integration docs. See Wikipedia's MIME page for more information and
-      // links to all IETF RFCs. If blank, assume all types are allowed.
-      repeated string mimes = 6;
+    // Allowlist of content MIME types supported. Popular MIME types include,
+    // but are not limited to "image/jpg" and "image/gif". Each implementing
+    // Exchange should have their own list of supported types in the
+    // integration docs. See Wikipedia's MIME page for more information and
+    // links to all IETF RFCs. If blank, assume all types are allowed.
+    repeated string mimes = 6;
 
-      // Placeholder for exchange-specific extensions to OpenRTB.
-      Ext ext = 99;
+    // Placeholder for exchange-specific extensions to OpenRTB.
+    Ext ext = 99;
 
-      message Ext {
-        extensions 500 to max;
-      }
-    } // Image
+    message Ext {
+      extensions 500 to max;
+    }
+  }  // Image
 
-    // The Data Object is to be used for all non-core elements of the native
-    // unit such as Ratings, Review Count, Stars, Download count, descriptions
-    // etc. It is also generic for future of Native elements not contemplated at
-    // the time of the writing of this document.
-    message Data {
-      // Type ID of the element supported by the publisher. The publisher can
-      // display this information in an appropriate format.
-      // Refer to enum com.iabtechlab.adcom.v1.NativeDataAssetType for values.
-      // REQUIRED by the OpenRTB Native specification.
-      int32 type = 1;
+  // The Data Object is to be used for all non-core elements of the native
+  // unit such as Ratings, Review Count, Stars, Download count, descriptions
+  // etc. It is also generic for future of Native elements not contemplated at
+  // the time of the writing of this document.
+  message Data {
+    // Type ID of the element supported by the publisher. The publisher can
+    // display this information in an appropriate format.
+    // Refer to enum com.iabtechlab.adcom.v1.NativeDataAssetType for values.
+    // REQUIRED by the OpenRTB Native specification.
+    int32 type = 1;
 
-      // Maximum length of the text in the element's response. Longer strings
-      // may be truncated and ellipsized by Ad Exchange or the publisher during
-      // rendering.
-      int32 len = 2;
+    // Maximum length of the text in the element's response. Longer strings
+    // may be truncated and ellipsized by Ad Exchange or the publisher during
+    // rendering.
+    int32 len = 2;
 
-      // Placeholder for exchange-specific extensions to OpenRTB.
-      Ext ext = 99;
+    // Placeholder for exchange-specific extensions to OpenRTB.
+    Ext ext = 99;
 
-      message Ext {
-        // The ID for a taxonomy that is registered centrally, at
-        // https://github.com/InteractiveAdvertisingBureau/openrtb/blob/main/extensions/community_extensions/segtax.md.
-        // Refer to enum com.iabtechlab.adcom.v1.CategoryTaxonomy for values.
-        int32 segtax = 1;
+    message Ext {
+      // The ID for a taxonomy that is registered centrally, at
+      // https://github.com/InteractiveAdvertisingBureau/openrtb/blob/main/extensions/community_extensions/segtax.md.
+      // Refer to enum com.iabtechlab.adcom.v1.CategoryTaxonomy for values.
+      int32 segtax = 1;
 
-        extensions 500 to max;
-      }
-    } // Data
-  } // Asset
+      extensions 500 to max;
+    }
+  }  // Data
 
   // The EventTrackers object specifies the type of events the bidder can
   // request to be tracked in the bid response, and which types of tracking are
@@ -3166,8 +3165,8 @@ message NativeRequest {
     message Ext {
       extensions 500 to max;
     }
-  } // EventTrackers
-} // NativeRequest
+  }  // EventTrackers
+}  // NativeRequest
 
 // The native response object is the top level JSON object which identifies an
 // native response. Note: Prior to VERSION 1.1, the native response's root node
@@ -3255,7 +3254,7 @@ message NativeResponse {
     message Ext {
       extensions 500 to max;
     }
-  } // Link
+  }  // Link
 
   // Corresponds to the Asset Object in the request. The main container object
   // for each asset requested or supported by Exchange on behalf of the
@@ -3299,114 +3298,114 @@ message NativeResponse {
     message Ext {
       extensions 500 to max;
     }
+  }  // Asset
 
-    // Corresponds to the Title Object in the request, with the value filled in.
-    // If using assetsurl or dcourl response rather than embedded asset
-    // response, it is recommended that three title objects be provided, the
-    // length of each is less than or equal to the three recommended maximum
-    // title lengths (25,90,140).
-    message Title {
-      // The text associated with the text element.
-      // REQUIRED by the OpenRTB Native specification.
-      string text = 1;
+  // Corresponds to the Title Object in the request, with the value filled in.
+  // If using assetsurl or dcourl response rather than embedded asset
+  // response, it is recommended that three title objects be provided, the
+  // length of each is less than or equal to the three recommended maximum
+  // title lengths (25,90,140).
+  message Title {
+    // The text associated with the text element.
+    // REQUIRED by the OpenRTB Native specification.
+    string text = 1;
 
-      // The length of the title being provided.
-      // REQUIRED if using assetsurl/dcourl representation.
-      int32 len = 2;
+    // The length of the title being provided.
+    // REQUIRED if using assetsurl/dcourl representation.
+    int32 len = 2;
 
-      // Placeholder for exchange-specific extensions to OpenRTB.
-      Ext ext = 99;
+    // Placeholder for exchange-specific extensions to OpenRTB.
+    Ext ext = 99;
 
-      message Ext {
-        extensions 500 to max;
-      }
-    } // Title
+    message Ext {
+      extensions 500 to max;
+    }
+  }  // Title
 
-    // Corresponds to the Image Object in the request. The Image object to be
-    // used for all image elements of the Native ad such as Icons, Main Image,
-    // etc. It is recommended that if assetsurl/dcourl is being used rather than
-    // embbedded assets, that an image of each recommended aspect ratio (per
-    // ImageType enum) be provided for image type 3 (MAIN_IMAGE).
-    message Image {
-      // The type of image element being submitted from the ImageType enum.
-      // Refer to enum com.iabtechlab.adcom.v1.NativeImageAssetType for values.
-      // REQUIRED for assetsurl or dcourl responses, not required to embedded
-      // asset responses.
-      int32 type = 4;
+  // Corresponds to the Image Object in the request. The Image object to be
+  // used for all image elements of the Native ad such as Icons, Main Image,
+  // etc. It is recommended that if assetsurl/dcourl is being used rather than
+  // embbedded assets, that an image of each recommended aspect ratio (per
+  // ImageType enum) be provided for image type 3 (MAIN_IMAGE).
+  message Image {
+    // The type of image element being submitted from the ImageType enum.
+    // Refer to enum com.iabtechlab.adcom.v1.NativeImageAssetType for values.
+    // REQUIRED for assetsurl or dcourl responses, not required to embedded
+    // asset responses.
+    int32 type = 4;
 
-      // URL of the image asset.
-      // REQUIRED by the OpenRTB Native specification.
-      string url = 1;
+    // URL of the image asset.
+    // REQUIRED by the OpenRTB Native specification.
+    string url = 1;
 
-      // Width of the image in pixels.
-      // RECOMMENDED in 1.0, 1.1, or in 1.2 for embedded asset responses.
-      // REQUIRED in 1.2 for assetsurl or dcourl if multiple assets of the same
-      // type submitted.
-      int32 w = 2;
+    // Width of the image in pixels.
+    // RECOMMENDED in 1.0, 1.1, or in 1.2 for embedded asset responses.
+    // REQUIRED in 1.2 for assetsurl or dcourl if multiple assets of the same
+    // type submitted.
+    int32 w = 2;
 
-      // Height of the image in pixels.
-      // RECOMMENDED in 1.0, 1.1, or in 1.2 for embedded asset responses.
-      // REQUIRED in 1.2 for assetsurl or dcourl if multiple assets of the same
-      // type submitted.
-      int32 h = 3;
+    // Height of the image in pixels.
+    // RECOMMENDED in 1.0, 1.1, or in 1.2 for embedded asset responses.
+    // REQUIRED in 1.2 for assetsurl or dcourl if multiple assets of the same
+    // type submitted.
+    int32 h = 3;
 
-      // Placeholder for exchange-specific extensions to OpenRTB.
-      Ext ext = 99;
+    // Placeholder for exchange-specific extensions to OpenRTB.
+    Ext ext = 99;
 
-      message Ext {
-        extensions 500 to max;
-      }
-    } // Image
+    message Ext {
+      extensions 500 to max;
+    }
+  }  // Image
 
-    // Corresponds to the Data Object in the request, with the value filled in.
-    // The Data Object is to be used for all miscellaneous elements of the
-    // native unit such as Brand Name, Ratings, Review Count, Stars, Downloads,
-    // etc. It is also generic for future of native elements not contemplated at
-    // the time of the writing of this document.
-    message Data {
-      // The type of data element being submitted.
-      // Refer to enum com.iabtechlab.adcom.v1.NativeDataAssetType for values.
-      // REQUIRED in 1.2 for assetsurl or dcourl responses.
-      int32 type = 3;
+  // Corresponds to the Data Object in the request, with the value filled in.
+  // The Data Object is to be used for all miscellaneous elements of the
+  // native unit such as Brand Name, Ratings, Review Count, Stars, Downloads,
+  // etc. It is also generic for future of native elements not contemplated at
+  // the time of the writing of this document.
+  message Data {
+    // The type of data element being submitted.
+    // Refer to enum com.iabtechlab.adcom.v1.NativeDataAssetType for values.
+    // REQUIRED in 1.2 for assetsurl or dcourl responses.
+    int32 type = 3;
 
-      // The length of the data element being submitted. Where applicable, must
-      // comply with the recommended maximum lengths in the
-      // com.iabtechlab.adcom.v1.NativeDataAssetType enum.
-      // REQUIRED in 1.2 for assetsurl or dcourl responses.
-      int32 len = 4;
+    // The length of the data element being submitted. Where applicable, must
+    // comply with the recommended maximum lengths in the
+    // com.iabtechlab.adcom.v1.NativeDataAssetType enum.
+    // REQUIRED in 1.2 for assetsurl or dcourl responses.
+    int32 len = 4;
 
-      // The optional formatted string name of the data type to be displayed.
-      // DEPRECATED in 1.2.
-      string label = 1;
+    // The optional formatted string name of the data type to be displayed.
+    // DEPRECATED in 1.2.
+    string label = 1;
 
-      // The formatted string of data to be displayed. Can contain a formatted
-      // value such as "5 stars" or "$10" or "3.4 stars out of 5".
-      // REQUIRED by the OpenRTB Native specification.
-      string value = 2;
+    // The formatted string of data to be displayed. Can contain a formatted
+    // value such as "5 stars" or "$10" or "3.4 stars out of 5".
+    // REQUIRED by the OpenRTB Native specification.
+    string value = 2;
 
-      // Placeholder for exchange-specific extensions to OpenRTB.
-      Ext ext = 99;
+    // Placeholder for exchange-specific extensions to OpenRTB.
+    Ext ext = 99;
 
-      message Ext {
-        extensions 500 to max;
-      }
-    } // Data
+    message Ext {
+      extensions 500 to max;
+    }
+  }  // Data
 
-    // Corresponds to the Video Object in the request, yet containing a value of
-    // a conforming VAST tag as a value.
-    message Video {
-      // VAST xml.
-      // REQUIRED by the OpenRTB Native specification.
-      string vasttag = 1;
+  // Corresponds to the Video Object in the request, yet containing a value of
+  // a conforming VAST tag as a value.
+  message Video {
+    // VAST xml.
+    // REQUIRED by the OpenRTB Native specification.
+    string vasttag = 1;
 
-      // Placeholder for exchange-specific extensions to OpenRTB.
-      Ext ext = 99;
+    // Placeholder for exchange-specific extensions to OpenRTB.
+    Ext ext = 99;
 
-      message Ext {
-        extensions 500 to max;
-      }
-    } // Video
-  } // Asset
+    message Ext {
+      extensions 500 to max;
+    }
+  }  // Video
 
   // The event trackers response is an array of objects and specifies the types
   // of events the bidder wishes to track and the URLs/information to track
@@ -3442,8 +3441,8 @@ message NativeResponse {
     message Ext {
       extensions 500 to max;
     }
-  } // EventTracker
-} // NativeResponse
+  }  // EventTracker
+}  // NativeResponse
 
 // ***** OpenRTB Core enums ****************************************************
 


### PR DESCRIPTION
The great flattening! This outlines many of the nested proto messages into root objects, dramatically reducing the full names of the generated types in some languages.

Objects were flattened until they were directly under:
* BidRequest
* BidResponse
* Transparency
* NativeRequest
* NativeResponse

A few objects were not flattened:
* Ext messages - They would need to be renamed to include the outer object, and they're supposed to be "inside" the parent object.
* BidRequest.EID.UID - The object is small, and moving an object called UID feels real strange to me when that term is massively overloaded. I can outline it if poked.

SupplyChainNode was outlined because it contained the entire wrapper class name in its own name, if it was called Node it would not have been outlined.