### PR TITLE
Imp Guidance for Live Event Attribute Updates

### DIFF
--- a/implementation.md
+++ b/implementation.md
@@ -1964,3 +1964,35 @@ While SSPs and DSPs may find use for Extended Content IDs, it is also perfectly 
   }
 }
 ```
+
+## 7.15 - Additional Telemetry for Live Events <a name="lea"></a>
+
+Additional telemetry can be provided by including `recording` and `airdate` attributes. There are some detailed examples below.
+
+- The first airing of a program or event that has played previously on a different channel should use the date the program originally ran (e.g. a show new to channel B should include the original airdate as it ran on channel A).  
+- Where the original airdate is very far in the past (e.g. a classic movie streaming live), the value in the `airdate` attribute should be left blank.
+
+---
+
+## Example Scenarios
+
+| Scenario | `recording` | `airdate` |
+|----------|-------------|-----------|
+| Live (current) basketball game streaming live | 1 | [0] |
+| Replay of past basketball game, programmed streaming on an ad-supported channel | 1 | [UNIX TIMESTAMP] |
+| Basketball game streaming on-demand (not live) | 0 | [UNIX TIMESTAMP] |
+| International sports coverage (e.g. Olympics, Tour de France, Formula 1) recorded in a different timezone, livestreamed for the first time during primetime hours internationally. <br><br>Event recorded abroad that premiered hours later in North America. | 1 | [UNIX TIMESTAMP] |
+| New episodic content, premiere, with live tune-in | 1 | [0] |
+| New episodic content, premiere, on demand viewing | 0 | [UNIX TIMESTAMP] |
+| Episodic content, not a premiere, with live tune-in | 1 | [UNIX TIMESTAMP] |
+| Episodic content, not a premiere, on demand viewing | 0 | [UNIX TIMESTAMP] |
+| Live award show streaming live | 1 | [0] |
+| Replay of award show, programmed streaming on an ad-supported channel | 1 | [UNIX TIMESTAMP] |
+| Award show streaming on-demand (not live) | 0 | [UNIX TIMESTAMP] |
+| Live (current episode) talk show streaming live | 1 | [0] |
+| Rerun of episode of talk show, programmed streaming on an ad-supported channel | 1 | [UNIX TIMESTAMP] |
+| Talk show streaming on-demand (not live) | 0 | [UNIX TIMESTAMP] |
+| Real-time news streaming live | 1 | [0] |
+| News streaming on-demand (not live) | 0 | [UNIX TIMESTAMP] |
+| Sitcom rerun, programmed streaming on an ad-supported channel | 1 | [UNIX TIMESTAMP] |
+| Sitcom rerun streaming on-demand (not live) | 0 | [UNIX TIMESTAMP] |

--- a/implementation.md
+++ b/implementation.md
@@ -1970,7 +1970,7 @@ While SSPs and DSPs may find use for Extended Content IDs, it is also perfectly 
 Additional telemetry can be provided by including `recording` and `airdate` attributes. There are some detailed examples below.
 
 - The first airing of a program or event that has played previously on a different channel should use the date the program originally ran (e.g. a show new to channel B should include the original airdate as it ran on channel A).  
-- Where the original airdate is very far in the past (e.g. a classic movie streaming live), the value in the `airdate` attribute should be left blank.
+- Where the original airdate is very far in the past (e.g. a classic movie streaming live), the value in the `airdate` attribute should be -2 to denote the program originally aired prior to the start of the UNIX Timestamp enumeration (Jan 1, 1970). 
 
 ---
 
@@ -1978,21 +1978,21 @@ Additional telemetry can be provided by including `recording` and `airdate` attr
 
 | Scenario | `recording` | `airdate` |
 |----------|-------------|-----------|
-| Live (current) basketball game streaming live | 1 | [0] |
+| Live (current) basketball game streaming live | 1 | [-1] |
 | Replay of past basketball game, programmed streaming on an ad-supported channel | 1 | [UNIX TIMESTAMP] |
 | Basketball game streaming on-demand (not live) | 0 | [UNIX TIMESTAMP] |
 | International sports coverage (e.g. Olympics, Tour de France, Formula 1) recorded in a different timezone, livestreamed for the first time during primetime hours internationally. <br><br>Event recorded abroad that premiered hours later in North America. | 1 | [UNIX TIMESTAMP] |
-| New episodic content, premiere, with live tune-in | 1 | [0] |
+| New episodic content, premiere, with live tune-in | 1 | [-1] |
 | New episodic content, premiere, on demand viewing | 0 | [UNIX TIMESTAMP] |
 | Episodic content, not a premiere, with live tune-in | 1 | [UNIX TIMESTAMP] |
 | Episodic content, not a premiere, on demand viewing | 0 | [UNIX TIMESTAMP] |
-| Live award show streaming live | 1 | [0] |
+| Live award show streaming live | 1 | [-1] |
 | Replay of award show, programmed streaming on an ad-supported channel | 1 | [UNIX TIMESTAMP] |
 | Award show streaming on-demand (not live) | 0 | [UNIX TIMESTAMP] |
-| Live (current episode) talk show streaming live | 1 | [0] |
+| Live (current episode) talk show streaming live | 1 | [-1] |
 | Rerun of episode of talk show, programmed streaming on an ad-supported channel | 1 | [UNIX TIMESTAMP] |
 | Talk show streaming on-demand (not live) | 0 | [UNIX TIMESTAMP] |
-| Real-time news streaming live | 1 | [0] |
+| Real-time news streaming live | 1 | [-1] |
 | News streaming on-demand (not live) | 0 | [UNIX TIMESTAMP] |
 | Sitcom rerun, programmed streaming on an ad-supported channel | 1 | [UNIX TIMESTAMP] |
 | Sitcom rerun streaming on-demand (not live) | 0 | [UNIX TIMESTAMP] |


### PR DESCRIPTION
Addition of section 7.15 to Implementation guidance around using new `recording` and `airdate` attributes