### PR TITLE
Converting to markdown tables

### DIFF
--- a/2.6.md
+++ b/2.6.md
@@ -776,8 +776,8 @@ The presence of a `Native` as a subordinate of the `Imp` object indicates that t
 | `request` | string; required | Request payload complying with the [Native Ad Specification](https://iabtechlab.com/standards/openrtb-native/) . The root node of the payload, "native", was dropped in the Native Ads Specification 1.1. For Native 1.0, this is a JSON-encoded string consisting of a unnamed root object, with a single subordinate object named 'native', which is the Native Markup Request object, section 4.1 of OpenRTB Native 1.0 specification. For Native 1.1 and higher, this is a JSON-encoded string consisting of an unnamed root object which is itself the Native Markup Request Object, section 4.1 of OpenRTB Native 1.1+ . |
 | `ver` | string; recommended | Version of the Dynamic Native Ads API to which `request` complies; highly recommended for efficient parsing. |
 | `api` | integer array | List of supported API frameworks for this impression. Refer to [List: API Frameworks](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--api-frameworks-) in AdCOM. If an API is not explicitly listed, it is assumed not to be supported. |
-| `battr` | integer array | Blocked creative attributes. Refer to [List: Creative Attributes](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--creative-attributes-) in AdCOM. | `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
-|  |
+| `battr` | integer array | Blocked creative attributes. Refer to [List: Creative Attributes](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--creative-attributes-) in AdCOM. |
+| `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
 
 
 
@@ -790,8 +790,8 @@ This object represents an allowed size (i.e., height and width combination) or F
 | `w` | integer | Width in device-independent pixels (DIPS). |
 | `h` | integer | Height in device-independent pixels (DIPS). |
 | `wratio` | integer | Relative width when expressing size as a ratio. |
-| `hratio` | integer | Relative height when expressing size as a ratio. | `wmin` | integer | The minimum width in device-independent pixels (DIPS) at which the ad will be displayed the size is expressed as a ratio. |
-|  |
+| `hratio` | integer | Relative height when expressing size as a ratio. |
+| `wmin` | integer | The minimum width in device-independent pixels (DIPS) at which the ad will be displayed the size is expressed as a ratio. |
 | `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
 
 
@@ -835,18 +835,18 @@ This object should be included if the ad supported content is a website as oppos
 | `id` | string; recommended | Exchange-specific site ID. |
 | `name` | string | Site name (may be aliased at the publisher's request). |
 | `domain` | string | Domain of the site (e.g., "mysite.foo.com"). |
-| `cattax` | integer; default 1 | The taxonomy in use. Refer to the AdCOM [List: Category Taxonomies](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_categorytaxonomies) for values. If no cattax field is supplied IAB Cotent Category Taxonomy 1.0 is assumed. | `cat` | string array | Array of IAB Tech Lab content categories of the site. The taxonomy to be used is defined by the cattax field. |
-|  |
+| `cattax` | integer; default 1 | The taxonomy in use. Refer to the AdCOM [List: Category Taxonomies](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_categorytaxonomies) for values. If no cattax field is supplied IAB Cotent Category Taxonomy 1.0 is assumed. |
+| `cat` | string array | Array of IAB Tech Lab content categories of the site. The taxonomy to be used is defined by the cattax field. |
 | `sectioncat` | string array | Array of IAB Tech Lab content categories that describe the current section of the site. The taxonomy to be used is defined by the cattax field. |
 | `pagecat` | string array | Array of IAB Tech Lab content categories that describe the current page or view of the site. The taxonomy to be used is definied by the cattax field. |
-| `page` | string | URL of the page where the impression will be shown. | `ref` | string | Referrer URL that caused navigation to the current page. |
-|  |
-| `search` | string | Search string that caused navigation to the current page. | `mobile` | integer | Indicates if the site has been programmed to optimize layout when viewed on mobile devices, where 0=no, 1=yes. |
-|  |
+| `page` | string | URL of the page where the impression will be shown. |
+| `ref` | string | Referrer URL that caused navigation to the current page. |
+| `search` | string | Search string that caused navigation to the current page. |
+| `mobile` | integer | Indicates if the site has been programmed to optimize layout when viewed on mobile devices, where 0=no, 1=yes. |
 | `privacypolicy` | integer | Indicates if the site has a privacy policy, where 0 = no, 1 = yes. |
 | `publisher` | object | Details about the Publisher (Section 3.2.15) of the site. |
-| `content` | object | Details about the Content (Section 3.2.16) within the site. | `keywords` | string | Comma separated list of keywords about the site. Only one of `keywords` or `kwarray` may be present. |
-|  |
+| `content` | object | Details about the Content (Section 3.2.16) within the site. |
+| `keywords` | string | Comma separated list of keywords about the site. Only one of `keywords` or `kwarray` may be present. |
 | `kwarray` | string array | Array of keywords about the site. Only one of `keywords` or `kwarray` may be present. | `inventorypartnerdomain` | string | A domain to be used for inventory authorization in the case of inventory sharing arrangements between a site owner and content owner. This field is typically used by authorization crawlers to establish the domain of the content owner, who has the right to monetize some portion of ad inventory within the site. The content owner's domain should be listed in the site owner's ads.txt file as an `inventorypartnerdomain` . Authorization for supply from the `inventorypartnerdomain` will be published in the ads.txt file on the root of that domain. Refer to [the ads.txt 1.1 spec](https://iabtechlab.com/wp-content/uploads/2022/04/Ads.txt-1.1.pdf) for more details. | `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
 | `inventorypartnerdomain` | string | A domain to be used for inventory authorization in the case of inventory sharing arrangements between a site owner and content owner. This field is typically used by authorization crawlers to establish the domain of the content owner, who has the right to monetize some portion of ad inventory within the site. The content owner's domain should be listed in the site owner's ads.txt file as an `inventorypartnerdomain` . Authorization for supply from the `inventorypartnerdomain` will be published in the ads.txt file on the root of that domain. Refer to [the ads.txt 1.1 spec](https://iabtechlab.com/wp-content/uploads/2022/04/Ads.txt-1.1.pdf) for more details. |
 | `inventorypartnerdomain` | string | A domain to be used for inventory authorization in the case of inventory sharing arrangements between a site owner and content owner. This field is typically used by authorization crawlers to establish the domain of the content owner, who has the right to monetize some portion of ad inventory within the site. The content owner's domain should be listed in the site owner's ads.txt file as an `inventorypartnerdomain` . Authorization for supply from the `inventorypartnerdomain` will be published in the ads.txt file on the root of that domain. Refer to [the ads.txt 1.1 spec](https://iabtechlab.com/wp-content/uploads/2022/04/Ads.txt-1.1.pdf) for more details. |
@@ -865,16 +865,16 @@ This object should be included if the ad supported content is a non-browser appl
 | `bundle` | string | The store ID of the app in an app store. See [OTT/CTV Store Assigned App Identification Guidelines](https://iabtechlab.com/wp-content/uploads/2020/08/IAB-Tech-Lab-OTT-store-assigned-App-Identification-Guidelines-2020.pdf) for more details about expected strings for CTV app stores. For mobile apps in Google Play Store, these should be bundle or package names (e.g. com.foo.mygame). For apps in Apple App Store, these should be a numeric ID. |
 | `domain` | string | Domain of the app (e.g., "mygame.foo.com"). |
 | `storeurl` | string | App store URL for an installed app; for IQG 2.1 compliance. |
-| `cattax` | integer; default 1 | The taxonomy in use. Refer to the AdCOM [List: Category Taxonomies](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_categorytaxonomies) for values. | `cat` | string array | Array of IAB Tech Lab content categories of the app. The taxonomy to be used is defined by the cattax field. If no cattax field is supplied Content Category Taxonomy 1.0 is assumed. |
-|  |
+| `cattax` | integer; default 1 | The taxonomy in use. Refer to the AdCOM [List: Category Taxonomies](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_categorytaxonomies) for values. |
+| `cat` | string array | Array of IAB Tech Lab content categories of the app. The taxonomy to be used is defined by the cattax field. If no cattax field is supplied Content Category Taxonomy 1.0 is assumed. |
 | `sectioncat` | string array | Array of IAB Tech Lab content categories that describe the current section of the app. The taxonomy to be used is defined by the cattax field. |
 | `pagecat` | string array | Array of IAB Tech Lab content categories that describe the current page or view of the app. The taxonomy to be used is definied by the cattax field. |
-| `ver` | string | Application version. | `privacypolicy` | integer | Indicates if the app has a privacy policy, where 0 = no, 1 = yes. |
-|  |
-| `paid` | integer | 0 = app is free, 1 = the app is a paid version. | `publisher` | object | Details about the Publisher (Section 3.2.15) of the app. |
-|  |
-| `content` | object | Details about the Content (Section 3.2.16) within the app. | `keywords` | string | Comma separated list of keywords about the app. Only one of `keywords` or `kwarray` may be present. |
-|  |
+| `ver` | string | Application version. |
+| `privacypolicy` | integer | Indicates if the app has a privacy policy, where 0 = no, 1 = yes. |
+| `paid` | integer | 0 = app is free, 1 = the app is a paid version. |
+| `publisher` | object | Details about the Publisher (Section 3.2.15) of the app. |
+| `content` | object | Details about the Content (Section 3.2.16) within the app. |
+| `keywords` | string | Comma separated list of keywords about the app. Only one of `keywords` or `kwarray` may be present. |
 | `kwarray` | string array | Array of keywords about the app. Only one of `keywords` or `kwarray` may be present. | `inventorypartnerdomain` | string | A domain to be used for inventory authorization in the case of inventory sharing arrangements between an app owner and content owner. This field is typically used by authorization crawlers to establish the domain of the content owner, who has the right to monetize some portion of ad inventory within the app. The content owner's domain should be listed in the app owner's app-ads.txt file as an `inventorypartnerdomain` . Authorization for supply from the `inventorypartnerdomain` will be published in the ads.txt file on the root of that domain. Refer to [the ads.txt 1.1 spec](https://iabtechlab.com/wp-content/uploads/2022/04/Ads.txt-1.1.pdf) for more details. | `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
 | `inventorypartnerdomain` | string | A domain to be used for inventory authorization in the case of inventory sharing arrangements between an app owner and content owner. This field is typically used by authorization crawlers to establish the domain of the content owner, who has the right to monetize some portion of ad inventory within the app. The content owner's domain should be listed in the app owner's app-ads.txt file as an `inventorypartnerdomain` . Authorization for supply from the `inventorypartnerdomain` will be published in the ads.txt file on the root of that domain. Refer to [the ads.txt 1.1 spec](https://iabtechlab.com/wp-content/uploads/2022/04/Ads.txt-1.1.pdf) for more details. |
 | `inventorypartnerdomain` | string | A domain to be used for inventory authorization in the case of inventory sharing arrangements between an app owner and content owner. This field is typically used by authorization crawlers to establish the domain of the content owner, who has the right to monetize some portion of ad inventory within the app. The content owner's domain should be listed in the app owner's app-ads.txt file as an `inventorypartnerdomain` . Authorization for supply from the `inventorypartnerdomain` will be published in the ads.txt file on the root of that domain. Refer to [the ads.txt 1.1 spec](https://iabtechlab.com/wp-content/uploads/2022/04/Ads.txt-1.1.pdf) for more details. |
@@ -892,8 +892,8 @@ This object describes the entity who directly supplies inventory to and is paid 
 | --- | --- | --- |
 | `id` | string | Exchange-specific seller ID. Every ID must map to only a single entity that is paid for inventory transacted via that ID. Corresponds to a `seller_id` of a seller in the exchange’s sellers.json file. |
 | `name` | string | Seller name (may be aliased at the seller's request). |
-| `cattax` | integer; default 1 | The taxonomy in use. Refer to the AdCOM [List: Category Taxonomies](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_categorytaxonomies) for values. | `cat` | string array | Array of IAB Tech Lab content categories of the publisher. The taxonomy to be used is defined by the cattax field. If no cattax field is supplied Content Category Taxonomy 1.0 is assumed. |
-|  |
+| `cattax` | integer; default 1 | The taxonomy in use. Refer to the AdCOM [List: Category Taxonomies](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_categorytaxonomies) for values. |
+| `cat` | string array | Array of IAB Tech Lab content categories of the publisher. The taxonomy to be used is defined by the cattax field. If no cattax field is supplied Content Category Taxonomy 1.0 is assumed. |
 | `domain` | string | Highest level domain of the seller (e.g., "seller.com"). |
 | `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
 
@@ -949,9 +949,8 @@ This object defines the producer of the content in which the ad will be shown. T
 | --- | --- | --- |
 | `id` | string | Content producer or originator ID. Useful if content is syndicated and may be posted on a site using embed tags. |
 | `name` | string | Content producer or originator name (e.g., “Warner Bros”). |
-| `cattax` | integer; default 1 | The taxonomy in use. Refer to the AdCOM 1.0 list [List: Category Taxonomies](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_categorytaxonomies) for values. | `cat` | string array | Array of IAB Tech Lab content categories that describe the content producer. 
-The taxonomy to be used is defined by the cattax field. If no cattax field is supplied Content Category Taxonomy 1.0 is assumed. |
-|  |
+| `cattax` | integer; default 1 | The taxonomy in use. Refer to the AdCOM 1.0 list [List: Category Taxonomies](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_categorytaxonomies) for values. |
+| `cat` | string array | Array of IAB Tech Lab content categories that describe the content producer. The taxonomy to be used is defined by the cattax field. If no cattax field is supplied Content Category Taxonomy 1.0 is assumed. |
 | `domain` | string | Highest level domain of the content producer (e.g., "producer.com"). |
 | `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
 
@@ -1013,15 +1012,15 @@ The `lat`/`lon` attributes should only be passed if they conform to the accuracy
 | `type` | integer | Source of location data; recommended when passing `lat` / `lon` . Refer to [List: Location Types](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--location-types-) in AdCOM 1.0. |
 | `accuracy` | integer | Estimated location accuracy in meters; recommended when `lat` / `lon` are specified and derived from a device’s location services (i.e., type = 1). Note that this is the accuracy as reported from the device. Consult OS specific documentation (e.g., Android, iOS) for exact interpretation. |
 | `lastfix` | integer | Number of seconds since this geolocation fix was established. Note that devices may cache location data across multiple fetches. Ideally, this value should be from the time the actual fix was taken. |
-| `ipservice` | integer | Service or provider used to determine geolocation from IP address if applicable (i.e., type = 2). Refer to [List: IP Location Services](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--ip-location-services-) in AdCOM 1.0. | `country` | string | Country code using ISO-3166-1-alpha-3. |
-|  |
+| `ipservice` | integer | Service or provider used to determine geolocation from IP address if applicable (i.e., type = 2). Refer to [List: IP Location Services](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--ip-location-services-) in AdCOM 1.0. |
+| `country` | string | Country code using ISO-3166-1-alpha-3. |
 | `region` | string | Region code using ISO-3166-2; 2-letter state code if USA. |
 | `regionfips104` | string | Region of a country using FIPS 10-4 notation. While OpenRTB supports this attribute, it was withdrawn by NIST in 2008. |
-| `metro` | string | Google metro code; similar to but not exactly Nielsen DMAs. See Appendix A for a link to the codes. | `city` | string | City using United Nations Code for Trade & Transport Locations. See Appendix A for a link to the codes. |
-|  |
-| `zip` | string | ZIP or postal code. | `utcoffset` | integer | Local time as the number +/- of minutes from UTC. | `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
-|  |
-|  |
+| `metro` | string | Google metro code; similar to but not exactly Nielsen DMAs. See Appendix A for a link to the codes. |
+| `city` | string | City using United Nations Code for Trade & Transport Locations. See Appendix A for a link to the codes. |
+| `zip` | string | ZIP or postal code. |
+| `utcoffset` | integer | Local time as the number +/- of minutes from UTC. |
+| `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
 
 
 ### 3.2.20 - Object: User <a name="objectuser"></a>
@@ -1037,12 +1036,12 @@ This object contains information known or derived about the human user of the de
 | `yob` | integer; DEPRECATED | Deprecated as of OpenRTB 2.6. |
 | `gender` | string; DEPRECATED | Deprecated as of OpenRTB 2.6. |
 | `keywords` | string | Comma separated list of keywords, interests, or intent. Only one of `keywords` or `kwarray` may be present. |
-| `kwarray` | string array | Array of keywords about the user. Only one of `keywords` or `kwarray` may be present. | `customdata` | string | Optional feature to pass bidder data that was set in the exchange’s cookie. The string must be in base85 cookie safe characters and be in any format. Proper JSON encoding must be used to include “escaped” quotation marks. |
-|  |
+| `kwarray` | string array | Array of keywords about the user. Only one of `keywords` or `kwarray` may be present. |
+| `customdata` | string | Optional feature to pass bidder data that was set in the exchange’s cookie. The string must be in base85 cookie safe characters and be in any format. Proper JSON encoding must be used to include “escaped” quotation marks. |
 | `geo` | object | Location of the user’s home base defined by a `Geo` object (Section 3.2.19). This is not necessarily their current location. |
 | `data` | object array | Additional user data. Each `Data` object (Section 3.2.21) represents a different data source. |
-| `consent` | string | When GDPR regulations are in effect this attribute contains the Transparency and Consent Framework’s [Consent String](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md) data structure. | `eids` | object array | Details for support of a standard protocol for multiple third party identity providers (Section 3.2.27). |
-|  |
+| `consent` | string | When GDPR regulations are in effect this attribute contains the Transparency and Consent Framework’s [Consent String](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md) data structure. |
+| `eids` | object array | Details for support of a standard protocol for multiple third party identity providers (Section 3.2.27). |
 | `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
 
 
@@ -2143,8 +2142,8 @@ This appendix serves as an index of specification changes across 2.x versions. T
 | --- | --- |
 | `3.1` | Object Model Update to model image to show DOOH and Qty objects |
 | `3.2.3` | Object: Regs Additional fields gpp and gpp_sid to support Global Privacy Protection string |
-| `3.2.13, 3.2.14` | Objects: Site, App Added inventorypartnerdomain (previously ext) | `3.2.31` | Object: Qty New object to describe source of multiplier value in Digital Out of Home |
-|  |
+| `3.2.13, 3.2.14` | Objects: Site, App Added inventorypartnerdomain (previously ext) |
+| `3.2.31` | Object: Qty New object to describe source of multiplier value in Digital Out of Home |
 | `3.2.32` | Object: DOOH New object to support programmatic buys of Digital Out of Home inventory |
 | `7.9` | Implementation Notes Addition of notes, examples and best practices for utilizing DOOH |
 
@@ -2159,21 +2158,21 @@ This appendix serves as an index of specification changes across 2.x versions. T
 | `5` | Removed section (Enumerated Lists) All references now point to AdCOM 1.0 / OpenRTB 3.0 Lists | `3.2.1, 3.2.13, 3.2.14, 3.2.15, 3.2.16, 3.2.17, 4.2.3` | Objects: BidRequest, Site, App, Publisher, Content, Producer, Bid Use of cattax for all taxonomy references | `3.2.7, 3.2.8` | Objects: Video, Audio Added rqddurs | `3.2.7, 3.2.8` | Objects: Video, Audio Added maxseq, poddur, podid, podseq, mincpmpersec, slotinpod for pod bidding support | `4.4, 4.4.1` | Substition Macros Added AUCTION_MIN_TO_WIN | `4.2.3` | Object, Bid Added apis | `3.2.4` | Object: Imp Added rwdd | `3.2.1, 3.2.14, 4.2.3` | Objects: App, Bid, BidRequest Clarified laguage around use of storeid vs bundle | `3.2.4` | Object Imp Added ssai | `3.2.18` | Object: Device Clarified language around mccmnc and roaming | `3.2.23, 3.2.24` | Added Objects: Network, Channel, SupplyChain, SupplyChainNode, EIDs and UIDs* | `4.2.3` | Object: Bid Added mtype | `3.2.6, 3.2.7, 3.2.16` | Removed previously deprecated attributes Object: Banner, wmax, hmax, wmin, hmin, Object: Video, protocol, Object: Content, videoquality | `7.6` | Pod Bidding for Video and Audio implementers guide | `7.7` | Network and Channel object examples | `3.2.7, 3.2.8, 3.2.18, 3.2.20, 4.2.3` | Deprecated attributes Object: Video, sequence, Object: Audio, sequence, Ojbect: Device, didsha1, didmd5, dpidsha1, dpidnd5, macsha1, macmd5, Object: User, yob, gender, Object: Bid, api | `7.8` | Added Counting Billable events and tracked ads | `3.2.29, 3.2.30` | Object: UserAgent & Object Brand Version added |
 | `5` | Removed section (Enumerated Lists) All references now point to AdCOM 1.0 / OpenRTB 3.0 Lists |
 | `3.2.1, 3.2.13, 3.2.14, 3.2.15, 3.2.16, 3.2.17, 4.2.3` | Objects: BidRequest, Site, App, Publisher, Content, Producer, Bid Use of cattax for all taxonomy references |
-| `3.2.7, 3.2.8` | Objects: Video, Audio Added rqddurs | `3.2.7, 3.2.8` | Objects: Video, Audio Added maxseq, poddur, podid, podseq, mincpmpersec, slotinpod for pod bidding support |
-|  |
+| `3.2.7, 3.2.8` | Objects: Video, Audio Added rqddurs |
+| `3.2.7, 3.2.8` | Objects: Video, Audio Added maxseq, poddur, podid, podseq, mincpmpersec, slotinpod for pod bidding support |
 | `4.4, 4.4.1` | Substition Macros Added AUCTION_MIN_TO_WIN |
 | `4.2.3` | Object, Bid Added apis |
 | `3.2.4` | Object: Imp Added rwdd |
-| `3.2.1, 3.2.14, 4.2.3` | Objects: App, Bid, BidRequest Clarified laguage around use of storeid vs bundle | `3.2.4` | Object Imp Added ssai |
-|  |
+| `3.2.1, 3.2.14, 4.2.3` | Objects: App, Bid, BidRequest Clarified laguage around use of storeid vs bundle |
+| `3.2.4` | Object Imp Added ssai |
 | `3.2.18` | Object: Device Clarified language around mccmnc and roaming |
-| `3.2.23, 3.2.24` | Added Objects: Network, Channel, SupplyChain, SupplyChainNode, EIDs and UIDs* | `4.2.3` | Object: Bid Added mtype |
-|  |
+| `3.2.23, 3.2.24` | Added Objects: Network, Channel, SupplyChain, SupplyChainNode, EIDs and UIDs* |
+| `4.2.3` | Object: Bid Added mtype |
 | `3.2.6, 3.2.7, 3.2.16` | Removed previously deprecated attributes Object: Banner, wmax, hmax, wmin, hmin, Object: Video, protocol, Object: Content, videoquality |
 | `7.6` | Pod Bidding for Video and Audio implementers guide |
 | `7.7` | Network and Channel object examples |
-| `3.2.7, 3.2.8, 3.2.18, 3.2.20, 4.2.3` | Deprecated attributes Object: Video, sequence, Object: Audio, sequence, Ojbect: Device, didsha1, didmd5, dpidsha1, dpidnd5, macsha1, macmd5, Object: User, yob, gender, Object: Bid, api | `7.8` | Added Counting Billable events and tracked ads |
-|  |
+| `3.2.7, 3.2.8, 3.2.18, 3.2.20, 4.2.3` | Deprecated attributes Object: Video, sequence, Object: Audio, sequence, Ojbect: Device, didsha1, didmd5, dpidsha1, dpidnd5, macsha1, macmd5, Object: User, yob, gender, Object: Bid, api |
+| `7.8` | Added Counting Billable events and tracked ads |
 | `3.2.29, 3.2.30` | Object: UserAgent & Object Brand Version added |
 
 	
@@ -2187,21 +2186,21 @@ This appendix serves as an index of specification changes across 2.x versions. T
 | `2.4` | Section: Data Encoding New section added. |
 | `3.1` | Object Model: Bid Request Update to include Source and Metric objects. |
 | 3.2.1 | Object: BidRequest , Attributes bseat, wlang, and source have been added. |
-| `3.2.2` | Object: Source New Source object has been added including the Payment ID pchain attribute. | `3.2.4` | Object: Imp Attribute Metric object has been added. |
-|  |
+| `3.2.2` | Object: Source New Source object has been added including the Payment ID pchain attribute. |
+| `3.2.4` | Object: Imp Attribute Metric object has been added. |
 | `3.2.5` | Object: Metric New Metric object has been added. |
 | `3.2.6` | Object: Banner , Attribute vcm has been added. |
 | `3.2.7` | Object: Video , Attributes placement and playbackend have been added. Guidance added to use only the first element of attribute playbackmethod in preparation for future converson to an integer. |
-| `3.2.10` | Object: Format Attributes wratio, hratio, and wmin have been added. | `3.2.4` | Object Imp Added ssai |
-|  |
+| `3.2.10` | Object: Format Attributes wratio, hratio, and wmin have been added. |
+| `3.2.4` | Object Imp Added ssai |
 | `3.2.13` | Object: Device Attribute mccmnc has been added. Attribute carrier has been clarified to eliminate a reference to using "WIFI" as a carrier. |
-| `4.2.3` | Object: Bid Attributes burl, lurl, tactic, language, wratio, and hratio have been added. | `4.4` | Subsititution Macros: Macros ${AUCTION_MBR} and ${AUCTION_LOSS} have been added. A best practice has been added to use “AUDIT” for unknown values when rendering for test or quality purposes. |
-|  |
+| `4.2.3` | Object: Bid Attributes burl, lurl, tactic, language, wratio, and hratio have been added. |
+| `4.4` | Subsititution Macros: Macros ${AUCTION_MBR} and ${AUCTION_LOSS} have been added. A best practice has been added to use “AUDIT” for unknown values when rendering for test or quality purposes. |
 | `5.6` | List: API Frameworks Item 6 has been added. |
 | `5.9` | List: Video Placement Types New list has been added. |
 | `5.10` | List: Playback Methods Items 5-6 have been added. |
-| `5.11` | List: Playback Cessation Modes New list has been added. | `5.24` | List: No-Bid Reason Codes Items 9-10 have been added. |
-|  |
+| `5.11` | List: Playback Cessation Modes New list has been added. |
+| `5.24` | List: No-Bid Reason Codes Items 9-10 have been added. |
 | `5.25` | List: Loss Reason Codes New list has been added. |
 
 

--- a/2.6.md
+++ b/2.6.md
@@ -501,7 +501,7 @@ The following table summarizes the objects in the Bid Request model and serves a
 | `Metric` | 3.2.5 | A quanitifiable often historical data point about an impression. |
 | `Banner` | 3.2.6 | Details for a banner impression (incl. in-banner video) or video companion ad. |
 | `Video` | 3.2.7 | Details for a video impression. |
-| `Audio` | 3.2.8 | Container for audio impression. . |
+| `Audio` | 3.2.8 | Container for audio impression. |
 | `Native` | 3.2.9 | Container for a native impression conforming to the Dynamic Native Ads API. |
 | `Format` | 3.2.10 | An allowed size of a banner. |
 | `Pmp` | 3.2.11 | Collection of private marketplace (PMP) deals applicable to this impression. |
@@ -557,8 +557,8 @@ There are also several subordinate objects that provide detailed data to potenti
 | `cur` | string array | Array of allowed currencies for bids on this bid request using ISO-4217 alpha codes. Recommended only if the exchange accepts multiple currencies. |
 | `wlang` | string array | Allowed list of languages for creatives using ISO-639-1-alpha-2. Omission implies no specific restrictions, but buyers would be advised to consider `language` attribute in the `Device` and/or `Content` objects if available. Only one of `wlang` or `wlangb` should be present. |
 | `wlangb` | string array | Allowed list of languages for creatives using IETF BCP 47I. Omission implies no specific restrictions, but buyers would be advised to consider language attribute in the `Device` and/or `Content` objects if available. Only one of `wlang` or `wlangb` should be present. |
-| `acat` | string array | Allowed advertiser categories using the specified category taxonomy. The taxonomy to be used is defined by the `cattax` field. If no `cattax` field is supplied IAB Content Taxonomy 1.0 is assumed. Only one of `acat` or `bcat` should be present. |
-| `bcat` | string array | Blocked advertiser categories using the specified category taxonomy. The taxonomy to be used is defined by the `cattax` field. If no `cattax` field is supplied IAB Content Taxonomy 1.0 is assumed. Only one of `acat` or `bcat` should be present. |
+| `acat` | string array | Allowed advertiser categories using the specified category taxonomy.<br>The taxonomy to be used is defined by the `cattax` field. If no `cattax` field is supplied IAB Content Taxonomy 1.0 is assumed. Only one of `acat` or `bcat` should be present. |
+| `bcat` | string array | Blocked advertiser categories using the specified category taxonomy.<br>The taxonomy to be used is defined by the `cattax` field. If no `cattax` field is supplied IAB Content Taxonomy 1.0 is assumed. Only one of `acat` or `bcat` should be present. |
 | `cattax` | integer; default 1 | The taxonomy in use for bcat. Refer to the AdCOM 1.0 list [List: Category Taxonomies](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_categorytaxonomies) for values. |
 | `badv` | string array | Block list of advertisers by their domains (e.g., “ford.com”). |
 | `bapp` | string array | Block list of applications by their app store IDs. See [OTT/CTV Store Assigned App Identification Guidelines](https://iabtechlab.com/wp-content/uploads/2020/08/IAB-Tech-Lab-OTT-store-assigned-App-Identification-Guidelines-2020.pdf) for more details about expected strings for CTV app stores. For mobile apps in Google Play Store, these should be bundle or package names (e.g. com.foo.mygame). For apps in Apple App Store, these should be a numeric ID. |
@@ -591,7 +591,7 @@ This object contains any legal, governmental, or industry regulations that the s
 | --- | --- | --- |
 | `coppa` | integer | Flag indicating if this request is subject to the COPPA regulations established by the USA FTC, where 0 = no, 1 = yes. Refer to Section 7.5 for more information. |
 | `gdpr` | integer | Flag that indicates whether or not the request is subject to GDPR regulations 0 = No, 1 = Yes, omission indicates unknown. Refer to Section 7.5 for more information. |
-| `us_privacy` | string | Communicates signals regarding consumer privacy under US privacy regulation. See [US Privacy String specifications](https://github.com/InteractiveAdvertisingBureau/USPrivacy/blob/master/CCPA/US%20Privacy%20String.md) . Refer to Section 7.5 for more information. |
+| `us_privacy` | string | Communicates signals regarding consumer privacy under US privacy regulation. See [US Privacy String specifications](https://github.com/InteractiveAdvertisingBureau/USPrivacy/blob/master/CCPA/US%20Privacy%20String.md). Refer to Section 7.5 for more information. |
 | `gpp` | string | Contains the Global Privacy Platform’s consent string. See the [Global Privacy Platform specification](https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform) for more details. |
 | `gpp_sid` | integer array | Array of the section(s) of the string which should be applied for this transaction. Generally will contain one and only one value, but there are edge cases where more than one may apply. GPP Section 3 (Header) and 4 (Signal Integrity) do not need to be included. See the [GPP Section Information](https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Sections/Section%20Information.md) for more details. |
 | `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
@@ -612,8 +612,8 @@ The presence of `Banner` (Section 3.2.6), `Video` (Section 3.2.7), and/or `Nativ
 | `audio` | object | An `Audio` object (Section 3.2.8); required if this impression is offered as an audio ad opportunity. |
 | `native` | object | A `Native` object (Section 3.2.9); required if this impression is offered as a native ad opportunity. |
 | `pmp` | object | A `Pmp` object (Section 3.2.11) containing any private marketplace deals in effect for this impression. |
-| `displaymanager` | string | Name of ad mediation partner, SDK technology, or player responsible for rendering ad (typically video or mobile). Used by some ad servers to customize ad code by partner. Recommended for video and/or apps. |
-| `displaymanagerver` | string | Version of ad mediation partner, SDK technology, or player responsible for rendering ad (typically video or mobile). Used by some ad servers to customize ad code by partner. Recommended for video and/or apps. |
+| `displaymanager` | string | Name of ad mediation partner, SDK technology, or player responsible for rendering ad (typically video or mobile). Used by some ad servers to customize ad code by partner.<br>Recommended for video and/or apps. |
+| `displaymanagerver` | string | Version of ad mediation partner, SDK technology, or player responsible for rendering ad (typically video or mobile). Used by some ad servers to customize ad code by partner.<br>Recommended for video and/or apps. |
 | `instl` | integer; default 0 | 1 = the ad is interstitial or full screen, 0 = not interstitial. |
 | `tagid` | string | Identifier for specific ad placement or ad tag that was used to initiate the auction. This can be useful for debugging of any issues, or for optimization by the buyer. |
 | `bidfloor` | float; default 0 | Minimum bid for this impression expressed in CPM. |
@@ -638,9 +638,9 @@ This object is associated with an impression as an array of metrics. These metri
 
 | Attribute | Type | Description |
 | --- | --- | --- |
-| `type` | string; required | Type of metric being presented using exchange curated string names which should be published to bidders a priori . |
+| `type` | string; required | Type of metric being presented using exchange curated string names which should be published to bidders a priori. |
 | `value` | float; required | Number representing the value of the metric. Probabilities must be in the range 0.0 – 1.0. |
-| `vendor` | string; recommended | Source of the value using exchange curated string names which should be published to bidders a priori . If the exchange itself is the source versus a third party, “EXCHANGE” is recommended. |
+| `vendor` | string; recommended | Source of the value using exchange curated string names which should be published to bidders a priori. If the exchange itself is the source versus a third party, “EXCHANGE” is recommended. |
 | `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
 
 
@@ -654,13 +654,13 @@ The presence of a `Banner` as a subordinate of the `Imp` object indicates that t
 
 | Attribute | Type | Description |
 | --- | --- | --- |
-| `format` | object array; recommended | Array of format objects (Section 3.2.10) representing the banner sizes permitted. If none are specified, then use of the `h` and `w` attributes is highly recommended. |
+| `format` | object array;<br>recommended | Array of format objects (Section 3.2.10) representing the banner sizes permitted. If none are specified, then use of the `h` and `w` attributes is highly recommended. |
 | `w` | integer | Exact width in device-independent pixels (DIPS); recommended if no `Format` objects are specified. |
 | `h` | integer | Exact height in device-independent pixels (DIPS); recommended if no `Format` objects are specified. |
 | `btype` | integer array | Blocked banner ad types.<br>Values:<br>1 = XHTML Text Ad,<br>2 = XHTML Banner Ad,<br>3 = JavaScript Ad,<br>4 = iframe. |
 | `battr` | integer array | Blocked creative attributes. Refer to [List: Creative Attributes](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--creative-attributes-) in AdCOM 1.0. |
 | `pos` | integer | Ad position on screen. Refer to [List: Placement Positions](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--placement-positions-) in AdCOM 1.0. |
-| `mimes` | string array | Content MIME types supported. Popular MIME types may include, `“image/jpeg”` and `“image/gif”` . |
+| `mimes` | string array | Content MIME types supported. Popular MIME types may include `“image/jpeg”` and `“image/gif”`. |
 | `topframe` | integer | Indicates if the banner is in the top frame as opposed to an iframe, where 0 = no, 1 = yes. |
 | `expdir` | integer array | Directions in which the banner may expand. Refer to [List: Expandable Directions](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--expandable-directions-) in AdCOM 1.0. |
 | `api` | integer array | List of supported API frameworks for this impression. Refer to [List: API Frameworks](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--api-frameworks-) in AdCOM 1.0. If an API is not explicitly listed, it is assumed not to be supported. |
@@ -679,25 +679,25 @@ The presence of a `Video` as a subordinate of the `Imp` object indicates that th
 
 | Attribute | Type | Description |
 | --- | --- | --- |
-| `mimes` | string array; required | Content MIME types supported (e.g., “ `video/mp4` ”). |
-| `minduration` | integer; default 0 recommended | Minimum video ad duration in seconds. This field is mutually exclusive with `rqddurs` ; only one of `minduration` and `rqddurs` may be in a bid request. |
-| `maxduration` | integer; recommended | Maximum video ad duration in seconds. This field is mutually exclusive with `rqddurs` ; only one of `maxduration` and `rqddurs` may be in a bid request. |
+| `mimes` | string array; required | Content MIME types supported (e.g., `"video/mp4"`). |
+| `minduration` | integer; default 0 recommended | Minimum video ad duration in seconds. This field is mutually exclusive with `rqddurs`; only one of `minduration` and `rqddurs` may be in a bid request. |
+| `maxduration` | integer; recommended | Maximum video ad duration in seconds. This field is mutually exclusive with `rqddurs`; only one of `maxduration` and `rqddurs` may be in a bid request. |
 | `startdelay` | integer; recommended | Indicates the start delay in seconds for pre-roll, mid-roll, or post-roll ad placements. Refer to [List: Start Delay Modes](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--start-delay-modes-) in AdCOM 1.0. |
 | `maxseq` | integer; recommended | Indicates the maximum number of ads that may be served into a “dynamic” video ad pod (where the precise number of ads is not predetermined by the seller). See Section 7.6 for more details. |
-| `poddur` | integer; recommended | Indicates the total amount of time in seconds that advertisers may fill for a “dynamic” video ad pod (See Section 7.6 for more details), or the dynamic portion of a “hybrid” ad pod. This field is required only for the dynamic portion(s) of video ad pods. This field refers to the length of the entire ad break, whereas `minduration` / `maxduration` / `rqddurs` are constraints relating to the slots that make up the pod. |
+| `poddur` | integer; recommended | Indicates the total amount of time in seconds that advertisers may fill for a “dynamic” video ad pod (See Section 7.6 for more details), or the dynamic portion of a “hybrid” ad pod. This field is required only for the dynamic portion(s) of video ad pods. This field refers to the length of the entire ad break, whereas `minduration`/`maxduration`/`rqddurs`are constraints relating to the slots that make up the pod. |
 | `protocols` | integer array; recommended | Array of supported video protocols. Refer to [List: Creative Substypes - Audio/Video](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--creative-subtypes---audiovideo-) in AdCOM 1.0. |
 | `w` | integer; recommended | Width of the video player in device-independent pixels (DIPS). |
 | `h` | integer; recommended | Height of the video player in device-independent pixels (DIPS). |
-| `podid` | string | Unique identifier indicating that an impression opportunity belongs to a video ad pod. If multiple impression opportunities within a bid request share the same `podid` , this indicates that those impression opportunities belong to the same video ad pod. |
-| `podseq` | integer; default 0 | The sequence (position) of the video ad pod within a content stream. Refer to [in AdCOM 1.0 for guidance on the use of this field.](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_podsequence) |
-| `rqddurs` | integer array | Precise acceptable durations for video creatives in seconds. This field specifically targets the Live TV use case where non-exact ad durations would result in undesirable ‘dead air’. This field is mutually exclusive with `minduration` and `maxduration` ; if rqddurs is specified, `minduration` and `maxduration` must not be specified and vice versa. |
+| `podid` | string | Unique identifier indicating that an impression opportunity belongs to a video ad pod. If multiple impression opportunities within a bid request share the same `podid`, this indicates that those impression opportunities belong to the same video ad pod. |
+| `podseq` | integer; default 0 | The sequence (position) of the video ad pod within a content stream. Refer to [AdCOM 1.0 for guidance on the use of this field.](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_podsequence) |
+| `rqddurs` | integer array | Precise acceptable durations for video creatives in seconds. This field specifically targets the Live TV use case where non-exact ad durations would result in undesirable ‘dead air’. This field is mutually exclusive with `minduration` and `maxduration`; if rqddurs is specified, `minduration` and `maxduration` must not be specified and vice versa. |
 | `placement` | integer; DEPRECATED | Deprecated as of OpenRTB 2.6-202303. Use `plcmt` instead. |
 | `plcmt` | integer | Video placement type for the impression. Refer to [List: Plcmt Subtypes - Video](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/develop/AdCOM%20v1.0%20FINAL.md#list_plcmtsubtypesvideo) in AdCOM 1.0. |
-| `linearity` | integer | Indicates if the impression must be linear, nonlinear, etc. If none specified, assume all are allowed. Refer to [List: Linearity Modes](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--linearity-modes-) in AdCOM 1.0. Note that this field describes the expected VAST response and not whether a placement is in-stream, out-stream, etc. For that, see `placement` . |
-| `skip` | integer | Indicates if the player will allow the video to be skipped, where 0 = no, 1 = yes. If a bidder sends markup/creative that is itself skippable, the `Bid` object should include the `attr` array with an element of 16 indicating skippable video. Refer to [List: Creative Attributes](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--creative-attributes-) in AdCOM 1.0. |
+| `linearity` | integer | Indicates if the impression must be linear, nonlinear, etc. If none specified, assume all are allowed. Refer to [List: Linearity Modes](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--linearity-modes-) in AdCOM 1.0. Note that this field describes the expected VAST response and not whether a placement is in-stream, out-stream, etc. For that, see `placement`. |
+| `skip` | integer | Indicates if the player will allow the video to be skipped, where 0 = no, 1 = yes.<br>If a bidder sends markup/creative that is itself skippable, the `Bid` object should include the `attr` array with an element of 16 indicating skippable video. Refer to [List: Creative Attributes](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--creative-attributes-) in AdCOM 1.0. |
 | `skipmin` | integer; default 0 | Videos of total duration greater than this number of seconds can be skippable; only applicable if the ad is skippable. |
 | `skipafter` | integer; default 0 | Number of seconds a video must play before skipping is enabled; only applicable if the ad is skippable. |
-| `sequence` | integer; default 0 DEPRECATED | Deprecated as of OpenRTB 2.6. Use `slotinpod` |
+| `sequence` | integer; default 0<br>DEPRECATED | Deprecated as of OpenRTB 2.6. Use `slotinpod` |
 | `slotinpod` | integer; default 0 | For video ad pods, this value indicates that the seller can guarantee delivery against the indicated slot position in the pod. Refer to [List: Slot Position in Pod](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--slot-position-in-pod-) in AdCOM 1.0 guidance on the use of this field. |
 | `mincpmpersec` | float | Minimum CPM per second. This is a price floor for the "dynamic" portion of a video ad pod, relative to the duration of bids an advertiser may submit. |
 | `battr` | integer array | Blocked creative attributes. Refer to [List: Creative Attributes](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--creative-attributes-) in AdCOM 1.0. |
@@ -712,7 +712,7 @@ The presence of a `Video` as a subordinate of the `Imp` object indicates that th
 | `companionad` | object array | Array of `Banner` objects (Section 3.2.6) if companion ads are available. |
 | `api` | integer array | List of supported API frameworks for this impression. Refer to [List: API Frameworks](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--api-frameworks-) in AdCOM 1.0. If an API is not explicitly listed, it is assumed not to be supported. |
 | `companiontype` | integer array | Supported VAST companion ad types. Refer to [List: Companion Types](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--companion-types-) in AdCOM 1.0. Recommended if companion `Banner` objects are included via the `companionad` array. If one of these banners will be rendered as an end-card, this can be specified using the `vcm` attribute with the particular banner (Section 3.2.6). |
-| `poddedupe` | enum array PROVISIONAL | Indicates pod deduplication settings that will be applied to bid responses. Refer to [List: Pod Deduplication](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/main/AdCOM%20v1.0%20FINAL.md#list--pod-deduplication-settings-) in AdCOM 1.0. |
+| `poddedupe` | enum array<br>PROVISIONAL | Indicates pod deduplication settings that will be applied to bid responses. Refer to [List: Pod Deduplication](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/main/AdCOM%20v1.0%20FINAL.md#list--pod-deduplication-settings-) in AdCOM 1.0. |
 | `durfloors` | object array | An array of `DurFloors` objects (Section 3.2.35) indicating the floor prices for video creatives of various durations that the buyer may bid with. |
 | `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
 
@@ -727,16 +727,16 @@ The presence of a `Audio` as a subordinate of the `Imp` object indicates that th
 
 | Attribute | Type | Description |
 | --- | --- | --- |
-| `mimes` | string array; required | Content MIME types supported (e.g., `“audio/mp4”` ). |
-| `minduration` | integer; default 0 recommended | Minimum audio ad duration in seconds. This field is mutually exclusive with `rqddurs` ; only one of `minduration` and `rqddurs` may be in a bid request. |
-| `maxduration` | integer; recommended | Maximum audio ad duration in seconds. This field is mutually exclusive with `rqddurs` ; only one of `maxduration` and `rqddurs` may be in a bid request. |
-| `poddur` | integer; recommended | Indicates the total amount of time that advertisers may fill for a "dynamic" audio ad pod, or the dynamic portion of a "hybrid" ad pod. This field is required only for the dynamic portion(s) of audio ad pods. This field refers to the length of the entire ad break, wheras `minduration` / `maxduration` / `rqddurs` are constraints relating to the slots that make up the pod. |
+| `mimes` | string array; required | Content MIME types supported (e.g.,`“audio/mp4”`). |
+| `minduration` | integer; default 0 recommended | Minimum audio ad duration in seconds. This field is mutually exclusive with `rqddurs`; only one of `minduration` and `rqddurs` may be in a bid request. |
+| `maxduration` | integer; recommended | Maximum audio ad duration in seconds. This field is mutually exclusive with `rqddurs`; only one of `maxduration` and `rqddurs` may be in a bid request. |
+| `poddur` | integer; recommended | Indicates the total amount of time that advertisers may fill for a "dynamic" audio ad pod, or the dynamic portion of a "hybrid" ad pod. This field is required only for the dynamic portion(s) of audio ad pods. This field refers to the length of the entire ad break, wheras `minduration`/`maxduration`/`rqddurs`are constraints relating to the slots that make up the pod. |
 | `protocols` | integer array; recommended | Array of supported audio protocols. Refer to [List: Creative Subtypes - Audio/Video](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--creative-subtypes---audiovideo-) in AdCOM 1.0. |
 | `startdelay` | integer; recommended | Indicates the start delay in seconds for pre-roll, mid-roll, or post-roll ad placements. Refer to [List: Start Delay Modes](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--start-delay-modes-) in AdCOM 1.0. |
-| `rqddurs` | integer array | Precise acceptable durations for audio creatives in seconds. This field specifically targets the live audio/radio use case where non-exact ad durations would result in undesirable 'dead air'. This field is mutually exclusive with `minduraiton` and `maxduration` ; if `rqddurs` is specified, `minduraiton` and `maxduration` must not be specified and vice versa. |
-| `podid` | string | Unique identifier indicating that an impression opportunity belongs to an audio ad pod. If multiple impression opportunities within a bid request share the same `podid` , this indicates that those impression opportunities belong to the same audio ad pod. |
+| `rqddurs` | integer array | Precise acceptable durations for audio creatives in seconds. This field specifically targets the live audio/radio use case where non-exact ad durations would result in undesirable 'dead air'. This field is mutually exclusive with `minduraiton` and `maxduration`; if `rqddurs` is specified, `minduraiton` and `maxduration` must not be specified and vice versa. |
+| `podid` | string | Unique identifier indicating that an impression opportunity belongs to an audio ad pod. If multiple impression opportunities within a bid request share the same `podid`, this indicates that those impression opportunities belong to the same audio ad pod. |
 | `podseq` | integer; default 0 | The sequence (position) of the audio ad pod within a content stream. Refer to [List: Pod Sequence](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--pod-sequence-) in AdCOM 1.0 for guidance on the use of this field. |
-| `sequence` | integer; default 0 DEPRECATED | Deprecated as of OpenRTB 2.6. Use `slotinpod` |
+| `sequence` | integer; default 0<br>DEPRECATED | Deprecated as of OpenRTB 2.6. Use `slotinpod` |
 | `slotinpod` | integer; default 0 | For audio ad pods, this value indicates that the seller can guarantee delivery against the indicated slot position in the pod. Refer to [List: Slot Position in Pod](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--slot-position-in-pod-) in AdCOM 1.0 guidance on the use of this field. |
 | `mincpmpersec` | float | Minimum CPM per second. This is a price floor for the “dynamic” portion of an audio ad pod, relative to the duration of bids an advertiser may submit. |
 | `battr` | integer array | Blocked creative attributes. Refer to [List: Creative Attributes](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--creative-attributes-) in AdCOM 1.0 |
@@ -768,7 +768,7 @@ The presence of a `Native` as a subordinate of the `Imp` object indicates that t
 
 | Attribute | Type | Description |
 | --- | --- | --- |
-| `request` | string; required | Request payload complying with the [Native Ad Specification](https://iabtechlab.com/standards/openrtb-native/) . The root node of the payload, "native", was dropped in the Native Ads Specification 1.1. For Native 1.0, this is a JSON-encoded string consisting of a unnamed root object, with a single subordinate object named 'native', which is the Native Markup Request object, section 4.1 of OpenRTB Native 1.0 specification. For Native 1.1 and higher, this is a JSON-encoded string consisting of an unnamed root object which is itself the Native Markup Request Object, section 4.1 of OpenRTB Native 1.1+ . |
+| `request` | string; required | Request payload complying with the [Native Ad Specification](https://iabtechlab.com/standards/openrtb-native/). The root node of the payload, "native", was dropped in the Native Ads Specification 1.1.<br>For Native 1.0, this is a JSON-encoded string consisting of a unnamed root object, with a single subordinate object named 'native', which is the Native Markup Request object, section 4.1 of OpenRTB Native 1.0 specification.<br>For Native 1.1 and higher, this is a JSON-encoded string consisting of an unnamed root object which is itself the Native Markup Request Object, section 4.1 of OpenRTB Native 1.1+ . |
 | `ver` | string; recommended | Version of the Dynamic Native Ads API to which `request` complies; highly recommended for efficient parsing. |
 | `api` | integer array | List of supported API frameworks for this impression. Refer to [List: API Frameworks](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--api-frameworks-) in AdCOM. If an API is not explicitly listed, it is assumed not to be supported. |
 | `battr` | integer array | Blocked creative attributes. Refer to [List: Creative Attributes](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--creative-attributes-) in AdCOM. |
@@ -812,7 +812,7 @@ This object constitutes a specific deal that was struck between a buyer and a se
 | `bidfloor` | float; default 0 | Minimum bid for this impression expressed in CPM. |
 | `bidfloorcur` | string; default "USD" | Currency specified using ISO-4217 alpha codes. This may be different from bid currency returned by bidder if this is allowed by the exchange. This field does not inherit from `Imp.bidfloorcur`; it is either explicitly specified or defaults to USD. |
 | `at` | integer | Optional override of the overall auction type of the bid request, where 1 = First Price, 2 = Second Price Plus, 3 = the value passed in `bidfloor` is the agreed upon deal price. Additional auction types can be defined by the exchange. |
-| `wseat` | string array | Allowed list of buyer seats (e.g., advertisers, agencies) allowed to bid on this deal. IDs of seats and the buyer’s customers to which they refer must be coordinated between bidders and the exchange a priori . Omission implies no seat restrictions. |
+| `wseat` | string array | Allowed list of buyer seats (e.g., advertisers, agencies) allowed to bid on this deal. IDs of seats and the buyer’s customers to which they refer must be coordinated between bidders and the exchange a priori. Omission implies no seat restrictions. |
 | `wadomain` | string array | Array of advertiser domains (e.g., advertiser.com) allowed to bid on this deal. Omission implies no advertiser restrictions. |
 | `guar` | integer, default 0 | Indicates that the deal is of type `guaranteed` and the bidder must bid on the deal, where 0 = not a guaranteed deal, 1 = guaranteed deal. |
 | `mincpmpersec` | float | Minimum CPM per second. This is a price floor for video or audio impression opportunities, relative to the duration of bids an advertiser may submit. |
@@ -842,9 +842,9 @@ This object should be included if the ad supported content is a website as oppos
 | `publisher` | object | Details about the Publisher (Section 3.2.15) of the site. |
 | `content` | object | Details about the Content (Section 3.2.16) within the site. |
 | `keywords` | string | Comma separated list of keywords about the site. Only one of `keywords` or `kwarray` may be present. |
-| `kwarray` | string array | Array of keywords about the site. Only one of `keywords` or `kwarray` may be present. | `inventorypartnerdomain` | string | A domain to be used for inventory authorization in the case of inventory sharing arrangements between a site owner and content owner. This field is typically used by authorization crawlers to establish the domain of the content owner, who has the right to monetize some portion of ad inventory within the site. The content owner's domain should be listed in the site owner's ads.txt file as an `inventorypartnerdomain` . Authorization for supply from the `inventorypartnerdomain` will be published in the ads.txt file on the root of that domain. Refer to [the ads.txt 1.1 spec](https://iabtechlab.com/wp-content/uploads/2022/04/Ads.txt-1.1.pdf) for more details. | `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
-| `inventorypartnerdomain` | string | A domain to be used for inventory authorization in the case of inventory sharing arrangements between a site owner and content owner. This field is typically used by authorization crawlers to establish the domain of the content owner, who has the right to monetize some portion of ad inventory within the site. The content owner's domain should be listed in the site owner's ads.txt file as an `inventorypartnerdomain` . Authorization for supply from the `inventorypartnerdomain` will be published in the ads.txt file on the root of that domain. Refer to [the ads.txt 1.1 spec](https://iabtechlab.com/wp-content/uploads/2022/04/Ads.txt-1.1.pdf) for more details. |
-| `inventorypartnerdomain` | string | A domain to be used for inventory authorization in the case of inventory sharing arrangements between a site owner and content owner. This field is typically used by authorization crawlers to establish the domain of the content owner, who has the right to monetize some portion of ad inventory within the site. The content owner's domain should be listed in the site owner's ads.txt file as an `inventorypartnerdomain` . Authorization for supply from the `inventorypartnerdomain` will be published in the ads.txt file on the root of that domain. Refer to [the ads.txt 1.1 spec](https://iabtechlab.com/wp-content/uploads/2022/04/Ads.txt-1.1.pdf) for more details. |
+| `kwarray` | string array | Array of keywords about the site. Only one of `keywords` or `kwarray` may be present. | `inventorypartnerdomain` | string | A domain to be used for inventory authorization in the case of inventory sharing arrangements between a site owner and content owner. This field is typically used by authorization crawlers to establish the domain of the content owner, who has the right to monetize some portion of ad inventory within the site. The content owner's domain should be listed in the site owner's ads.txt file as an `inventorypartnerdomain`. Authorization for supply from the `inventorypartnerdomain` will be published in the ads.txt file on the root of that domain. Refer to [the ads.txt 1.1 spec](https://iabtechlab.com/wp-content/uploads/2022/04/Ads.txt-1.1.pdf) for more details. | `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
+| `inventorypartnerdomain` | string | A domain to be used for inventory authorization in the case of inventory sharing arrangements between a site owner and content owner. This field is typically used by authorization crawlers to establish the domain of the content owner, who has the right to monetize some portion of ad inventory within the site. The content owner's domain should be listed in the site owner's ads.txt file as an `inventorypartnerdomain`. Authorization for supply from the `inventorypartnerdomain` will be published in the ads.txt file on the root of that domain. Refer to [the ads.txt 1.1 spec](https://iabtechlab.com/wp-content/uploads/2022/04/Ads.txt-1.1.pdf) for more details. |
+| `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
 
 
 
@@ -870,10 +870,9 @@ This object should be included if the ad supported content is a non-browser appl
 | `publisher` | object | Details about the Publisher (Section 3.2.15) of the app. |
 | `content` | object | Details about the Content (Section 3.2.16) within the app. |
 | `keywords` | string | Comma separated list of keywords about the app. Only one of `keywords` or `kwarray` may be present. |
-| `kwarray` | string array | Array of keywords about the app. Only one of `keywords` or `kwarray` may be present. | `inventorypartnerdomain` | string | A domain to be used for inventory authorization in the case of inventory sharing arrangements between an app owner and content owner. This field is typically used by authorization crawlers to establish the domain of the content owner, who has the right to monetize some portion of ad inventory within the app. The content owner's domain should be listed in the app owner's app-ads.txt file as an `inventorypartnerdomain` . Authorization for supply from the `inventorypartnerdomain` will be published in the ads.txt file on the root of that domain. Refer to [the ads.txt 1.1 spec](https://iabtechlab.com/wp-content/uploads/2022/04/Ads.txt-1.1.pdf) for more details. | `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
-| `inventorypartnerdomain` | string | A domain to be used for inventory authorization in the case of inventory sharing arrangements between an app owner and content owner. This field is typically used by authorization crawlers to establish the domain of the content owner, who has the right to monetize some portion of ad inventory within the app. The content owner's domain should be listed in the app owner's app-ads.txt file as an `inventorypartnerdomain` . Authorization for supply from the `inventorypartnerdomain` will be published in the ads.txt file on the root of that domain. Refer to [the ads.txt 1.1 spec](https://iabtechlab.com/wp-content/uploads/2022/04/Ads.txt-1.1.pdf) for more details. |
-| `inventorypartnerdomain` | string | A domain to be used for inventory authorization in the case of inventory sharing arrangements between an app owner and content owner. This field is typically used by authorization crawlers to establish the domain of the content owner, who has the right to monetize some portion of ad inventory within the app. The content owner's domain should be listed in the app owner's app-ads.txt file as an `inventorypartnerdomain` . Authorization for supply from the `inventorypartnerdomain` will be published in the ads.txt file on the root of that domain. Refer to [the ads.txt 1.1 spec](https://iabtechlab.com/wp-content/uploads/2022/04/Ads.txt-1.1.pdf) for more details. |
-
+| `kwarray` | string array | Array of keywords about the app. Only one of `keywords` or `kwarray` may be present. | `inventorypartnerdomain` | string | A domain to be used for inventory authorization in the case of inventory sharing arrangements between an app owner and content owner. This field is typically used by authorization crawlers to establish the domain of the content owner, who has the right to monetize some portion of ad inventory within the app. The content owner's domain should be listed in the app owner's app-ads.txt file as an `inventorypartnerdomain`. Authorization for supply from the `inventorypartnerdomain` will be published in the ads.txt file on the root of that domain. Refer to [the ads.txt 1.1 spec](https://iabtechlab.com/wp-content/uploads/2022/04/Ads.txt-1.1.pdf) for more details. | `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
+| `inventorypartnerdomain` | string | A domain to be used for inventory authorization in the case of inventory sharing arrangements between an app owner and content owner. This field is typically used by authorization crawlers to establish the domain of the content owner, who has the right to monetize some portion of ad inventory within the app. The content owner's domain should be listed in the app owner's app-ads.txt file as an `inventorypartnerdomain`. Authorization for supply from the `inventorypartnerdomain` will be published in the ads.txt file on the root of that domain. Refer to [the ads.txt 1.1 spec](https://iabtechlab.com/wp-content/uploads/2022/04/Ads.txt-1.1.pdf) for more details. |
+| `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
 
 
 
@@ -902,13 +901,13 @@ This object describes the content in which the impression will appear, which may
 | --- | --- | --- |
 | `id` | string | Publisher-provided ID uniquely identifying the content. |
 | `episode` | integer | Episode number. |
-| `title` | string | Content title. *Video Examples:* “Search Committee” (television), “A New Hope” (movie), or “Endgame” (made for web). *Non-Video Example:* “Why an Antarctic Glacier Is Melting So Quickly” (Time magazine article). |
-| `series` | string | Content series. *Video Examples:* “The Office” (television), “Star Wars” (movie), or “Arby ‘N’ The Chief” (made for web). *Non-Video Example:* “Ecocentric” (Time Magazine blog). |
+| `title` | string | Content title.<br>*Video Examples:* “Search Committee” (television), “A New Hope” (movie), or “Endgame” (made for web).<br>*Non-Video Example:* “Why an Antarctic Glacier Is Melting So Quickly” (Time magazine article). |
+| `series` | string | Content series.<br>*Video Examples:* “The Office” (television), “Star Wars” (movie), or “Arby ‘N’ The Chief” (made for web).<br>*Non-Video Example:* “Ecocentric” (Time Magazine blog). |
 | `season` | string | Content season (e.g., “Season 3”). |
 | `artist` | string | Artist credited with the content. |
 | `genre` | string | Genre that best describes the content (e.g., rock, pop, etc). |
-| `gtax` | int; default 9 | The taxonomy in use. Refer to list [List: Category Taxonomies](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_categorytaxonomies) in AdCOM 1.0 for values. If no gtax field is supplied rows listed, Content Category Taxonomy 3.1 is assumed |
-| `genres` | string array | Unique ID(s) for the genre of the content as listed in the taxonomy defined by the gtax field. If no gtax field is supplied, subset of rows listed in [CTV Genre Mapping](https://github.com/InteractiveAdvertisingBureau/Taxonomies/blob/main/Taxonomy%20Mappings/CTV%20Genre%20Mapping.tsv) of [Content Category Taxonomy 3.1](https://github.com/InteractiveAdvertisingBureau/Taxonomies/blob/main/Content%20Taxonomies/Content%20Taxonomy%203.1.tsv) are assumed See [Section 7.13 of Implementation Guidance](implementation.md#genre) for additional detail. |
+| `gtax` | int; default 9 | The taxonomy in use. Refer to list [List: Category Taxonomies](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_categorytaxonomies) in AdCOM 1.0 for values.<br><br>If no gtax field is supplied rows listed, Content Category Taxonomy 3.1 is assumed |
+| `genres` | string array | Unique ID(s) for the genre of the content as listed in the taxonomy defined by the gtax field. If no gtax field is supplied, subset of rows listed in [CTV Genre Mapping](https://github.com/InteractiveAdvertisingBureau/Taxonomies/blob/main/Taxonomy%20Mappings/CTV%20Genre%20Mapping.tsv) of [Content Category Taxonomy 3.1](https://github.com/InteractiveAdvertisingBureau/Taxonomies/blob/main/Content%20Taxonomies/Content%20Taxonomy%203.1.tsv) are assumed.<br><br>See [Section 7.13 of Implementation Guidance](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/2.6-202506/implementation.md#genre) for additional detail. |
 | `album` | string | Album to which the content belongs; typically for audio. |
 | `isrc` | string | International Standard Recording Code conforming to ISO- 3901. |
 | `producer` | object | Details about the content `Producer` (Section 3.2.17). |
@@ -960,7 +959,7 @@ This object provides information pertaining to the device through which the user
 | `geo` | object; recommended | Location of the device assumed to be the user’s current location defined by a `Geo` object (Section 3.2.19). |
 | `dnt` | integer; recommended | Standard “Do Not Track” flag as set in the header by the browser, where 0 = tracking is unrestricted, 1 = do not track. |
 | `lmt` | integer; recommended | “Limit Ad Tracking” signal commercially endorsed (e.g., iOS, Android), where 0 = tracking is unrestricted, 1 = tracking must be limited per commercial guidelines. |
-| `ua` | string | Browser user agent string. This field represents a raw user agent string from the browser. For backwards compatibility, exchanges are recommended to always populate `ua` with the User-Agent string, when available from the end user’s device, even if an alternative representation, such as the User-Agent Client-Hints, is available and is used to populate `sua` . No inferred or approximated user agents are expected in this field. If a client supports User-Agent Client Hints, and `sua` field is present, bidders are recommended to rely on `sua` for detecting device type, browser type and version and other purposes that rely on the user agent information, and ignore `ua` field. This is because the `ua` may contain a frozen or reduced user agent string. |
+| `ua` | string | Browser user agent string. This field represents a raw user agent string from the browser. For backwards compatibility, exchanges are recommended to always populate `ua` with the User-Agent string, when available from the end user’s device, even if an alternative representation, such as the User-Agent Client-Hints, is available and is used to populate `sua`. No inferred or approximated user agents are expected in this field.<br>If a client supports User-Agent Client Hints, and `sua` field is present, bidders are recommended to rely on `sua` for detecting device type, browser type and version and other purposes that rely on the user agent information, and ignore `ua` field. This is because the `ua` may contain a frozen or reduced user agent string. |
 | `sua` | object | Structured user agent information defined by a `UserAgent` object (see Section 3.2.29). If both `ua` and `sua` are present in the bid request, `sua` should be considered the more accurate representation of the device attributes. This is because the `ua` may contain a frozen or reduced user agent string. |
 | `ip` | string | IPv4 address closest to device. |
 | `ipv6` | string | IP address closest to device as IPv6. |
@@ -982,7 +981,7 @@ This object provides information pertaining to the device through which the user
 | `carrier` | string | Carrier or ISP (e.g., “VERIZON”) using exchange curated string names which should be published to bidders *a priori*. |
 | `mccmnc` | string | Mobile carrier as the concatenated MCC-MNC code (e.g., “310-005” identifies Verizon Wireless CDMA in the USA). Refer to https://en.wikipedia.org/wiki/Mobile_country_code for further examples. Note that the dash between the MCC and MNC parts is required to remove parsing ambiguity. The MCC-MNC values represent the SIM installed on the device and do not change when a device is roaming. Roaming may be inferred by a combination of the MCC-MNC, geo, IP and other data signals. |
 | `connectiontype` | integer | Network connection type. Refer to [List: Connection Types](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--connection-types-) in AdCOM 1.0. |
-| `ifa` | string | ID sanctioned for advertiser use in the clear (i.e., not hashed) Unless prior arrangements have been made between the buyer and the seller directly, the value in this field is expected to be an ID derived from a call to an advertising API provided by the device’s Operating System. |
+| `ifa` | string | ID sanctioned for advertiser use in the clear (i.e., not hashed)<br>Unless prior arrangements have been made between the buyer and the seller directly, the value in this field is expected to be an ID derived from a call to an advertising API provided by the device’s Operating System. |
 | `didsha1` | string; DEPRECATED | Deprecated as of OpenRTB 2.6. |
 | `didmd5` | string; DEPRECATED | Deprecated as of OpenRTB 2.6. |
 | `dpidsha1` | string; DEPRECATED | Deprecated as of OpenRTB 2.6. |
@@ -1004,8 +1003,8 @@ The `lat`/`lon` attributes should only be passed if they conform to the accuracy
 | --- | --- | --- |
 | `lat` | float | Latitude from -90.0 to +90.0, where negative is south. |
 | `lon` | float | Longitude from -180.0 to +180.0, where negative is west. |
-| `type` | integer | Source of location data; recommended when passing `lat` / `lon` . Refer to [List: Location Types](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--location-types-) in AdCOM 1.0. |
-| `accuracy` | integer | Estimated location accuracy in meters; recommended when `lat` / `lon` are specified and derived from a device’s location services (i.e., type = 1). Note that this is the accuracy as reported from the device. Consult OS specific documentation (e.g., Android, iOS) for exact interpretation. |
+| `type` | integer | Source of location data; recommended when passing `lat`/`lon`. Refer to [List: Location Types](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--location-types-) in AdCOM 1.0. |
+| `accuracy` | integer | Estimated location accuracy in meters; recommended when `lat`/`lon` are specified and derived from a device’s location services (i.e., type = 1). Note that this is the accuracy as reported from the device. Consult OS specific documentation (e.g., Android, iOS) for exact interpretation. |
 | `lastfix` | integer | Number of seconds since this geolocation fix was established. Note that devices may cache location data across multiple fetches. Ideally, this value should be from the time the actual fix was taken. |
 | `ipservice` | integer | Service or provider used to determine geolocation from IP address if applicable (i.e., type = 2). Refer to [List: IP Location Services](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--ip-location-services-) in AdCOM 1.0. |
 | `country` | string | Country code using ISO-3166-1-alpha-3. |
@@ -1018,6 +1017,7 @@ The `lat`/`lon` attributes should only be passed if they conform to the accuracy
 | `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
 
 
+
 ### 3.2.20 - Object: User <a name="objectuser"></a>
 
 This object contains information known or derived about the human user of the device (i.e., the audience for advertising). The user `id` is an exchange artifact and may be subject to rotation or other privacy policies. However, when present, this user ID should be stable long enough to serve reasonably as the basis for frequency capping and retargeting.
@@ -1026,8 +1026,8 @@ This object contains information known or derived about the human user of the de
 
 | Attribute | Type | Description |
 | --- | --- | --- |
-| `id` | string | Exchange-specific ID for the user. Unless prior arrangements have been made between the buyer and the seller directly, the value in this field is expected to be derived from an ID sync. (see [Appendix: Cookie Based ID Syncing)](#appendixc) |
-| `buyeruid` | string | Buyer-specific ID for the user as mapped by the exchange for the buyer. Unless prior arrangements have been made between the buyer and the seller directly, the value in this field is expected to be derived from an ID sync. (see [Appendix: Cookie Based ID Syncing)](#appendixc) |
+| `id` | string | Exchange-specific ID for the user.<br>Unless prior arrangements have been made between the buyer and the seller directly, the value in this field is expected to be derived from an ID sync. (see [Appendix: Cookie Based ID Syncing)](#appendixc) |
+| `buyeruid` | string | Buyer-specific ID for the user as mapped by the exchange for the buyer.<br>Unless prior arrangements have been made between the buyer and the seller directly, the value in this field is expected to be derived from an ID sync. (see [Appendix: Cookie Based ID Syncing)](#appendixc) |
 | `yob` | integer; DEPRECATED | Deprecated as of OpenRTB 2.6. |
 | `gender` | string; DEPRECATED | Deprecated as of OpenRTB 2.6. |
 | `keywords` | string | Comma separated list of keywords, interests, or intent. Only one of `keywords` or `kwarray` may be present. |
@@ -1120,11 +1120,11 @@ This object is associated with a `SupplyChain` object as an array of nodes. Thes
 | Attribute | Type | Description |
 | --- | --- | --- |
 | `asi` | string; required | The canonical domain name of the SSP, Exchange, Header Wrapper, etc system that bidders connect to. This may be the operational domain of the system, if that is different than the parent corporate domain, to facilitate WHOIS and reverse IP lookups to establish clear ownership of the delegate system. This should be the same value as used to identify sellers in an ads.txt file if one exists. |
-| `sid` | string; required | The identifier associated with the seller or reseller account within the advertising system. This must contain the same value used in transactions (i.e. OpenRTB bid requests) in the field specified by the SSP/exchange. Typically, in OpenRTB, this is `publisher.id` . For OpenDirect it is typically the publisher’s organization ID. Should be limited to 64 characters in length. |
+| `sid` | string; required | The identifier associated with the seller or reseller account within the advertising system. This must contain the same value used in transactions (i.e. OpenRTB bid requests) in the field specified by the SSP/exchange. Typically, in OpenRTB, this is `publisher.id`. For OpenDirect it is typically the publisher’s organization ID. Should be limited to 64 characters in length. |
 | `rid` | string | The OpenRTB RequestId of the request as issued by this seller. |
-| `name` | string | The name of the company (the legal entity) that is paid for inventory transacted under the given `seller_ID` . This value is optional and should NOT be included if it exists in the advertising system’s sellers.json file. |
+| `name` | string | The name of the company (the legal entity) that is paid for inventory transacted under the given `seller_ID`. This value is optional and should NOT be included if it exists in the advertising system’s sellers.json file. |
 | `domain` | string | The business domain name of the entity represented by this node. This value is optional and should NOT be included if it exists in the advertising system’s sellers.json file. |
-| `hp` | integer | Indicates whether this node will be involved in the flow of payment for the inventory. When set to 1, the advertising system in the `asi` field pays the seller in the `sid` field, who is responsible for paying the previous node in the chain. When set to 0, this node is not involved in the flow of payment for the inventory. For version 1.0 of `SupplyChain` , this property should always be 1. Implementers should ensure that they propagate this field onwards when constructing `SupplyChain` objects in bid requests sent to a downstream advertising system. |
+| `hp` | integer | Indicates whether this node will be involved in the flow of payment for the inventory. When set to 1, the advertising system in the `asi` field pays the seller in the `sid` field, who is responsible for paying the previous node in the chain. When set to 0, this node is not involved in the flow of payment for the inventory. For version 1.0 of `SupplyChain`, this property should always be 1. Implementers should ensure that they propagate this field onwards when constructing `SupplyChain` objects in bid requests sent to a downstream advertising system. |
 | `ext` | object | Placeholder for advertising-system specific extensions to this object. |
 
 
@@ -1137,10 +1137,10 @@ Extended identifiers support in the OpenRTB specification allows buyers to use a
 
 | Attribute | Type | Description |
 | --- | --- | --- |
-| `inserter` | string | The canonical domain name of the entity (publisher, publisher monetization company, SSP, Exchange, Header Wrapper, etc.) that caused the ID array element to be added. This may be the operational domain of the system, if that is different from the parent corporate domain, to facilitate WHOIS and reverse IP lookups to establish clear ownership of the delegate system. This should be the same value as used to identify sellers in an ads.txt file if one exists. For ad tech intermediaries, this would be the domain as used in ads.txt. For publishers, this would match the domain in the `site` or `app` object. |
+| `inserter` | string | The canonical domain name of the entity (publisher, publisher monetization company, SSP, Exchange, Header Wrapper, etc.) that caused the ID array element to be added. This may be the operational domain of the system, if that is different from the parent corporate domain, to facilitate WHOIS and reverse IP lookups to establish clear ownership of the delegate system.<br>This should be the same value as used to identify sellers in an ads.txt file if one exists.<br>For ad tech intermediaries, this would be the domain as used in ads.txt. For publishers, this would match the domain in the `site` or `app` object. |
 | `source` | string | Canonical domain of the ID. |
-| `matcher` | string | Technology providing the match method as defined in `mm` . In some cases, this may be the same value as inserter. When blank, it is assumed that the `matcher` is equal to the `source` May be omitted when mm=0, 1, or 2. |
-| `mm` | int | Match method used by the `matcher` . Refer to [List: ID Match Methods](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/main/AdCOM%20v1.0%20FINAL.md#list-id-match-methods-) in AdCOM 1.0 |
+| `matcher` | string | Technology providing the match method as defined in `mm`.<br>In some cases, this may be the same value as inserter.<br>When blank, it is assumed that the `matcher` is equal to the `source`<br>May be omitted when mm=0, 1, or 2. |
+| `mm` | int | Match method used by the `matcher`. Refer to [List: ID Match Methods](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/main/AdCOM%20v1.0%20FINAL.md#list-id-match-methods-) in AdCOM 1.0 |
 | `uids` | object array | Array of extended ID `UID` objects from the given source. Refer to the `Extended Identifier UIDs` object (Section 3.2.28) |
 | `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
 
@@ -1167,17 +1167,17 @@ Structured user agent information, which can be used when a client supports [Use
 
 | Attribute | Type | Description |
 | --- | --- | --- |
-| `browsers` | array of `BrandVersion` objects; recommended | Each `BrandVersion` object (see Section 3.2.30) identifies a browser or similar software component. Implementers should send brands and versions derived from the Sec-CH-UA-Full-Version-List header*. |
-| `platform` | BrandVersion object; recommended | A `BrandVersion` object (see Section 3.2.30) that identifies the user agent’s execution platform / OS. Implementers should send a brand derived from the Sec-CH-UA-Platform header, and version derived from the Sec-CH-UA-Platform-Version header *. |
-| `mobile` | integer | 1 if the agent prefers a “mobile” version of the content, if available, i.e. optimized for small screens or touch input. 0 if the agent prefers the “desktop” or “full” content. Implementers should derive this value from the Sec-CH-UA-Mobile header *. |
-| `architecture` | string | Device’s major binary architecture, e.g. “x86” or “arm”. Implementers should retrieve this value from the Sec-CH-UA-Arch header*. |
-| `bitness` | string | Device’s bitness, e.g. “64” for 64-bit architecture. Implementers should retrieve this value from the Sec-CH-UA-Bitness header*. |
-| `model` | string | Device model. Implementers should retrieve this value from the Sec-CH-UA-Model header*. |
+| `browsers` | array of `BrandVersion` objects; recommended | Each `BrandVersion` object (see Section 3.2.30) identifies a browser or similar software component. Implementers should send brands and versions derived from the Sec-CH-UA-Full-Version-List header\*. |
+| `platform` | BrandVersion object; recommended | A `BrandVersion` object (see Section 3.2.30) that identifies the user agent’s execution platform / OS. Implementers should send a brand derived from the Sec-CH-UA-Platform header, and version derived from the Sec-CH-UA-Platform-Version header\*. |
+| `mobile` | integer | 1 if the agent prefers a “mobile” version of the content, if available, i.e. optimized for small screens or touch input. 0 if the agent prefers the “desktop” or “full” content. Implementers should derive this value from the Sec-CH-UA-Mobile header\*. |
+| `architecture` | string | Device’s major binary architecture, e.g. “x86” or “arm”. Implementers should retrieve this value from the Sec-CH-UA-Arch header\*. |
+| `bitness` | string | Device’s bitness, e.g. “64” for 64-bit architecture. Implementers should retrieve this value from the Sec-CH-UA-Bitness header\*. |
+| `model` | string | Device model. Implementers should retrieve this value from the Sec-CH-UA-Model header\*. |
 | `source` | integer; default 0 | The source of data used to create this object, [List: User-Agent Source](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--user-agent-source-) in AdCOM 1.0 |
 | `ext` | object | Placeholder for vendor specific extensions to this object. |
 
 
-* or an equivalent JavaScript accessor from [NavigatorUAData interface](https://wicg.github.io/ua-client-hints/#navigatoruadata). This header or accessor are only available for browsers that support [User-Agent Client Hints](https://wicg.github.io/ua-client-hints/). 
+\* or an equivalent JavaScript accessor from [NavigatorUAData interface](https://wicg.github.io/ua-client-hints/#navigatoruadata). This header or accessor are only available for browsers that support [User-Agent Client Hints](https://wicg.github.io/ua-client-hints/). 
 
 ### 3.2.30 - Object: BrandVersion <a name="objectbrandversion"></a>
 
@@ -1219,6 +1219,9 @@ This object should be included if the ad supported content is a Digital Out-Of-H
 |keywords    |string             |Comma separated list of keywords about the DOOH placement.                                                                                                                                                                               |
 |content     |object             |Details about the Content within the DOOH placement.                                                                                                                                                                     |
 |ext         |object             |Placeholder for exchange-specific extensions to OpenRTB.                                                                                                                                                                                 |
+
+
+
 ### 3.2.33 - Object: Refresh <a name="objectrefresh"></a>
 
 | Attribute | Type | Description |
@@ -1342,12 +1345,12 @@ A `SeatBid` object contains one or more `Bid` objects, each of which relates to 
 | `iurl` | string | URL without cache-busting to an image that is representative of the content of the campaign for ad quality/safety checking. |
 | `cid` | string | Campaign ID to assist with ad quality checking; the collection of creatives for which `iurl` should be representative. |
 | `crid` | string | Creative ID to assist with ad quality checking. |
-| `tactic` | string | Tactic ID to enable buyers to label bids for reporting to the exchange the tactic through which their bid was submitted. The specific usage and meaning of the tactic ID should be communicated between buyer and exchanges a priori . |
+| `tactic` | string | Tactic ID to enable buyers to label bids for reporting to the exchange the tactic through which their bid was submitted. The specific usage and meaning of the tactic ID should be communicated between buyer and exchanges a priori. |
 | `cattax` | integer; default 1 | The taxonomy in use. Refer to [List: Category Taxonomies](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_categorytaxonomies) for values. |
 | `cat` | string array | IAB Tech Lab content categories of the creative. The taxonomy to be used is defined by the cattax field. If no cattax field is supplied Content Taxonomy 1.0 is assumed |
 | `attr` | integer array | Set of attributes describing the creative. Refer to [List: Creative Attributes](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--creative-attributes-) in AdCOM 1.0. |
-| `apis` | integer array | List of supported APIs for the markup. If an API is not explicitly listed, it is assumed to be unsupported. Refer to [List: API Frameworks]() in AdCOM 1.0. |
-| `api` | integer; DEPRECATED | NOTE: Deprecated in favor of `apis` . |
+| `apis` | integer array | List of supported APIs for the markup. If an API is not explicitly listed, it is assumed to be unsupported. Refer to [List: API Frameworks](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/main/AdCOM%20v1.0%20FINAL.md#list_apiframeworks) in AdCOM 1.0. |
+| `api` | integer; DEPRECATED | NOTE: Deprecated in favor of `apis`. |
 | `protocol` | integer | Video response protocol of the markup if applicable. Refer to [List: Creative Subtypes - Audio/Video](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--creative-subtypes---audiovideo-) in AdCOM 1.0. |
 | `qagmediarating` | integer | Creative media rating per IQG guidelines. Refer to [List: Media Ratings](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--media-ratings-) in AdCOM 1.0. |
 | `language` | string | Language of the creative using ISO-639-1-alpha-2. The non- standard code “xx” may also be used if the creative has no linguistic content (e.g., a banner with just a company logo). Only one of `language` or `langb` should be present. |
@@ -1359,8 +1362,8 @@ A `SeatBid` object contains one or more `Bid` objects, each of which relates to 
 | `hratio` | integer | Relative height of the creative when expressing size as a ratio. Required for Flex Ads. |
 | `exp` | integer | Advisory as to the number of seconds the bidder is willing to wait between the auction and the actual impression. |
 | `dur` | integer | Duration of the video or audio creative in seconds. |
-| `mtype` | integer | Type of the creative markup so that it can properly be associated with the right sub-object of the `BidRequest.Imp.` Values: 1 = Banner 2 = Video, 3 = Audio 4 = Native |
-| `slotinpod` | integer; default 0 | Indicates that the bid response is only eligible for a specific position within a video or audio ad pod (e.g. first position, last position, or any). Refer to List: [Slot Position in Pod](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_slotpositioninpod) in AdCOM 1.0 for guidance on the use of this field. |
+| `mtype` | integer | Type of the creative markup so that it can properly be associated with the right sub-object of the `BidRequest.Imp.`<br>Values:<br>1 = Banner<br>2 = Video,<br>3 = Audio<br>4 = Native<br> |
+| `slotinpod` | integer; default 0 | Indicates that the bid response is only eligible for a specific position within a video or audio ad pod (e.g. first position, last position, or any). Refer to List:[Slot Position in Pod](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_slotpositioninpod) in AdCOM 1.0 for guidance on the use of this field. |
 | `ext` | object | Placeholder for bidder-specific extensions to OpenRTB. |
 
 
@@ -1977,7 +1980,7 @@ Following is an example of a bid response that returns the VAST document inline 
           "impid": "2",
           "price": 3.00,
           "nurl": "http://example.com/winnoticeurl",
-          "adm": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<VAST version=\"2.0\">\n<Ad id=\"12345\">\n<InLine>\n<AdSystem version=\"1.0\">SpotXchange</AdSystem>\n<AdTitle>\n<![CDATA[Sample VAST]]>\n</AdTitle>\n<Impression>http://sample.com</Impression>\n<Description>\n<![C DATA[A sample VAST feed]]>\n</Description>\n <Creatives>\n<Creative sequence=\"1\" id=\"1\">\n<Linear>\n<Duration>00:00:30</Duration>\n <TrackingEvents>< /TrackingEvents>\n<VideoClicks>\n<ClickThrough>\n<![CDATA[http://sample.com/openrtb test]]>\n</ClickThrough >\n</ VideoClicks >\n< MediaFiles >\n < MediaFile delivery =\"progressive\" bitrate=\"256\" width=\"640\" height=\"480\" type=\"video/mp4\">\n<![CDATA[http://sample.com/video.mp4]]>\n< /MediaFile>\n</MediaFiles >\n < /Linear>\n< /Creative>\n</Creatives >\n < /InLine>\n</Ad >\n < /VAST>"
+          "adm": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<VAST version=\"2.0\">\n<Ad id=\"12345\">\n<InLine>\n<AdSystem version=\"1.0\">SpotXchange</AdSystem>\n<AdTitle>\n<![CDATA[Sample VAST]]>\n</AdTitle>\n<Impression>http://sample.com</Impression>\n<Description>\n<![CDATA[A sample VAST feed]]>\n</Description>\n <Creatives>\n<Creative sequence=\"1\" id=\"1\">\n<Linear>\n<Duration>00:00:30</Duration>\n <TrackingEvents></TrackingEvents>\n<VideoClicks>\n<ClickThrough>\n<![CDATA[http://sample.com/openrtb test]]>\n</ClickThrough>\n</VideoClicks>\n<MediaFiles>\n <MediaFile delivery =\"progressive\" bitrate=\"256\" width=\"640\" height=\"480\" type=\"video/mp4\">\n<![CDATA[http://sample.com/video.mp4]]>\n</MediaFile>\n</MediaFiles>\n </Linear>\n</Creative>\n</Creatives>\n </InLine>\n</Ad>\n </VAST>"
         }
       ]
     }
@@ -2074,12 +2077,6 @@ Following is an example of a bid response that returns a native ad inline to be 
 - [7.10 - Updated Video Signals](implementation.md#videosignals)
 
 - [7.11 - Guidance on the Use of Floors](implementation.md#floors)
-  
-- [7.12 - ID Match Method Guidance](implementation.md#idmm)
-  
-- [7.13 - Using genres and gtax attributes](implementation.md#genre)
-  
-- [7.14 - Using Extended Content Identifiers](implementation.md#cids)
 
 	
 # Appendix A. Additional Information <a name="appendixa"></a>
@@ -2135,12 +2132,12 @@ This appendix serves as an index of specification changes across 2.x versions. T
 **Version 2.6-202210 (Base 2.6 version) to 2.6-202211:**
 | Section | Description |
 | --- | --- |
-| `3.1` | Object Model Update to model image to show DOOH and Qty objects |
-| `3.2.3` | Object: Regs Additional fields gpp and gpp_sid to support Global Privacy Protection string |
-| `3.2.13, 3.2.14` | Objects: Site, App Added inventorypartnerdomain (previously ext) |
-| `3.2.31` | Object: Qty New object to describe source of multiplier value in Digital Out of Home |
-| `3.2.32` | Object: DOOH New object to support programmatic buys of Digital Out of Home inventory |
-| `7.9` | Implementation Notes Addition of notes, examples and best practices for utilizing DOOH |
+| `3.1` | **Object Model** Update to model image to show DOOH and Qty objects |
+| `3.2.3` | **Object: Regs** Additional fields gpp and gpp_sid to support Global Privacy Protection string |
+| `3.2.13, 3.2.14` | **Objects: Site, App** Added inventorypartnerdomain (previously ext) |
+| `3.2.31` | **Object: Qty** New object to describe source of multiplier value in Digital Out of Home |
+| `3.2.32` | **Object: DOOH** New object to support programmatic buys of Digital Out of Home inventory |
+| `7.9` | **Implementation Notes** Addition of notes, examples and best practices for utilizing DOOH |
 
 
 **Version 2.5 to 2.6:**
@@ -2149,54 +2146,52 @@ This appendix serves as an index of specification changes across 2.x versions. T
 | Section | Description |
 | --- | --- |
 | `3.2.1, 3.2.16, 4.2.3, 3.2.18` | Added new language field to support IETF BCP 47, IETF BCP 47 offers additional layers of granularity, for example, differentiating written language versions of the same spoken language (e.g. Traditional and Simplified Chinese), https://en.wikipedia.org/wiki/IETF_language_tag |
-| `3.2.20` | Object: User added `consent` attribute (previously ext) |
-| `5` | Removed section (Enumerated Lists) All references now point to AdCOM 1.0 / OpenRTB 3.0 Lists | `3.2.1, 3.2.13, 3.2.14, 3.2.15, 3.2.16, 3.2.17, 4.2.3` | Objects: BidRequest, Site, App, Publisher, Content, Producer, Bid Use of cattax for all taxonomy references | `3.2.7, 3.2.8` | Objects: Video, Audio Added rqddurs | `3.2.7, 3.2.8` | Objects: Video, Audio Added maxseq, poddur, podid, podseq, mincpmpersec, slotinpod for pod bidding support | `4.4, 4.4.1` | Substition Macros Added AUCTION_MIN_TO_WIN | `4.2.3` | Object, Bid Added apis | `3.2.4` | Object: Imp Added rwdd | `3.2.1, 3.2.14, 4.2.3` | Objects: App, Bid, BidRequest Clarified laguage around use of storeid vs bundle | `3.2.4` | Object Imp Added ssai | `3.2.18` | Object: Device Clarified language around mccmnc and roaming | `3.2.23, 3.2.24` | Added Objects: Network, Channel, SupplyChain, SupplyChainNode, EIDs and UIDs* | `4.2.3` | Object: Bid Added mtype | `3.2.6, 3.2.7, 3.2.16` | Removed previously deprecated attributes Object: Banner, wmax, hmax, wmin, hmin, Object: Video, protocol, Object: Content, videoquality | `7.6` | Pod Bidding for Video and Audio implementers guide | `7.7` | Network and Channel object examples | `3.2.7, 3.2.8, 3.2.18, 3.2.20, 4.2.3` | Deprecated attributes Object: Video, sequence, Object: Audio, sequence, Ojbect: Device, didsha1, didmd5, dpidsha1, dpidnd5, macsha1, macmd5, Object: User, yob, gender, Object: Bid, api | `7.8` | Added Counting Billable events and tracked ads | `3.2.29, 3.2.30` | Object: UserAgent & Object Brand Version added |
+| `3.2.3` | **Object: Regs** added `gdpr` attribute (previously ext) |
+| `3.2.20` | **Object: User** added `consent` attribute (previously ext) |
 | `5` | Removed section (Enumerated Lists) All references now point to AdCOM 1.0 / OpenRTB 3.0 Lists |
-| `3.2.1, 3.2.13, 3.2.14, 3.2.15, 3.2.16, 3.2.17, 4.2.3` | Objects: BidRequest, Site, App, Publisher, Content, Producer, Bid Use of cattax for all taxonomy references |
-| `3.2.7, 3.2.8` | Objects: Video, Audio Added rqddurs |
-| `3.2.7, 3.2.8` | Objects: Video, Audio Added maxseq, poddur, podid, podseq, mincpmpersec, slotinpod for pod bidding support |
-| `4.4, 4.4.1` | Substition Macros Added AUCTION_MIN_TO_WIN |
-| `4.2.3` | Object, Bid Added apis |
-| `3.2.4` | Object: Imp Added rwdd |
-| `3.2.1, 3.2.14, 4.2.3` | Objects: App, Bid, BidRequest Clarified laguage around use of storeid vs bundle |
-| `3.2.4` | Object Imp Added ssai |
-| `3.2.18` | Object: Device Clarified language around mccmnc and roaming |
-| `3.2.23, 3.2.24` | Added Objects: Network, Channel, SupplyChain, SupplyChainNode, EIDs and UIDs* |
-| `4.2.3` | Object: Bid Added mtype |
-| `3.2.6, 3.2.7, 3.2.16` | Removed previously deprecated attributes Object: Banner, wmax, hmax, wmin, hmin, Object: Video, protocol, Object: Content, videoquality |
+| `3.2.1, 3.2.13, 3.2.14, 3.2.15, 3.2.16, 3.2.17, 4.2.3` | **Objects: BidRequest, Site, App, Publisher, Content, Producer, Bid** Use of cattax for all taxonomy references |
+| `3.2.7, 3.2.8` | **Objects: Video, Audio** Added rqddurs |
+| `3.2.7, 3.2.8` | **Objects: Video, Audio** Added maxseq, poddur, podid, podseq, mincpmpersec, slotinpod for pod bidding support |
+| `4.4, 4.4.1` | **Substitution Macros** Added AUCTION_MIN_TO_WIN |
+| `4.2.3` | **Object, Bid** Added apis |
+| `3.2.4` | **Object: Imp** Added rwdd |
+| `3.2.1, 3.2.14, 4.2.3` | **Objects: App, Bid, BidRequest** Clarified language around use of storeid vs bundle |
+| `3.2.4` | **Object Imp** Added ssai |
+| `3.2.18` | **Object: Device** Clarified language around mccmnc and roaming |
+| `3.2.23, 3.2.24` | **Added Objects:** Network, Channel, SupplyChain, SupplyChainNode, EIDs and UIDs* |
+| `4.2.3` | **Object: Bid** Added mtype |
+| `3.2.6, 3.2.7, 3.2.16` | **Removed previously deprecated attributes** Object: Banner, wmax, hmax, wmin, hmin, Object: Video, protocol, Object: Content, videoquality |
 | `7.6` | Pod Bidding for Video and Audio implementers guide |
 | `7.7` | Network and Channel object examples |
-| `3.2.7, 3.2.8, 3.2.18, 3.2.20, 4.2.3` | Deprecated attributes Object: Video, sequence, Object: Audio, sequence, Ojbect: Device, didsha1, didmd5, dpidsha1, dpidnd5, macsha1, macmd5, Object: User, yob, gender, Object: Bid, api |
+| `3.2.7, 3.2.8, 3.2.18, 3.2.20, 4.2.3` | **Deprecated attributes** Object: Video, sequence, Object: Audio, sequence, Ojbect: Device, didsha1, didmd5, dpidsha1, dpidnd5, macsha1, macmd5, Object: User, yob, gender, Object: Bid, api |
 | `7.8` | Added Counting Billable events and tracked ads |
 | `3.2.29, 3.2.30` | Object: UserAgent & Object Brand Version added |
-
 	
-
 	
 **Version 2.4 to 2.5:**
 	
 	
 | Section | Description |
 | --- | --- |
-| `2.4` | Section: Data Encoding New section added. |
-| `3.1` | Object Model: Bid Request Update to include Source and Metric objects. |
-| 3.2.1 | Object: BidRequest , Attributes bseat, wlang, and source have been added. |
-| `3.2.2` | Object: Source New Source object has been added including the Payment ID pchain attribute. |
-| `3.2.4` | Object: Imp Attribute Metric object has been added. |
-| `3.2.5` | Object: Metric New Metric object has been added. |
-| `3.2.6` | Object: Banner , Attribute vcm has been added. |
-| `3.2.7` | Object: Video , Attributes placement and playbackend have been added. Guidance added to use only the first element of attribute playbackmethod in preparation for future converson to an integer. |
-| `3.2.10` | Object: Format Attributes wratio, hratio, and wmin have been added. |
-| `3.2.4` | Object Imp Added ssai |
-| `3.2.13` | Object: Device Attribute mccmnc has been added. Attribute carrier has been clarified to eliminate a reference to using "WIFI" as a carrier. |
-| `4.2.3` | Object: Bid Attributes burl, lurl, tactic, language, wratio, and hratio have been added. |
-| `4.4` | Subsititution Macros: Macros ${AUCTION_MBR} and ${AUCTION_LOSS} have been added. A best practice has been added to use “AUDIT” for unknown values when rendering for test or quality purposes. |
-| `5.6` | List: API Frameworks Item 6 has been added. |
-| `5.9` | List: Video Placement Types New list has been added. |
-| `5.10` | List: Playback Methods Items 5-6 have been added. |
-| `5.11` | List: Playback Cessation Modes New list has been added. |
-| `5.24` | List: No-Bid Reason Codes Items 9-10 have been added. |
-| `5.25` | List: Loss Reason Codes New list has been added. |
+| `2.4` | **Section: Data Encoding** New section added. |
+| `3.1` | **Object Model: Bid Request** Update to include Source and Metric objects. |
+| `3.2.1` | **Object: BidRequest** Attributes bseat, wlang, and source have been added. |
+| `3.2.2` | **Object: Source** New Source object has been added including the Payment ID pchain attribute. |
+| `3.2.4` | **Object: Imp** Attribute Metric object has been added. |
+| `3.2.5` | **Object: Metric** New Metric object has been added. |
+| `3.2.6` | **Object: Banner** Attribute vcm has been added. |
+| `3.2.7` | **Object: Video** Attributes placement and playbackend have been added. Guidance added to use only the first element of attribute playbackmethod in preparation for future converson to an integer. |
+| `3.2.10` | **Object: Format** Attributes wratio, hratio, and wmin have been added. |
+| `3.2.4` | **Object Imp** Added ssai |
+| `3.2.13` | **Object: Device** Attribute mccmnc has been added. Attribute carrier has been clarified to eliminate a reference to using "WIFI" as a carrier. |
+| `4.2.3` | **Object: Bid** Attributes burl, lurl, tactic, language, wratio, and hratio have been added. |
+| `4.4` | **Substitution Macros:** Macros ${AUCTION_MBR} and ${AUCTION_LOSS} have been added. A best practice has been added to use “AUDIT” for unknown values when rendering for test or quality purposes. |
+| `5.6` | **List: API Frameworks** Item 6 has been added. |
+| `5.9` | **List: Video Placement Types** New list has been added. |
+| `5.10` | **List: Playback Methods** Items 5-6 have been added. |
+| `5.11` | **List: Playback Cessation Modes** New list has been added. |
+| `5.24` | **List: No-Bid Reason Codes** Items 9-10 have been added. |
+| `5.25` | **List: Loss Reason Codes** New list has been added. |
 
 
 # Appendix C. Cookie Based ID Syncing <a name="appendixc"></a>

--- a/2.6.md
+++ b/2.6.md
@@ -657,12 +657,7 @@ The presence of a `Banner` as a subordinate of the `Imp` object indicates that t
 | `format` | object array; recommended | Array of format objects (Section 3.2.10) representing the banner sizes permitted. If none are specified, then use of the `h` and `w` attributes is highly recommended. |
 | `w` | integer | Exact width in device-independent pixels (DIPS); recommended if no `Format` objects are specified. |
 | `h` | integer | Exact height in device-independent pixels (DIPS); recommended if no `Format` objects are specified. |
-| `btype` | integer array | Blocked banner ad types.<br>
-Values:<br>
-1 = XHTML Text Ad,<br>
-2 = XHTML Banner Ad,<br>
-3 = JavaScript Ad,<br>
-4 = iframe. |
+| `btype` | integer array | Blocked banner ad types.<br>Values:<br>1 = XHTML Text Ad,<br>2 = XHTML Banner Ad,<br>3 = JavaScript Ad,<br>4 = iframe. |
 | `battr` | integer array | Blocked creative attributes. Refer to [List: Creative Attributes](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--creative-attributes-) in AdCOM 1.0. |
 | `pos` | integer | Ad position on screen. Refer to [List: Placement Positions](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--placement-positions-) in AdCOM 1.0. |
 | `mimes` | string array | Content MIME types supported. Popular MIME types may include, `“image/jpeg”` and `“image/gif”` . |

--- a/2.6.md
+++ b/2.6.md
@@ -913,7 +913,7 @@ This object describes the content in which the impression will appear, which may
 | `artist` | string | Artist credited with the content. |
 | `genre` | string | Genre that best describes the content (e.g., rock, pop, etc). |
 | `gtax` | int; default 9 | The taxonomy in use. Refer to list [List: Category Taxonomies](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_categorytaxonomies) in AdCOM 1.0 for values. If no gtax field is supplied rows listed, Content Category Taxonomy 3.1 is assumed |
-| `genres` | string array | Unique ID(s) for the genre of the content as listed in the taxonomy defined by the gtax field. If no gtax field is supplied, subset of rows listed in [CTV Genre Mapping](https://github.com/InteractiveAdvertisingBureau/Taxonomies/blob/main/Taxonomy%20Mappings/CTV%20Genre%20Mapping.tsv) of [Content Category Taxonomy 3.1](https://github.com/InteractiveAdvertisingBureau/Taxonomies/blob/main/Content%20Taxonomies/Content%20Taxonomy%203.1.tsv) are assumed See [Section 7.13 of Implementation Guidance](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/2.6-202506/implementation.md#genre) for additional detail. |
+| `genres` | string array | Unique ID(s) for the genre of the content as listed in the taxonomy defined by the gtax field. If no gtax field is supplied, subset of rows listed in [CTV Genre Mapping](https://github.com/InteractiveAdvertisingBureau/Taxonomies/blob/main/Taxonomy%20Mappings/CTV%20Genre%20Mapping.tsv) of [Content Category Taxonomy 3.1](https://github.com/InteractiveAdvertisingBureau/Taxonomies/blob/main/Content%20Taxonomies/Content%20Taxonomy%203.1.tsv) are assumed See [Section 7.13 of Implementation Guidance](implementation.md#genre) for additional detail. |
 | `album` | string | Album to which the content belongs; typically for audio. |
 | `isrc` | string | International Standard Recording Code conforming to ISO- 3901. |
 | `producer` | object | Details about the content `Producer` (Section 3.2.17). |
@@ -928,9 +928,6 @@ This object describes the content in which the impression will appear, which may
 | `keywords` | string | Comma separated list of keywords describing the content. Only one of `keywords` or `kwarray` may be present. |
 | `kwarray` | string array | Array of keywords about the site. Only one of `keywords` or `kwarray` may be present. |
 | `livestream` | integer | 0 = not live, 1 = content is live (e.g., stream, live blog). |
-| `recording` | integer | An enumeration indicating how the content was recorded where 0 = pre-recorded content and 1 = real-time. See [Section 7.15 of Implementation Guidance](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/develop/implementation.md#715---additional-telemetry-for-live-events) for additional detail. |
-| `airdate` | integer | UNIX timestamp indicating when the content was first broadcast or made available to the public in the geographic region where it aired 
-(i.e. 1752057600). Content airing for the first time at the time of the bid request should use a value of -1. Content that aired prior to Jan 1, 1970 should use a value of -2. See [Section 7.15 of Implementation Guidance](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/develop/implementation.md#715---additional-telemetry-for-live-events-) for additional detail. |
 | `sourcerelationship` | integer | 0 = indirect, 1 = direct. |
 | `len` | integer | Length of content in seconds; appropriate for video or audio. |
 | `language` | string | Content language using ISO-639-1-alpha-2. Only one of `language` or `langb` should be present. |
@@ -1035,8 +1032,8 @@ This object contains information known or derived about the human user of the de
 
 | Attribute | Type | Description |
 | --- | --- | --- |
-| `id` | string | Exchange-specific ID for the user. Unless prior arrangements have been made between the buyer and the seller directly, the value in this field is expected to be derived from an ID sync. (see [Appendix: Cookie Based ID Syncing)](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/develop/2.6.md#appendix-c-cookie-based-id-syncing-) |
-| `buyeruid` | string | Buyer-specific ID for the user as mapped by the exchange for the buyer. Unless prior arrangements have been made between the buyer and the seller directly, the value in this field is expected to be derived from an ID sync. (see [Appendix: Cookie Based ID Syncing)](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/develop/2.6.md#appendix-c-cookie-based-id-syncing-) |
+| `id` | string | Exchange-specific ID for the user. Unless prior arrangements have been made between the buyer and the seller directly, the value in this field is expected to be derived from an ID sync. (see [Appendix: Cookie Based ID Syncing)](#appendixc) |
+| `buyeruid` | string | Buyer-specific ID for the user as mapped by the exchange for the buyer. Unless prior arrangements have been made between the buyer and the seller directly, the value in this field is expected to be derived from an ID sync. (see [Appendix: Cookie Based ID Syncing)](#appendixc) |
 | `yob` | integer; DEPRECATED | Deprecated as of OpenRTB 2.6. |
 | `gender` | string; DEPRECATED | Deprecated as of OpenRTB 2.6. |
 | `keywords` | string | Comma separated list of keywords, interests, or intent. Only one of `keywords` or `kwarray` may be present. |

--- a/2.6.md
+++ b/2.6.md
@@ -224,8 +224,6 @@ THE STANDARDS, THE SPECIFICATIONS, THE MEASUREMENT GUIDELINES, AND ANY OTHER MAT
 - [7.13 - Using genres and gtax attributes](implementation.md#genre)
   
 - [7.14 - Using Extended Content Identifiers](implementation.md#cids)
-  
-- [7.15 - Additional Telemetry for Live Events](implementation.md#lea)
 
   
 ## [Appendix A. Additional Information](#appendixa)
@@ -351,40 +349,16 @@ Updates to the specification are made through the IAB Tech Lab’s [Programmatic
 The following terms are used throughout this document specifically in the context of the OpenRTB Interface and this specification.
 
 
-<table>
-  <tr>
-    <td><strong>Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Definition&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-  </tr>
-  <tr>
-    <td><code>RTB</code></td>
-    <td>Bidding for individual impressions in real-time (i.e., while a consumer is waiting).</td>
-  </tr>
-  <tr>
-    <td><code>Exchange</code></td>
-    <td>A service that conducts an auction among bidders per impression.</td>
-  </tr>
-  <tr>
-    <td><code>Bidder</code></td>
-    <td>An entity that competes in real-time auctions to acquire impressions.</td>
-  </tr>
-  <tr>
-    <td><code>Seat</code></td>
-    <td>An advertising entity (e.g., advertiser, agency) that wishes to obtain impressions and uses bidders to act on their behalf; a customer of a bidder and usually the owner of the advertising budget.</td>
-  </tr>
-  <tr>
-    <td><code>Publisher</code></td>
-    <td>An entity that operates one or more sites.</td>
-  </tr>
-  <tr>
-    <td><code>Site</code></td>
-    <td>Ad supported content including web and applications unless otherwise specified.</td>
-  </tr>
-  <tr>
-    <td><code>Deal</code></td>
-    <td>A pre-arranged agreement between a Publisher and a Seat to purchase impressions under certain terms.</td>
-  </tr>
-</table>
+| Term      | Definition |
+|-----------|------------|
+| `RTB`     | Bidding for individual impressions in real-time (i.e., while a consumer is waiting). |
+| `Exchange` | A service that conducts an auction among bidders per impression. |
+| `Bidder`  | An entity that competes in real-time auctions to acquire impressions. |
+| `Seat`    | An advertising entity (e.g., advertiser, agency) that wishes to obtain impressions and uses bidders to act on their behalf; a customer of a bidder and usually the owner of the advertising budget. |
+| `Publisher` | An entity that operates one or more sites. |
+| `Site`    | Ad supported content including web and applications unless otherwise specified. |
+| `Deal`    | A pre-arranged agreement between a Publisher and a Seat to purchase impressions under certain terms. |
+
 
 
 ## 2. OpenRTB Basics <a name="rtbbasics"></a>
@@ -518,179 +492,41 @@ The following table summarizes the objects in the Bid Request model and serves a
 
 
 
-<table>
-  <tr>
-    <td><strong>Object&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Section&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>BidRequest</code></td>
-    <td>3.2.1</td>
-    <td>Top-level object.</td>
-  </tr>
-  <tr>
-    <td><code>Source</code></td>
-    <td>3.2.2</td>
-    <td>Request source details on post-auction decisioning (e.g., header bidding).</td>
-  </tr>
-  <tr>
-    <td><code>Regs</code></td>
-    <td>3.2.3</td>
-    <td>Regulatory conditions in effect for all impressions in this bid request.</td>
-  </tr>
-  <tr>
-    <td><code>Imp</code></td>
-    <td>3.2.4</td>
-    <td>Container for the description of a specific impression; at least 1 per request.</td>
-  </tr>
-  <tr>
-    <td><code>Metric</code></td>
-    <td>3.2.5</td>
-    <td>A quanitifiable often historical data point about an impression.</td>
-  </tr>
-  <tr>
-    <td><code>Banner</code></td>
-    <td>3.2.6</td>
-    <td>Details for a banner impression (incl. in-banner video) or video companion ad.</td>
-  </tr>
-  <tr>
-    <td><code>Video</code></td>
-    <td>3.2.7</td>
-    <td>Details for a video impression.</td>
-  </tr>
-  <tr>
-    <td><code>Audio</code></td>
-    <td>3.2.8</td>
-    <td>Container for audio impression.</a>.</td>
-  </tr>
-  <tr>
-    <td><code>Native</code></td>
-    <td>3.2.9</td>
-    <td>Container for a native impression conforming to the Dynamic Native Ads API.</td>
-  </tr>
-  <tr>
-    <td><code>Format</code></td>
-    <td>3.2.10</td>
-    <td>An allowed size of a banner.</td>
-  </tr>
-  <tr>
-    <td><code>Pmp</code></td>
-    <td>3.2.11</td>
-    <td>Collection of private marketplace (PMP) deals applicable to this impression.</td>
-  </tr>
-  <tr>
-    <td><code>Deal</code></td>
-    <td>3.2.12</td>
-    <td>Deal terms pertaining to this impression between a seller and buyer.</td>
-  </tr>
-  <tr>
-    <td><code>Site</code></td>
-    <td>3.2.13</td>
-    <td>Details of the website calling for the impression.</td>
-  </tr>
-  <tr>
-    <td><code>App</code></td>
-    <td>3.2.14</td>
-    <td>Details of the application calling for the impression.</td>
-  </tr>
-  <tr>
-    <td><code>Publisher</code></td>
-    <td>3.2.15</td>
-    <td>Entity that controls the content of and distributes the site or app.</td>
-    </tr>
-  <tr>
-    <td><code>Content</code></td>
-    <td>3.2.16</td>
-    <td>Details about the published content itself, within which the ad will be shown.</td>
-  </tr>
-  <tr>
-    <td><code>Producer</code></td>
-    <td>3.2.17</td>
-    <td>Producer of the content; not necessarily the publisher (e.g., syndication).</td>
-  </tr>
-  <tr>
-    <td><code>Device</code></td>
-    <td>3.2.18</td>
-    <td>Details of the device on which the content and impressions are displayed.</td>
-  </tr>
-  <tr>
-    <td><code>Geo</code></td>
-    <td>3.2.19</td>
-    <td>Location of the device or user's home base depending on the parent object.</td>
-  </tr>
-  <tr>
-    <td><code>User</code></td>
-    <td>3.2.20</td>
-    <td>Human user of the device; audience for advertising.</td>
-  </tr>
-  <tr>
-    <td><code>Data</code></td>
-    <td>3.2.21</td>
-    <td>Collection of additional user targeting data from a specific data source.</td>
-  </tr>
-  <tr>
-    <td><code>Segment</code></td>
-    <td>3.2.22</td>
-    <td>Specific data point about a user from a specific data source.</td>
-  </tr>
-  <tr>
-    <td><code>Network</code></td>
-    <td>3.2.23</td>
-    <td>Network on which an ad will be displayed.</td>
-  </tr>
-  <tr>
-    <td><code>Channel</code></td>
-    <td>3.2.24</td>
-    <td>Channel on which an ad will be displayed.</td>
-  </tr>
-  <tr>
-    <td><code>SupplyChain</code></td>
-    <td>3.2.25</td>
-    <td>Chain of nodes from beginning to end representing the entities involved in the direct flow of payment for inventory.</td>
-  </tr>
-  <tr>
-    <td><code>SupplyChainNode</code></td>
-    <td>3.2.26</td>
-    <td>Nodes defining the identity of an entity participating in the supply chain of a bid request.</td>
-  </tr>
-  <tr>
-    <td><code>EIDs</code></td>
-    <td>3.2.27</td>
-    <td>Extended identifiers support.</td>
-  </tr>
-  <tr>
-    <td><code>UIDs</code></td>
-    <td>3.2.28</td>
-    <td>Extended identifiers user id support.</td>
-  </tr>
-  <tr>
-    <td><code>UserAgent</code></td>
-    <td>3.2.29</td>
-    <td>Structured user agent information.</td>
-  </tr>
-  <tr>
-    <td><code>BrandVersion</code></td>
-    <td>3.2.30</td>
-    <td>Name and version information for a browser or similar software component.</td>
-    </td>
-    </td>
-  </tr>
- <tr>
-    <td><code>Qty</code></td>
-    <td>3.2.31</td>
-    <td>A means of passing a multiplier in the bid request, representing the total quantity of impressions for adverts that display to more than one person.</td>
-    </td>
-    </td>
-  </tr>
-  <tr>
-    <td><code>DOOH</code></td>
-    <td>3.2.32</td>
-    <td>Details of the Digital Out of Home inventory calling for the impression.</td>
-    </td>
-    </td>
-  </tr>
-</table>
+| Object | Section | Description |
+| --- | --- | --- |
+| `BidRequest` | 3.2.1 | Top-level object. |
+| `Source` | 3.2.2 | Request source details on post-auction decisioning (e.g., header bidding). |
+| `Regs` | 3.2.3 | Regulatory conditions in effect for all impressions in this bid request. |
+| `Imp` | 3.2.4 | Container for the description of a specific impression; at least 1 per request. |
+| `Metric` | 3.2.5 | A quanitifiable often historical data point about an impression. |
+| `Banner` | 3.2.6 | Details for a banner impression (incl. in-banner video) or video companion ad. |
+| `Video` | 3.2.7 | Details for a video impression. |
+| `Audio` | 3.2.8 | Container for audio impression. . |
+| `Native` | 3.2.9 | Container for a native impression conforming to the Dynamic Native Ads API. |
+| `Format` | 3.2.10 | An allowed size of a banner. |
+| `Pmp` | 3.2.11 | Collection of private marketplace (PMP) deals applicable to this impression. |
+| `Deal` | 3.2.12 | Deal terms pertaining to this impression between a seller and buyer. |
+| `Site` | 3.2.13 | Details of the website calling for the impression. |
+| `App` | 3.2.14 | Details of the application calling for the impression. |
+| `Publisher` | 3.2.15 | Entity that controls the content of and distributes the site or app. |
+| `Content` | 3.2.16 | Details about the published content itself, within which the ad will be shown. |
+| `Producer` | 3.2.17 | Producer of the content; not necessarily the publisher (e.g., syndication). |
+| `Device` | 3.2.18 | Details of the device on which the content and impressions are displayed. |
+| `Geo` | 3.2.19 | Location of the device or user's home base depending on the parent object. |
+| `User` | 3.2.20 | Human user of the device; audience for advertising. |
+| `Data` | 3.2.21 | Collection of additional user targeting data from a specific data source. |
+| `Segment` | 3.2.22 | Specific data point about a user from a specific data source. |
+| `Network` | 3.2.23 | Network on which an ad will be displayed. |
+| `Channel` | 3.2.24 | Channel on which an ad will be displayed. |
+| `SupplyChain` | 3.2.25 | Chain of nodes from beginning to end representing the entities involved in the direct flow of payment for inventory. |
+| `SupplyChainNode` | 3.2.26 | Nodes defining the identity of an entity participating in the supply chain of a bid request. |
+| `EIDs` | 3.2.27 | Extended identifiers support. |
+| `UIDs` | 3.2.28 | Extended identifiers user id support. |
+| `UserAgent` | 3.2.29 | Structured user agent information. |
+| `BrandVersion` | 3.2.30 | Name and version information for a browser or similar software component. |
+| `Qty` | 3.2.31 | A means of passing a multiplier in the bid request, representing the total quantity of impressions for adverts that display to more than one person. |
+| `DOOH` | 3.2.32 | Details of the Digital Out of Home inventory calling for the impression. |
+
 
 
 # 3.2 - Object Specifications <a name="objectspecs"></a>
@@ -703,135 +539,33 @@ There are also several subordinate objects that provide detailed data to potenti
 
 
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>id</code></td>
-    <td>string; required</td>
-    <td>ID of the bid request, assigned by the exchange, and unique for the exchange’s subsequent tracking of the responses. The exchange may use different values for different recipients.</td>
-  </tr>
-  <tr>
-    <td><code>imp</code></td>
-    <td>object array; required</td>
-    <td>Array of <code>Imp</code> objects (Section 3.2.4) representing the impressions offered. At least 1 <code>Imp</code> object is required.</td>
-  </tr>
-  <tr>
-    <td><code>site</code></td>
-    <td>object; recommended</td>
-    <td>Details via a <code>Site</code> object (Section 3.2.13) about the publisher’s website. Only applicable and recommended for websites.</td>
-  </tr>
-  <tr>
-    <td><code>app</code></td>
-    <td>object; recommended</td>
-    <td>Details via an <code>App</code> object (Section 3.2.14) about the publisher’s app (i.e., non-browser applications). Only applicable and recommended for apps.</td>
-  </tr>
-  <tr>
-    <td><code>dooh</code></td>
-    <td>object</td>
-    <td>This object should be included if the ad supported content is a Digital Out-Of-Home screen. A bid request with a DOOH object must not contain a site or app object.</td>
-  </tr>
-  <tr>
-    <td><code>device</code></td>
-    <td>object; recommended</td>
-    <td>Details via a <code>Device</code> object (Section 3.2.18) about the user’s device to which the impression will be delivered.</td>
-  </tr>
-  <tr>
-    <td><code>user</code></td>
-    <td>object; recommended</td>
-    <td>Details via a <code>User</code> object (Section 3.2.20) about the human user of the device; the advertising audience.</td>
-  </tr>
-  <tr>
-    <td><code>test</code></td>
-    <td>integer; default 0</td>
-    <td>Indicator of test mode in which auctions are not billable, where 0 = live mode, 1 = test mode.</td>
-  </tr>
-  <tr>
-    <td><code>at</code></td>
-    <td>integer; default 2</td>
-    <td>Auction type, where 1 = First Price, 2 = Second Price Plus. Exchange-specific auction types can be defined using values 500 and greater.</td>
-  </tr>
-  <tr>
-    <td><code>tmax</code></td>
-    <td>integer</td>
-    <td>Maximum time in milliseconds the exchange allows for bids to be received including Internet latency to avoid timeout. This value supersedes any *a priori* guidance from the exchange.</td>
-  </tr>
-  <tr>
-    <td><code>wseat</code></td>
-    <td>string array</td>
-    <td>Allowed list of buyer seats (e.g., advertisers, agencies) allowed to bid on this impression. IDs of seats and knowledge of the buyer’s customers to which they refer must be coordinated between bidders and the exchange *a priori*. At most, only one of <code>wseat</code> and <code>bseat</code> should be used in the same request. Omission of both implies no seat restrictions.</td>
-  </tr>
-  <tr>
-    <td><code>bseat</code></td>
-    <td>string array</td>
-    <td>Block list of buyer seats (e.g., advertisers, agencies) restricted from bidding on this impression. IDs of seats and knowledge of the buyer’s customers to which they refer must be coordinated between bidders and the exchange *a priori*. At most, only one of <code>wseat</code> and <code>bseat</code> should be used in the same request. Omission of both implies no seat restrictions.</td>
-  </tr>
-  <tr>
-    <td><code>allimps</code></td>
-    <td>integer; default 0</td>
-    <td>Flag to indicate if Exchange can verify that the impressions offered represent all of the impressions available in context (e.g., all on the web page, all video spots such as pre/mid/post roll) to support road-blocking. 0 = no or unknown, 1 = yes, the impressions offered represent all that are available.</td>
-  </tr>
-  <tr>
-    <td><code>cur</code></td>
-    <td>string array</td>
-    <td>Array of allowed currencies for bids on this bid request using ISO-4217 alpha codes. Recommended only if the exchange accepts multiple currencies.</td>
-  </tr>
-  <tr>
-    <td><code>wlang</code></td>
-    <td>string array</td>
-    <td>Allowed list of languages for creatives using ISO-639-1-alpha-2. Omission implies no specific restrictions, but buyers would be advised to consider <code>language</code> attribute in the <code>Device</code> and/or <code>Content</code> objects if available. Only one of <code>wlang</code> or <code>wlangb</code> should be present.</td>
-  </tr>
-  <tr>
-    <td><code>wlangb</code></td>
-    <td>string array</td>
-    <td>Allowed list of languages for creatives using IETF BCP 47I. Omission implies no specific restrictions, but buyers would be advised to consider language attribute in the <code>Device</code> and/or <code>Content</code> objects if available. Only one of <code>wlang</code> or <code>wlangb</code> should be present.</td>
-  </tr>
-  <tr>
-    <td><code>acat</code></td>
-    <td>string array</td>
-    <td>Allowed advertiser categories using the specified category taxonomy. <br>The taxonomy to be used is defined by the <code>cattax</code> field. If no <code>cattax</code> field is supplied IAB Content Taxonomy 1.0 is assumed. Only one of <code>acat</code> or <code>bcat</code> should be present.</td>
-  </tr>
-  <tr>
-    <td><code>bcat</code></td>
-    <td>string array</td>
-    <td>Blocked advertiser categories using the specified category taxonomy. <br>The taxonomy to be used is defined by the <code>cattax</code> field. If no <code>cattax</code> field is supplied IAB Content Taxonomy 1.0 is assumed. Only one of <code>acat</code> or <code>bcat</code> should be present.</td>
-  </tr>
-  <tr>
-    <td><code>cattax</code></td>
-    <td>integer; default 1</td>
-    <td>The taxonomy in use for bcat. Refer to the AdCOM 1.0 list <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_categorytaxonomies">List: Category Taxonomies</a> for values.</td>
-  </tr>
-  <tr>
-    <td><code>badv</code></td>
-    <td>string array</td>
-    <td>Block list of advertisers by their domains (e.g., “ford.com”).</td>
-  </tr>
-  <tr>
-    <td><code>bapp</code></td>
-    <td>string array</td>
-    <td>Block list of applications by their app store IDs. See <a href="https://iabtechlab.com/wp-content/uploads/2020/08/IAB-Tech-Lab-OTT-store-assigned-App-Identification-Guidelines-2020.pdf">OTT/CTV Store Assigned App Identification Guidelines</a> for more details about expected strings for CTV app stores. For mobile apps in Google Play Store, these should be bundle or package names (e.g. com.foo.mygame). For apps in Apple App Store, these should be a numeric ID.</td>
-  </tr>
-  <tr>
-    <td><code>source</code></td>
-    <td>object</td>
-    <td>A Source object (Section 3.2.2) that provides data about the inventory source and which entity makes the final decision.</td>
-  </tr>
-  <tr>
-    <td><code>regs</code></td>
-    <td>object</td>
-    <td>A Regs object (Section 3.2.3) that specifies any industry, legal, or governmental regulations in force for this request.</td>
-  </tr>
-  <tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for exchange-specific extensions to OpenRTB.</td>
-    </td>
-    </td>
-  </tr>
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `id` | string; required | ID of the bid request, assigned by the exchange, and unique for the exchange’s subsequent tracking of the responses. The exchange may use different values for different recipients. |
+| `imp` | object array; required | Array of `Imp` objects (Section 3.2.4) representing the impressions offered. At least 1 `Imp` object is required. |
+| `site` | object; recommended | Details via a `Site` object (Section 3.2.13) about the publisher’s website. Only applicable and recommended for websites. |
+| `app` | object; recommended | Details via an `App` object (Section 3.2.14) about the publisher’s app (i.e., non-browser applications). Only applicable and recommended for apps. |
+| `dooh` | object | This object should be included if the ad supported content is a Digital Out-Of-Home screen. A bid request with a DOOH object must not contain a site or app object. |
+| `device` | object; recommended | Details via a `Device` object (Section 3.2.18) about the user’s device to which the impression will be delivered. |
+| `user` | object; recommended | Details via a `User` object (Section 3.2.20) about the human user of the device; the advertising audience. |
+| `test` | integer; default 0 | Indicator of test mode in which auctions are not billable, where 0 = live mode, 1 = test mode. |
+| `at` | integer; default 2 | Auction type, where 1 = First Price, 2 = Second Price Plus. Exchange-specific auction types can be defined using values 500 and greater. |
+| `tmax` | integer | Maximum time in milliseconds the exchange allows for bids to be received including Internet latency to avoid timeout. This value supersedes any *a priori* guidance from the exchange. |
+| `wseat` | string array | Allowed list of buyer seats (e.g., advertisers, agencies) allowed to bid on this impression. IDs of seats and knowledge of the buyer’s customers to which they refer must be coordinated between bidders and the exchange *a priori*. At most, only one of `wseat` and `bseat` should be used in the same request. Omission of both implies no seat restrictions. |
+| `bseat` | string array | Block list of buyer seats (e.g., advertisers, agencies) restricted from bidding on this impression. IDs of seats and knowledge of the buyer’s customers to which they refer must be coordinated between bidders and the exchange *a priori*. At most, only one of `wseat` and `bseat` should be used in the same request. Omission of both implies no seat restrictions. |
+| `allimps` | integer; default 0 | Flag to indicate if Exchange can verify that the impressions offered represent all of the impressions available in context (e.g., all on the web page, all video spots such as pre/mid/post roll) to support road-blocking. 0 = no or unknown, 1 = yes, the impressions offered represent all that are available. |
+| `cur` | string array | Array of allowed currencies for bids on this bid request using ISO-4217 alpha codes. Recommended only if the exchange accepts multiple currencies. |
+| `wlang` | string array | Allowed list of languages for creatives using ISO-639-1-alpha-2. Omission implies no specific restrictions, but buyers would be advised to consider `language` attribute in the `Device` and/or `Content` objects if available. Only one of `wlang` or `wlangb` should be present. |
+| `wlangb` | string array | Allowed list of languages for creatives using IETF BCP 47I. Omission implies no specific restrictions, but buyers would be advised to consider language attribute in the `Device` and/or `Content` objects if available. Only one of `wlang` or `wlangb` should be present. |
+| `acat` | string array | Allowed advertiser categories using the specified category taxonomy. The taxonomy to be used is defined by the `cattax` field. If no `cattax` field is supplied IAB Content Taxonomy 1.0 is assumed. Only one of `acat` or `bcat` should be present. |
+| `bcat` | string array | Blocked advertiser categories using the specified category taxonomy. The taxonomy to be used is defined by the `cattax` field. If no `cattax` field is supplied IAB Content Taxonomy 1.0 is assumed. Only one of `acat` or `bcat` should be present. |
+| `cattax` | integer; default 1 | The taxonomy in use for bcat. Refer to the AdCOM 1.0 list [List: Category Taxonomies](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_categorytaxonomies) for values. |
+| `badv` | string array | Block list of advertisers by their domains (e.g., “ford.com”). |
+| `bapp` | string array | Block list of applications by their app store IDs. See [OTT/CTV Store Assigned App Identification Guidelines](https://iabtechlab.com/wp-content/uploads/2020/08/IAB-Tech-Lab-OTT-store-assigned-App-Identification-Guidelines-2020.pdf) for more details about expected strings for CTV app stores. For mobile apps in Google Play Store, these should be bundle or package names (e.g. com.foo.mygame). For apps in Apple App Store, these should be a numeric ID. |
+| `source` | object | A Source object (Section 3.2.2) that provides data about the inventory source and which entity makes the final decision. |
+| `regs` | object | A Regs object (Section 3.2.3) that specifies any industry, legal, or governmental regulations in force for this request. |
+| `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
+
 
 
 
@@ -839,85 +573,29 @@ There are also several subordinate objects that provide detailed data to potenti
 
 This object describes the nature and behavior of the entity that is the source of the bid request upstream from the exchange. The primary purpose of this object is to define post-auction or upstream decisioning when the exchange itself does not control the final decision. A common example of this is header bidding, but it can also apply to upstream server entities such as another RTB exchange, a mediation platform, or an ad server combines direct campaigns with 3rd party demand in decisioning.
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>fd</code></td>
-    <td>integer, recommended</td>
-    <td>Entity responsible for the final impression sale decision, where 0 = exchange, 1 = upstream source.</td>
-  </tr>
-  <tr>
-    <td><code>tid</code></td>
-    <td>string; recommended</td>
-    <td>Transaction ID that must be common across all participants in this bid request (e.g., potentially multiple exchanges).</td>
-  </tr>
-  <tr>
-    <td><code>pchain</code></td>
-    <td>string; recommended</td>
-    <td>Payment ID chain string containing embedded syntax described in the TAG payment ID Protocol v1.0.</td>
-  </tr>
-  <tr>
-    <td><code>schain</code></td>
-    <td>object; recommended</td>
-    <td>This object represents both the links in the supply chain as well as an indicator whether or not the supply chain is complete. Details via the <code>SupplyChain</code> object (section 3.2.25).</td>
-  </tr>
-  <tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for exchange-specific extensions to OpenRTB.</td>
-     </td>
-     </td>
-  </tr>
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `fd` | integer, recommended | Entity responsible for the final impression sale decision, where 0 = exchange, 1 = upstream source. |
+| `tid` | string; recommended | Transaction ID that must be common across all participants in this bid request (e.g., potentially multiple exchanges). |
+| `pchain` | string; recommended | Payment ID chain string containing embedded syntax described in the TAG payment ID Protocol v1.0. |
+| `schain` | object; recommended | This object represents both the links in the supply chain as well as an indicator whether or not the supply chain is complete. Details via the `SupplyChain` object (section 3.2.25). |
+| `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
+
 
 
 ### 3.2.3 - Object: Regs <a name="objectregs"></a>
 
 This object contains any legal, governmental, or industry regulations that the sender deems applicable to the request. See Section 7.5 for more details on the flags supporting Coppa, GDPR and others.
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>coppa</code></td>
-    <td>integer</td>
-    <td>Flag indicating if this request is subject to the COPPA regulations established by the USA FTC, where 0 = no, 1 = yes. Refer to Section 7.5 for more information.</td>
-  </tr>
-  <tr>
-    <td><code>gdpr</code></td>
-    <td>integer</td>
-    <td>Flag that indicates whether or not the request is subject to GDPR regulations 0 = No, 1 = Yes, omission indicates unknown. Refer to Section 7.5 for more information.</td>
-  </tr>
-  <tr>
-    <td><code>us_privacy</code></td>
-    <td>string</td>
-    <td>Communicates signals regarding consumer privacy under US privacy regulation. See <a href="https://github.com/InteractiveAdvertisingBureau/USPrivacy/blob/master/CCPA/US%20Privacy%20String.md">US Privacy String specifications</a>. Refer to Section 7.5 for more information.</td>
-  </tr>
-  <tr>
-    <td><code>gpp</code></td>
-    <td>string</td>
-    <td>Contains the Global Privacy Platform’s consent string. See the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">Global Privacy Platform specification</a> for more details.</td>
-  </tr>
-  <tr>
-    <td><code>gpp_sid</code></td>
-    <td>integer array</td>
-    <td>Array of the section(s) of the string which should be applied for this transaction. Generally will contain one and only one value, but there are edge cases where more than one may apply. GPP Section 3 (Header) and 4 (Signal Integrity) do not need to be included. See the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Sections/Section%20Information.md">GPP Section Information</a> for more details.</td>
-  </tr>
-  <tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for exchange-specific extensions to OpenRTB.</td>
-     </td>
-     </td>
-  </tr>
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `coppa` | integer | Flag indicating if this request is subject to the COPPA regulations established by the USA FTC, where 0 = no, 1 = yes. Refer to Section 7.5 for more information. |
+| `gdpr` | integer | Flag that indicates whether or not the request is subject to GDPR regulations 0 = No, 1 = Yes, omission indicates unknown. Refer to Section 7.5 for more information. |
+| `us_privacy` | string | Communicates signals regarding consumer privacy under US privacy regulation. See [US Privacy String specifications](https://github.com/InteractiveAdvertisingBureau/USPrivacy/blob/master/CCPA/US%20Privacy%20String.md) . Refer to Section 7.5 for more information. |
+| `gpp` | string | Contains the Global Privacy Platform’s consent string. See the [Global Privacy Platform specification](https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform) for more details. |
+| `gpp_sid` | integer array | Array of the section(s) of the string which should be applied for this transaction. Generally will contain one and only one value, but there are edge cases where more than one may apply. GPP Section 3 (Header) and 4 (Signal Integrity) do not need to be included. See the [GPP Section Information](https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Sections/Section%20Information.md) for more details. |
+| `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
+
 
 ### 3.2.4 - Object: Imp <a name="objectimp"></a>
 
@@ -925,132 +603,32 @@ This object describes an ad placement or impression being auctioned. A single bi
 
 The presence of `Banner` (Section 3.2.6), `Video` (Section 3.2.7), and/or `Native` (Section 3.2.9) objects subordinate to the `Imp` object indicates the type of impression being offered. The publisher can choose one such type which is the typical case or mix them at their discretion. However, any given bid for the impression must conform to one of the offered type.
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>id</code></td>
-    <td>string; required</td>
-    <td>A unique identifier for this impression within the content of the bid request (typically, starts with 1 and increments).</td>
-  </tr>
-  <tr>
-    <td><code>metric</code></td>
-    <td>object array</td>
-    <td>An array of <code>Metric</code> object (section 3.2.5).</td>
-  </tr>
-  <tr>
-    <td><code>banner</code></td>
-    <td>object</td>
-    <td>A <code>Banner</code> object (section 3.2.6); required if this impression is offered as a banner ad opportunity.</td>
-  </tr>
-  <tr>
-    <td><code>video</code></td>
-    <td>object</td>
-    <td>A <code>Video</code> object (Section 3.2.7); required if this impression is offered as a video ad opportunity.</td>
-  </tr>
-  <tr>
-    <td><code>audio</code></td>
-    <td>object</td>
-    <td>An <code>Audio</code> object (Section 3.2.8); required if this impression is offered as an audio ad opportunity.</td>
-  </tr>
-  <tr>
-    <td><code>native</code></td>
-    <td>object</td>
-    <td>A <code>Native</code> object (Section 3.2.9); required if this impression is offered as a native ad opportunity.</td>
-  </tr>
-  <tr>
-    <td><code>pmp</code></td>
-    <td>object</td>
-    <td>A <code>Pmp</code> object (Section 3.2.11) containing any private marketplace deals in effect for this impression.</td>
-  </tr>
-  <tr>
-    <td><code>displaymanager</code></td>
-    <td>string</td>
-    <td>Name of ad mediation partner, SDK technology, or player responsible for rendering ad (typically video or mobile). Used by some ad servers to customize ad code by partner. <br>Recommended for video and/or apps.</td>
-  </tr>
-  <tr>
-    <td><code>displaymanagerver</code></td>
-    <td>string</td>
-    <td>Version of ad mediation partner, SDK technology, or player responsible for rendering ad (typically video or mobile). Used by some ad servers to customize ad code by partner. <br>Recommended for video and/or apps.</td>
-  </tr>
-  <tr>
-    <td><code>instl</code></td>
-    <td>integer; default 0</td>
-    <td>1 = the ad is interstitial or full screen, 0 = not interstitial.</td>
-  </tr>
-  <tr>
-    <td><code>tagid</code></td>
-    <td>string</td>
-    <td>Identifier for specific ad placement or ad tag that was used to initiate the auction. This can be useful for debugging of any issues, or for optimization by the buyer.</td>
-  </tr>
-  <tr>
-    <td><code>bidfloor</code></td>
-    <td>float; default 0</td>
-    <td>Minimum bid for this impression expressed in CPM.</td>
-  </tr>
-  <tr>
-    <td><code>bidfloorcur</code></td>
-    <td>string; default "USD"</td>
-    <td>Currency specified using ISO-4217 alpha codes. This may be different from bid currency returned by bidder if this is allowed by the exchange. This currency sets the default for all floors specified in the `Imp` object.</td>
-  </tr>
-  <tr>
-    <td><code>clickbrowser</code></td>
-    <td>integer</td>
-    <td>Indicates the type of browser opened upon clicking the creative in an app, where 0 = embedded, 1 = native. Note that the Safari View Controller in iOS 9.x devices is considered a native browser for purposes of this attribute.</td>
-  </tr>
-  <tr>
-    <td><code>secure</code></td>
-    <td>integer</td>
-    <td>Flag to indicate if the impression requires secure HTTPS URL creative assets and markup, where 0 = non-secure, 1 = secure. If omitted, the secure state is unknown, but non-secure HTTP support can be assumed.</td>
-  </tr>
-  <tr>
-    <td><code>iframebuster</code></td>
-    <td>string array</td>
-    <td>Array of exchange-specific names of supported iframe busters.</td>
-  </tr>
-  <tr>
-    <td><code>rwdd</code></td>
-    <td>integer; default 0</td>
-    <td>Indicates whether the user receives a reward for viewing the ad, where 0 = no, 1 = yes. Typically video ad implementations allow users to read an additional news article for free, receive an extra life in a game, or get a sponsored ad-free music session. The reward is typically distributed after the video ad is completed.</td>
-  </tr>
-  <tr>
-    <td><code>ssai</code></td>
-    <td>integer; default 0</td>
-    <td>Indicates if server-side ad insertion (e.g., stitching an ad into an audio or video stream) is in use and the impact of this on asset and tracker retrieval, where 0 = status unknown, 1 = all client-side (i.e., not server-side), 2 = assets stitched server-side but tracking pixels fired client-side, 3 = all server-side.</td>
-  </tr>
-  <tr>
-    <td><code>exp</code></td>
-    <td>integer</td>
-    <td>Advisory as to the number of seconds that may elapse between the auction and the actual impression.</td>
-  </tr>
-  <tr>
-    <td><code>qty</code></td>
-    <td>object</td>
-    <td>A means of passing a multiplier in the bid request, representing the total quantity of impressions for adverts that display to more than one person.</td>
-  </tr>
-  <tr>
-    <td><code>dt</code></td>
-    <td>float</td>
-    <td>Timestamp when the item is estimated to be fulfilled (e.g. when a DOOH impression will be displayed) in Unix format (i.e., milliseconds since the epoch).</td>
-  </tr>
-  <tr>
-    <td><code>refresh</code></td>
-    <td>object</td>
-    <td>Details about ad slots being refreshed automatically. (Section 3.2.33)</td>
-    </td>
-  </tr>
-  <tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for exchange-specific extensions to OpenRTB.</td>
-    </td>
-    </td>
-  </tr>
-  
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `id` | string; required | A unique identifier for this impression within the content of the bid request (typically, starts with 1 and increments). |
+| `metric` | object array | An array of `Metric` object (section 3.2.5). |
+| `banner` | object | A `Banner` object (section 3.2.6); required if this impression is offered as a banner ad opportunity. |
+| `video` | object | A `Video` object (Section 3.2.7); required if this impression is offered as a video ad opportunity. |
+| `audio` | object | An `Audio` object (Section 3.2.8); required if this impression is offered as an audio ad opportunity. |
+| `native` | object | A `Native` object (Section 3.2.9); required if this impression is offered as a native ad opportunity. |
+| `pmp` | object | A `Pmp` object (Section 3.2.11) containing any private marketplace deals in effect for this impression. |
+| `displaymanager` | string | Name of ad mediation partner, SDK technology, or player responsible for rendering ad (typically video or mobile). Used by some ad servers to customize ad code by partner. Recommended for video and/or apps. |
+| `displaymanagerver` | string | Version of ad mediation partner, SDK technology, or player responsible for rendering ad (typically video or mobile). Used by some ad servers to customize ad code by partner. Recommended for video and/or apps. |
+| `instl` | integer; default 0 | 1 = the ad is interstitial or full screen, 0 = not interstitial. |
+| `tagid` | string | Identifier for specific ad placement or ad tag that was used to initiate the auction. This can be useful for debugging of any issues, or for optimization by the buyer. |
+| `bidfloor` | float; default 0 | Minimum bid for this impression expressed in CPM. |
+| `bidfloorcur` | string; default "USD" | Currency specified using ISO-4217 alpha codes. This may be different from bid currency returned by bidder if this is allowed by the exchange. This currency sets the default for all floors specified in the `Imp` object. |
+| `clickbrowser` | integer | Indicates the type of browser opened upon clicking the creative in an app, where 0 = embedded, 1 = native. Note that the Safari View Controller in iOS 9.x devices is considered a native browser for purposes of this attribute. |
+| `secure` | integer | Flag to indicate if the impression requires secure HTTPS URL creative assets and markup, where 0 = non-secure, 1 = secure. If omitted, the secure state is unknown, but non-secure HTTP support can be assumed. |
+| `iframebuster` | string array | Array of exchange-specific names of supported iframe busters. |
+| `rwdd` | integer; default 0 | Indicates whether the user receives a reward for viewing the ad, where 0 = no, 1 = yes. Typically video ad implementations allow users to read an additional news article for free, receive an extra life in a game, or get a sponsored ad-free music session. The reward is typically distributed after the video ad is completed. |
+| `ssai` | integer; default 0 | Indicates if server-side ad insertion (e.g., stitching an ad into an audio or video stream) is in use and the impact of this on asset and tracker retrieval, where 0 = status unknown, 1 = all client-side (i.e., not server-side), 2 = assets stitched server-side but tracking pixels fired client-side, 3 = all server-side. |
+| `exp` | integer | Advisory as to the number of seconds that may elapse between the auction and the actual impression. |
+| `qty` | object | A means of passing a multiplier in the bid request, representing the total quantity of impressions for adverts that display to more than one person. |
+| `dt` | float | Timestamp when the item is estimated to be fulfilled (e.g. when a DOOH impression will be displayed) in Unix format (i.e., milliseconds since the epoch). |
+| `refresh` | object | Details about ad slots being refreshed automatically. (Section 3.2.33) |
+| `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
+
 
 
 
@@ -1058,35 +636,13 @@ The presence of `Banner` (Section 3.2.6), `Video` (Section 3.2.7), and/or `Nativ
 
 This object is associated with an impression as an array of metrics. These metrics can offer insight into the impression to assist with decisioning such as average recent viewability, click-through rate, etc. Each metric is identified by its type, reports the value of the metric, and optionally identifies the source or vendor measuring the value.
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>type</code></td>
-    <td>string; required</td>
-    <td>Type of metric being presented using exchange curated string names which should be published to bidders <i>a priori</i>.</td>
-  </tr>
-  <tr>
-    <td><code>value</code></td>
-    <td>float; required</td>
-    <td>Number representing the value of the metric. Probabilities must be in the range 0.0 – 1.0.</td>
-  </tr>
-  <tr>
-    <td><code>vendor</code></td>
-    <td>string; recommended</td>
-    <td>Source of the value using exchange curated string names which should be published to bidders <i>a priori</i>. If the exchange itself is the source versus a third party, “EXCHANGE” is recommended.</td>
-  </tr>
-  <tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for exchange-specific extensions to OpenRTB.</td>
-     </td>
-     </td>
-  </tr>
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `type` | string; required | Type of metric being presented using exchange curated string names which should be published to bidders a priori . |
+| `value` | float; required | Number representing the value of the metric. Probabilities must be in the range 0.0 – 1.0. |
+| `vendor` | string; recommended | Source of the value using exchange curated string names which should be published to bidders a priori . If the exchange itself is the source versus a third party, “EXCHANGE” is recommended. |
+| `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
+
 
 
 ### 3.2.6 - Object: Banner <a name="objectbanner"></a>
@@ -1096,85 +652,22 @@ This object represents the most general type of impression. Although the term �
 The presence of a `Banner` as a subordinate of the `Imp` object indicates that this impression is offered as a banner type impression. At the publisher’s discretion, that same impression may also be offered as video, audio, and/or native by also including as `Imp` subordinates objects of those types. However, any given bid for the impression must conform to one of the offered types.
 
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>format</code></td>
-    <td>object array;<br> recommended</td>
-    <td>Array of format objects (Section 3.2.10) representing the banner sizes permitted. If none are specified, then use of the <code>h</code> and <code>w</code> attributes is highly recommended.</td>
-  </tr>
-  <tr>
-    <td><code>w</code></td>
-    <td>integer</td>
-    <td>Exact width in device-independent pixels (DIPS); recommended if no <code>Format</code> objects are specified.</td>
-  </tr>
-  <tr>
-    <td><code>h</code></td>
-    <td>integer</td>
-    <td>Exact height in device-independent pixels (DIPS); recommended if no <code>Format</code> objects are specified. </td>
-  </tr>
-  <tr>
-    <td><code>btype</code></td>
-    <td>integer array</td>
-    <td>Blocked banner ad types.<br>
-	Values:<br>
-1 = XHTML Text Ad,<br> 
-2 = XHTML Banner Ad,<br> 
-3 = JavaScript Ad,<br> 
-4 = iframe.<br></td>
-  </tr>
-  <tr>
-    <td><code>battr</code></td>
-    <td>integer array</td>
-    <td>Blocked creative attributes. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--creative-attributes-">List: Creative Attributes</a> in AdCOM 1.0.</td>
-  </tr>
-  <tr>
-    <td><code>pos</code></td>
-    <td>integer</td>
-    <td>Ad position on screen. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--placement-positions-">List: Placement Positions</a> in AdCOM 1.0.</td>
-  </tr>
-  <tr>
-    <td><code>mimes</code></td>
-    <td>string array</td>
-    <td>Content MIME types supported. Popular MIME types may include, <code>“image/jpeg”</code> and <code>“image/gif”</code>.</td>
-  </tr>
-  <tr>
-    <td><code>topframe</code></td>
-    <td>integer</td>
-    <td>Indicates if the banner is in the top frame as opposed to an iframe, where 0 = no, 1 = yes.</td>
-  </tr>
-  <tr>
-    <td><code>expdir</code></td>
-    <td>integer array</td>
-    <td>Directions in which the banner may expand. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--expandable-directions-">List: Expandable Directions</a> in AdCOM 1.0.</td>
-  </tr>
-  <tr>
-    <td><code>api</code></td>
-    <td>integer array</td>
-    <td>List of supported API frameworks for this impression. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--api-frameworks-">List: API Frameworks</a> in AdCOM 1.0. If an API is not explicitly listed, it is assumed not to be supported.</td>
-  </tr>
-  <tr>
-    <td><code>id</code></td>
-    <td>string</td>
-    <td>Unique identifier for this banner object. Recommended when <code>Banner</code> objects are used with a <code>Video</code> object (Section 3.2.7) to represent an array of companion ads. Values usually start at 1 and increase with each object; should be unique within an impression.</td>
-  </tr>
-  <tr>
-    <td><code>vcm</code></td>
-    <td>integer</td>
-    <td>Relevant only for <code>Banner</code> objects used with a <code>Video</code> object (Section 3.2.7) in an array of companion ads. Indicates the companion banner rendering mode relative to the associated video, where 0 = concurrent, 1 = end-card.</td>
-  </tr>
-  <tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for exchange-specific extensions to OpenRTB.</td>
-    </td>
-    </td>
-  </tr>
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `format` | object array; recommended | Array of format objects (Section 3.2.10) representing the banner sizes permitted. If none are specified, then use of the `h` and `w` attributes is highly recommended. |
+| `w` | integer | Exact width in device-independent pixels (DIPS); recommended if no `Format` objects are specified. |
+| `h` | integer | Exact height in device-independent pixels (DIPS); recommended if no `Format` objects are specified. |
+| `btype` | integer array | Blocked banner ad types. Values: 1 = XHTML Text Ad, 2 = XHTML Banner Ad, 3 = JavaScript Ad, 4 = iframe. |
+| `battr` | integer array | Blocked creative attributes. Refer to [List: Creative Attributes](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--creative-attributes-) in AdCOM 1.0. |
+| `pos` | integer | Ad position on screen. Refer to [List: Placement Positions](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--placement-positions-) in AdCOM 1.0. |
+| `mimes` | string array | Content MIME types supported. Popular MIME types may include, `“image/jpeg”` and `“image/gif”` . |
+| `topframe` | integer | Indicates if the banner is in the top frame as opposed to an iframe, where 0 = no, 1 = yes. |
+| `expdir` | integer array | Directions in which the banner may expand. Refer to [List: Expandable Directions](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--expandable-directions-) in AdCOM 1.0. |
+| `api` | integer array | List of supported API frameworks for this impression. Refer to [List: API Frameworks](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--api-frameworks-) in AdCOM 1.0. If an API is not explicitly listed, it is assumed not to be supported. |
+| `id` | string | Unique identifier for this banner object. Recommended when `Banner` objects are used with a `Video` object (Section 3.2.7) to represent an array of companion ads. Values usually start at 1 and increase with each object; should be unique within an impression. |
+| `vcm` | integer | Relevant only for `Banner` objects used with a `Video` object (Section 3.2.7) in an array of companion ads. Indicates the companion banner rendering mode relative to the associated video, where 0 = concurrent, 1 = end-card. |
+| `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
+
 
 
 ### 3.2.7 - Object: Video <a name="objectvideo"></a>
@@ -1184,195 +677,45 @@ This object represents a video impression. Many of the fields are non-essential 
 The presence of a `Video` as a subordinate of the `Imp` object indicates that this impression is offered as a video type impression. At the publisher’s discretion, that same impression may also be offered as `Banner`, `Audio`, and/or `Native` by also including as `Imp` subordinates objects of those types. However, any given bid for the impression must conform to one of the offered types.
 
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>mimes</code></td>
-    <td>string array; required</td>
-    <td>Content MIME types supported (e.g., “<code>video/mp4</code>”).</td>
-  </tr>
-  <tr>
-    <td><code>minduration</code></td>
-    <td>integer; default 0 recommended</td>
-    <td>Minimum video ad duration in seconds. This field is mutually exclusive with <code>rqddurs</code>; only one of <code>minduration</code> and <code>rqddurs</code> may be in a bid request.</td>
-  </tr>
-  <tr>
-    <td><code>maxduration</code></td>
-    <td>integer; recommended</td>
-    <td>Maximum video ad duration in seconds. This field is mutually exclusive with <code>rqddurs</code>; only one of <code>maxduration</code> and <code>rqddurs</code> may be in a bid request.</td>
-  </tr>
-  <tr>
-    <td><code>startdelay</code></td>
-    <td>integer; recommended</td>
-    <td>Indicates the start delay in seconds for pre-roll, mid-roll, or post-roll ad placements. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--start-delay-modes-">List: Start Delay Modes</a> in AdCOM 1.0.</td>
-  </tr>
-  <tr>
-    <td><code>maxseq</code></td>
-    <td>integer; recommended</td>
-    <td>Indicates the maximum number of ads that may be served into a “dynamic” video ad pod (where the precise number of ads is not predetermined by the seller). See Section 7.6 for more details.</td>
-  </tr>
-  <tr>
-    <td><code>poddur</code></td>
-    <td>integer; recommended</td>
-    <td>Indicates the total amount of time in seconds that advertisers may fill for a “dynamic” video ad pod (See Section 7.6 for more details), or the dynamic portion of a “hybrid” ad pod. This field is required only for the dynamic portion(s) of video ad pods. This field refers to the length of the entire ad break, whereas <code>minduration</code>/<code>maxduration</code>/<code>rqddurs</code> are constraints relating to the slots that make up the pod.</td>
-  </tr>
-  <tr>
-    <td><code>protocols</code></td>
-    <td>integer array; recommended</td>
-    <td>Array of supported video protocols. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--creative-subtypes---audiovideo-">List: Creative Substypes - Audio/Video</a> in AdCOM 1.0.</td>
-  </tr>
-  <tr>
-    <td><code>w</code></td>
-    <td>integer; recommended</td>
-    <td>Width of the video player in device-independent pixels (DIPS).</td>
-  </tr>
-  <tr>
-    <td><code>h</code></td>
-    <td>integer; recommended</td>
-    <td>Height of the video player in device-independent pixels (DIPS).</td>
-  </tr>
-  <tr>
-    <td><code>podid</code></td>
-    <td>string</td>
-    <td>Unique identifier indicating that an impression opportunity belongs to a video ad pod. If multiple impression opportunities within a bid request share the same <code>podid</code>, this indicates that those impression opportunities belong to the same video ad pod.</td>
-  </tr>
-  <tr>
-    <td><code>podseq</code></td>
-    <td>integer; default 0</td>
-    <td>The sequence (position) of the video ad pod within a content stream. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_podsequence"List: Pod Sequence</a> in AdCOM 1.0 for guidance on the use of this field.</td>
-  </tr>
-  <tr>
-    <td><code>rqddurs</code></td>
-    <td>integer array</td>
-    <td>Precise acceptable durations for video creatives in seconds. This field specifically targets the Live TV use case where non-exact ad durations would result in undesirable ‘dead air’. This field is mutually exclusive with <code>minduration</code> and <code>maxduration</code>; if rqddurs is specified, <code>minduration</code> and <code>maxduration</code> must not be specified and vice versa.</td>
-  </tr>
-  <tr>
-    <td><code>placement</code></td>
-    <td>integer; DEPRECATED</td>
-    <td>Deprecated as of OpenRTB 2.6-202303. Use <code>plcmt</code> instead.</td>
-  </tr>
-  <tr>
-    <td><code>plcmt</code></td>
-    <td>integer</td>
-    <td>Video placement type for the impression. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/develop/AdCOM%20v1.0%20FINAL.md#list_plcmtsubtypesvideo">List: Plcmt Subtypes - Video</a> in AdCOM 1.0.</td>
-  </tr>
-  <tr>
-    <td><code>linearity</code></td>
-    <td>integer</td>
-    <td>Indicates if the impression must be linear, nonlinear, etc. If none specified, assume all are allowed. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--linearity-modes-">List: Linearity Modes</a> in AdCOM 1.0. Note that this field describes the expected VAST response and not whether a placement is in-stream, out-stream, etc. For that, see <code>placement</code>.</td>
-  </tr>
-  <tr>
-    <td><code>skip</code></td>
-    <td>integer</td>
-    <td>Indicates if the player will allow the video to be skipped, where 0 = no, 1 = yes. <br>If a bidder sends markup/creative that is itself skippable, the <code>Bid</code> object should include the <code>attr</code> array with an element of 16 indicating skippable video. Refer to  <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--creative-attributes-">List: Creative Attributes</a> in AdCOM 1.0.</td>
-    </tr>
-  <tr>
-    <td><code>skipmin</code></td>
-    <td>integer; default 0</td>
-    <td>Videos of total duration greater than this number of seconds can be skippable; only applicable if the ad is skippable. </td>
-  </tr>
-  <tr>
-    <td><code>skipafter</code></td>
-    <td>integer; default 0</td>
-    <td>Number of seconds a video must play before skipping is enabled; only applicable if the ad is skippable.</td>
-  </tr>
-  <tr>
-    <td><code>sequence</code></td>
-    <td>integer; default 0 <br>DEPRECATED</td>
-    <td>Deprecated as of OpenRTB 2.6. Use <code>slotinpod</code></td>
-  </tr>
-  <tr>
-    <td><code>slotinpod</code></td>
-    <td>integer; default 0</td>
-    <td>For video ad pods, this value indicates that the seller can guarantee delivery against the indicated slot position in the pod. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--slot-position-in-pod-">List: Slot Position in Pod</a> in AdCOM 1.0 guidance on the use of this field.</td>
-  </tr>
-  <tr>
-    <td><code>mincpmpersec</code></td>
-    <td>float</td>
-    <td>Minimum CPM per second. This is a price floor for the "dynamic" portion of a video ad pod, relative to the duration of bids an advertiser may submit.</td>
-  </tr>
-  <tr>
-    <td><code>battr</code></td>
-    <td>integer array</td>
-    <td>Blocked creative attributes. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--creative-attributes-">List: Creative Attributes</a> in AdCOM 1.0.</td>
-  </tr>
-  <tr>
-    <td><code>maxextended</code></td>
-    <td>integer</td>
-    <td>Maximum extended ad duration if extension is allowed. If blank or 0, extension is not allowed. If -1, extension is allowed, and there is no time limit imposed. If greater than 0, then the value represents the number of seconds of extended play supported beyond the <code>maxduration</code> value.</td>
-  </tr>
-  <tr>
-    <td><code>minbitrate</code></td>
-    <td>inpteger</td>
-    <td>Minimum bit rate in Kbps (kilobits per second).</td>
- </tr>
-  <tr>
-    <td><code>maxbitrate</code></td>
-    <td>integer</td>
-    <td>Maximum bit rate in Kbps (kilobits per second).</td>
-  </tr>
-  <tr>
-    <td><code>boxingallowed</code></td>
-    <td>integer; default 1</td>
-    <td>Indicates if letter-boxing of 4:3 content into a 16:9 window is allowed, where 0=no, 1=yes.</td>
-  </tr>
-  <tr>
-    <td><code>playbackmethod</code></td>
-    <td>integer array</td>
-    <td>Playback methods that may be in use. If none are specified, any method may be used. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--playback-methods-">List: Playback Methods</a> in AdCOM 1.0. Only one method is typically used in practice. As a result, this array may be converted to an integer in a future version of the specification. It is strongly advised to use only the first element of this array in preparation for this change.</td>
- </tr>
-  <tr>
-    <td><code>playbackend</code></td>
-    <td>integer</td>
-    <td>The event that causes playback to end. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--playback-cessation-modes-">List: Playback Cessation Modes</a> in AdCOM 1.0.</td>
-  </tr>
-  <tr>
-    <td><code>delivery</code></td>
-    <td>integer array</td>
-    <td>Supported delivery methods (e.g., streaming, progressive). If none specified, assume all are supported. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--delivery-methods-">List: Delivery Methods</a> in AdCOM 1.0. </td>
-  </tr>
-  <tr>
-    <td><code>pos</code></td>
-    <td>integer</td>
-    <td>Ad position on screen. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--placement-positions-">List: Placement Positions </a> in AdCOM 1.0.</td>
-  </tr>
-  <tr>
-    <td><code>companionad</code></td>
-    <td>object array</td>
-    <td>Array of <code>Banner</code> objects (Section 3.2.6) if companion ads are available.</td>
-  </tr>
-  <tr>
-    <td><code>api</code></td>
-    <td>integer array</td>
-    <td>List of supported API frameworks for this impression. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--api-frameworks-">List: API Frameworks</a> in AdCOM 1.0. If an API is not explicitly listed, it is assumed not to be supported.</td>
-  </tr>
-  <tr>
-    <td><code>companiontype</code></td>
-    <td>integer array</td>
-    <td>Supported VAST companion ad types. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--companion-types-">List: Companion Types</a> in AdCOM 1.0. Recommended if companion <code>Banner</code> objects are included via the <code>companionad</code> array. If one of these banners will be rendered as an end-card, this can be specified using the <code>vcm</code> attribute with the particular banner (Section 3.2.6).</td>
-  </tr>
-<tr>
-    <td><code>poddedupe</code></td>
-    <td>enum array <b>PROVISIONAL</b></td>
-    <td>Indicates pod deduplication settings that will be applied to bid responses. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/main/AdCOM%20v1.0%20FINAL.md#list--pod-deduplication-settings-">List: Pod Deduplication</a> in AdCOM 1.0.</td>
-  </tr>
-  <tr>
-    <td><code>durfloors</code></td>
-    <td>object array</td>
-    <td>An array of `DurFloors` objects (Section 3.2.35) indicating the floor prices for video creatives of various durations that the buyer may bid with.</td>
-  </tr>
-  <tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for exchange-specific extensions to OpenRTB.</td>
-    </td>
-    </td>
-  </tr>
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `mimes` | string array; required | Content MIME types supported (e.g., “ `video/mp4` ”). |
+| `minduration` | integer; default 0 recommended | Minimum video ad duration in seconds. This field is mutually exclusive with `rqddurs` ; only one of `minduration` and `rqddurs` may be in a bid request. |
+| `maxduration` | integer; recommended | Maximum video ad duration in seconds. This field is mutually exclusive with `rqddurs` ; only one of `maxduration` and `rqddurs` may be in a bid request. |
+| `startdelay` | integer; recommended | Indicates the start delay in seconds for pre-roll, mid-roll, or post-roll ad placements. Refer to [List: Start Delay Modes](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--start-delay-modes-) in AdCOM 1.0. |
+| `maxseq` | integer; recommended | Indicates the maximum number of ads that may be served into a “dynamic” video ad pod (where the precise number of ads is not predetermined by the seller). See Section 7.6 for more details. |
+| `poddur` | integer; recommended | Indicates the total amount of time in seconds that advertisers may fill for a “dynamic” video ad pod (See Section 7.6 for more details), or the dynamic portion of a “hybrid” ad pod. This field is required only for the dynamic portion(s) of video ad pods. This field refers to the length of the entire ad break, whereas `minduration` / `maxduration` / `rqddurs` are constraints relating to the slots that make up the pod. |
+| `protocols` | integer array; recommended | Array of supported video protocols. Refer to [List: Creative Substypes - Audio/Video](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--creative-subtypes---audiovideo-) in AdCOM 1.0. |
+| `w` | integer; recommended | Width of the video player in device-independent pixels (DIPS). |
+| `h` | integer; recommended | Height of the video player in device-independent pixels (DIPS). |
+| `podid` | string | Unique identifier indicating that an impression opportunity belongs to a video ad pod. If multiple impression opportunities within a bid request share the same `podid` , this indicates that those impression opportunities belong to the same video ad pod. |
+| `podseq` | integer; default 0 | The sequence (position) of the video ad pod within a content stream. Refer to [in AdCOM 1.0 for guidance on the use of this field.](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_podsequence) |
+| `rqddurs` | integer array | Precise acceptable durations for video creatives in seconds. This field specifically targets the Live TV use case where non-exact ad durations would result in undesirable ‘dead air’. This field is mutually exclusive with `minduration` and `maxduration` ; if rqddurs is specified, `minduration` and `maxduration` must not be specified and vice versa. |
+| `placement` | integer; DEPRECATED | Deprecated as of OpenRTB 2.6-202303. Use `plcmt` instead. |
+| `plcmt` | integer | Video placement type for the impression. Refer to [List: Plcmt Subtypes - Video](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/develop/AdCOM%20v1.0%20FINAL.md#list_plcmtsubtypesvideo) in AdCOM 1.0. |
+| `linearity` | integer | Indicates if the impression must be linear, nonlinear, etc. If none specified, assume all are allowed. Refer to [List: Linearity Modes](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--linearity-modes-) in AdCOM 1.0. Note that this field describes the expected VAST response and not whether a placement is in-stream, out-stream, etc. For that, see `placement` . |
+| `skip` | integer | Indicates if the player will allow the video to be skipped, where 0 = no, 1 = yes. If a bidder sends markup/creative that is itself skippable, the `Bid` object should include the `attr` array with an element of 16 indicating skippable video. Refer to [List: Creative Attributes](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--creative-attributes-) in AdCOM 1.0. |
+| `skipmin` | integer; default 0 | Videos of total duration greater than this number of seconds can be skippable; only applicable if the ad is skippable. |
+| `skipafter` | integer; default 0 | Number of seconds a video must play before skipping is enabled; only applicable if the ad is skippable. |
+| `sequence` | integer; default 0 DEPRECATED | Deprecated as of OpenRTB 2.6. Use `slotinpod` |
+| `slotinpod` | integer; default 0 | For video ad pods, this value indicates that the seller can guarantee delivery against the indicated slot position in the pod. Refer to [List: Slot Position in Pod](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--slot-position-in-pod-) in AdCOM 1.0 guidance on the use of this field. |
+| `mincpmpersec` | float | Minimum CPM per second. This is a price floor for the "dynamic" portion of a video ad pod, relative to the duration of bids an advertiser may submit. |
+| `battr` | integer array | Blocked creative attributes. Refer to [List: Creative Attributes](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--creative-attributes-) in AdCOM 1.0. |
+| `maxextended` | integer | Maximum extended ad duration if extension is allowed. If blank or 0, extension is not allowed. If -1, extension is allowed, and there is no time limit imposed. If greater than 0, then the value represents the number of seconds of extended play supported beyond the `maxduration` value. |
+| `minbitrate` | inpteger | Minimum bit rate in Kbps (kilobits per second). |
+| `maxbitrate` | integer | Maximum bit rate in Kbps (kilobits per second). |
+| `boxingallowed` | integer; default 1 | Indicates if letter-boxing of 4:3 content into a 16:9 window is allowed, where 0=no, 1=yes. |
+| `playbackmethod` | integer array | Playback methods that may be in use. If none are specified, any method may be used. Refer to [List: Playback Methods](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--playback-methods-) in AdCOM 1.0. Only one method is typically used in practice. As a result, this array may be converted to an integer in a future version of the specification. It is strongly advised to use only the first element of this array in preparation for this change. |
+| `playbackend` | integer | The event that causes playback to end. Refer to [List: Playback Cessation Modes](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--playback-cessation-modes-) in AdCOM 1.0. |
+| `delivery` | integer array | Supported delivery methods (e.g., streaming, progressive). If none specified, assume all are supported. Refer to [List: Delivery Methods](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--delivery-methods-) in AdCOM 1.0. |
+| `pos` | integer | Ad position on screen. Refer to [List: Placement Positions](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--placement-positions-) in AdCOM 1.0. |
+| `companionad` | object array | Array of `Banner` objects (Section 3.2.6) if companion ads are available. |
+| `api` | integer array | List of supported API frameworks for this impression. Refer to [List: API Frameworks](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--api-frameworks-) in AdCOM 1.0. If an API is not explicitly listed, it is assumed not to be supported. |
+| `companiontype` | integer array | Supported VAST companion ad types. Refer to [List: Companion Types](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--companion-types-) in AdCOM 1.0. Recommended if companion `Banner` objects are included via the `companionad` array. If one of these banners will be rendered as an end-card, this can be specified using the `vcm` attribute with the particular banner (Section 3.2.6). |
+| `poddedupe` | enum array PROVISIONAL | Indicates pod deduplication settings that will be applied to bid responses. Refer to [List: Pod Deduplication](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/main/AdCOM%20v1.0%20FINAL.md#list--pod-deduplication-settings-) in AdCOM 1.0. |
+| `durfloors` | object array | An array of `DurFloors` objects (Section 3.2.35) indicating the floor prices for video creatives of various durations that the buyer may bid with. |
+| `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
+
 
 
 ### 3.2.8 - Object: Audio <a name="objectaudio"></a>
@@ -1382,145 +725,35 @@ This object represents an audio type impression. Many of the fields are non-esse
 The presence of a `Audio` as a subordinate of the `Imp` object indicates that this impression is offered as an audio type impression. At the publisher’s discretion, that same impression may also be offered as `Banner`, `Video`, and/or `Native` by also including as `Imp` subordinates objects of those types. However, any given bid for the impression must conform to one of the offered types.
 
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>mimes</code></td>
-    <td>string array; required</td>
-    <td>Content MIME types supported (e.g., <code>“audio/mp4”</code>).</td>
-  </tr>
-  <tr>
-    <td><code>minduration</code></td>
-    <td>integer; default 0 recommended</td>
-    <td>Minimum audio ad duration in seconds. This field is mutually exclusive with <code>rqddurs</code>; only one of <code>minduration</code> and <code>rqddurs</code> may be in a bid request.</td>
-  </tr>
-  <tr>
-    <td><code>maxduration</code></td>
-    <td>integer; recommended</td>
-    <td>Maximum audio ad duration in seconds. This field is mutually exclusive with <code>rqddurs</code>; only one of <code>maxduration</code> and <code>rqddurs</code> may be in a bid request.</td>
-  </tr>
-  <tr>
-    <td><code>poddur</code></td>
-    <td>integer; recommended</td>
-    <td>Indicates the total amount of time that advertisers may fill for a "dynamic" audio ad pod, or the dynamic portion of a "hybrid" ad pod. This field is required only for the dynamic portion(s) of audio ad pods. This field refers to the length of the entire ad break, wheras <code>minduration</code>/<code>maxduration</code>/<code>rqddurs</code> are constraints relating to the slots that make up the pod.</td>
-  </tr>
-  <tr>
-    <td><code>protocols</code></td>
-    <td>integer array; recommended</td>
-    <td>Array of supported audio protocols. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--creative-subtypes---audiovideo-">List: Creative Subtypes - Audio/Video</a> in AdCOM 1.0.</td>
-  </tr>
-  <tr>
-    <td><code>startdelay</code></td>
-    <td>integer; recommended</td>
-    <td>Indicates the start delay in seconds for pre-roll, mid-roll, or post-roll ad placements. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--start-delay-modes-">List: Start Delay Modes</a> in AdCOM 1.0.</td>
-  </tr>
-  <tr>
-    <td><code>rqddurs</code></td>
-    <td>integer array</td>
-    <td>Precise acceptable durations for audio creatives in seconds. This field specifically targets the live audio/radio use case where non-exact ad durations would result in undesirable 'dead air'. This field is mutually exclusive with <code>minduraiton</code> and <code>maxduration</code>; if <code>rqddurs</code> is specified, <code>minduraiton</code> and <code>maxduration</code> must not be specified and vice versa.</td>
-  </tr>
-  <tr>
-    <td><code>podid</code></td>
-    <td>string</td>
-    <td>Unique identifier indicating that an impression opportunity belongs to an audio ad pod. If multiple impression opportunities within a bid request share the same <code>podid</code>, this indicates that those impression opportunities belong to the same audio ad pod.</td>
-  </tr>
-  <tr>
-    <td><code>podseq</code></td>
-    <td>integer; default 0</td>
-    <td>The sequence (position) of the audio ad pod within a content stream. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--pod-sequence-">List: Pod Sequence</a> in AdCOM 1.0 for guidance on the use of this field.</td>
-  </tr>
-  <tr>
-    <td><code>sequence</code></td>
-    <td>integer; default 0<br>DEPRECATED</td>
-    <td>Deprecated as of OpenRTB 2.6. Use <code>slotinpod</code></td>
-  </tr>
-  <tr>
-    <td><code>slotinpod</code></td>
-    <td>integer; default 0</td>
-    <td>For audio ad pods, this value indicates that the seller can guarantee delivery against the indicated slot position in the pod. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--slot-position-in-pod-">List: Slot Position in Pod</a> in AdCOM 1.0 guidance on the use of this field.</td>
-  </tr>
-  <tr>
-    <td><code>mincpmpersec</code></td>
-    <td>float</td>
-    <td>Minimum CPM per second. This is a price floor for the “dynamic” portion of an audio ad pod, relative to the duration of bids an advertiser may submit.</td>
- </tr>
-  <tr>
-    <td><code>battr</code></td>
-    <td>integer array</td>
-    <td>Blocked creative attributes. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--creative-attributes-">List: Creative Attributes</a> in AdCOM 1.0</td>
-  </tr>
-  <tr>
-    <td><code>maxextended</code></td>
-    <td>integer</td>
-    <td>Maximum extended ad duration if extension is allowed. If blank or 0, extension is not allowed. If -1, extension is allowed, and there is no time limit imposed. If greater than 0, then the value represents the number of seconds of extended play supported beyond the <code>maxduration</code> value.</td>
-  </tr>
-  <tr>
-    <td><code>minbitrate</code></td>
-    <td>integer</td>
-    <td>Minimum bit rate in Kbps (kilobits per second).</td>
- </tr>
-  <tr>
-    <td><code>maxbitrate</code></td>
-    <td>integer</td>
-    <td>Maximum bit rate in Kbps (kilobits per second).</td>
-  </tr>
-  <tr>
-    <td><code>delivery</code></td>
-    <td>integer array</td>
-    <td>Supported delivery methods (e.g., streaming, progressive). If none specified, assume all are supported. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--delivery-methods-">List: Delivery Methods</a> in AdCOM 1.0.</td>
-  </tr>
-  <tr>
-    <td><code>companionad</code></td>
-    <td>object array</td>
-    <td>Array of <code>Banner</code> objects (Section 3.2.6) if companion ads are available.</td>
-  </tr>
-  <tr>
-    <td><code>api</code></td>
-    <td>integer array</td>
-    <td>List of supported API frameworks for this impression. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--api-frameworks-">List: API Framworks</a> in AdCOM 1.0. If an API is not explicitly listed, it is assumed not to be supported.</td>
- </tr>
-  <tr>
-    <td><code>companiontype</code></td>
-    <td>integer array</td>
-    <td>Supported companion ad types. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--companion-types-">List: Companion Types</a> in AdCOM 1.0. Recommended if companion <code>Banner</code> objects are included via the <code>companionad</code> array.</td>
-  </tr>
-  <tr>
-    <td><code>maxseq</code></td>
-    <td>integer</td>
-    <td>The maximum number of ads that can be played in an ad pod.</td>
-  </tr>
-  <tr>
-    <td><code>feed</code></td>
-    <td>integer</td>
-    <td>Type of audio feed. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--feed-types-">List: Feed Types</a> in AdCOM 1.0.</td>
-  </tr>
-  <tr>
-    <td><code>stitched</code></td>
-    <td>integer</td>
-    <td>Indicates if the ad is stitched with audio content or delivered independently, where 0=no, 1=yes.</td>
-  </tr>
-  <tr>
-    <td><code>nvol</code></td>
-    <td>integer</td>
-    <td>Volume normalization mode. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--volume-normalization-modes-">List: Volume Normalization Modes</a> in AdCOM 1.0.</td>
- </tr>
-  <tr>
-    <td><code>durfloors</code></td>
-    <td>object array</td>
-    <td>An array of `DurFloors` objects (Section 3.2.35) indicating the floor prices for audio creatives of various durations that the buyer may bid with.</td>
-  </tr>
-  <tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for exchange-specific extensions to OpenRTB.</td>
-    </td>
-    </td>
-  </tr>
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `mimes` | string array; required | Content MIME types supported (e.g., `“audio/mp4”` ). |
+| `minduration` | integer; default 0 recommended | Minimum audio ad duration in seconds. This field is mutually exclusive with `rqddurs` ; only one of `minduration` and `rqddurs` may be in a bid request. |
+| `maxduration` | integer; recommended | Maximum audio ad duration in seconds. This field is mutually exclusive with `rqddurs` ; only one of `maxduration` and `rqddurs` may be in a bid request. |
+| `poddur` | integer; recommended | Indicates the total amount of time that advertisers may fill for a "dynamic" audio ad pod, or the dynamic portion of a "hybrid" ad pod. This field is required only for the dynamic portion(s) of audio ad pods. This field refers to the length of the entire ad break, wheras `minduration` / `maxduration` / `rqddurs` are constraints relating to the slots that make up the pod. |
+| `protocols` | integer array; recommended | Array of supported audio protocols. Refer to [List: Creative Subtypes - Audio/Video](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--creative-subtypes---audiovideo-) in AdCOM 1.0. |
+| `startdelay` | integer; recommended | Indicates the start delay in seconds for pre-roll, mid-roll, or post-roll ad placements. Refer to [List: Start Delay Modes](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--start-delay-modes-) in AdCOM 1.0. |
+| `rqddurs` | integer array | Precise acceptable durations for audio creatives in seconds. This field specifically targets the live audio/radio use case where non-exact ad durations would result in undesirable 'dead air'. This field is mutually exclusive with `minduraiton` and `maxduration` ; if `rqddurs` is specified, `minduraiton` and `maxduration` must not be specified and vice versa. |
+| `podid` | string | Unique identifier indicating that an impression opportunity belongs to an audio ad pod. If multiple impression opportunities within a bid request share the same `podid` , this indicates that those impression opportunities belong to the same audio ad pod. |
+| `podseq` | integer; default 0 | The sequence (position) of the audio ad pod within a content stream. Refer to [List: Pod Sequence](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--pod-sequence-) in AdCOM 1.0 for guidance on the use of this field. |
+| `sequence` | integer; default 0 DEPRECATED | Deprecated as of OpenRTB 2.6. Use `slotinpod` |
+| `slotinpod` | integer; default 0 | For audio ad pods, this value indicates that the seller can guarantee delivery against the indicated slot position in the pod. Refer to [List: Slot Position in Pod](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--slot-position-in-pod-) in AdCOM 1.0 guidance on the use of this field. |
+| `mincpmpersec` | float | Minimum CPM per second. This is a price floor for the “dynamic” portion of an audio ad pod, relative to the duration of bids an advertiser may submit. |
+| `battr` | integer array | Blocked creative attributes. Refer to [List: Creative Attributes](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--creative-attributes-) in AdCOM 1.0 |
+| `maxextended` | integer | Maximum extended ad duration if extension is allowed. If blank or 0, extension is not allowed. If -1, extension is allowed, and there is no time limit imposed. If greater than 0, then the value represents the number of seconds of extended play supported beyond the `maxduration` value. |
+| `minbitrate` | integer | Minimum bit rate in Kbps (kilobits per second). |
+| `maxbitrate` | integer | Maximum bit rate in Kbps (kilobits per second). |
+| `delivery` | integer array | Supported delivery methods (e.g., streaming, progressive). If none specified, assume all are supported. Refer to [List: Delivery Methods](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--delivery-methods-) in AdCOM 1.0. |
+| `companionad` | object array | Array of `Banner` objects (Section 3.2.6) if companion ads are available. |
+| `api` | integer array | List of supported API frameworks for this impression. Refer to [List: API Framworks](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--api-frameworks-) in AdCOM 1.0. If an API is not explicitly listed, it is assumed not to be supported. |
+| `companiontype` | integer array | Supported companion ad types. Refer to [List: Companion Types](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--companion-types-) in AdCOM 1.0. Recommended if companion `Banner` objects are included via the `companionad` array. |
+| `maxseq` | integer | The maximum number of ads that can be played in an ad pod. |
+| `feed` | integer | Type of audio feed. Refer to [List: Feed Types](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--feed-types-) in AdCOM 1.0. |
+| `stitched` | integer | Indicates if the ad is stitched with audio content or delivered independently, where 0=no, 1=yes. |
+| `nvol` | integer | Volume normalization mode. Refer to [List: Volume Normalization Modes](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--volume-normalization-modes-) in AdCOM 1.0. |
+| `durfloors` | object array | An array of `DurFloors` objects (Section 3.2.35) indicating the floor prices for audio creatives of various durations that the buyer may bid with. |
+| `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
+
 
 
 
@@ -1533,282 +766,86 @@ The Native Subcommittee has developed a companion specification to OpenRTB calle
 The presence of a `Native` as a subordinate of the `Imp` object indicates that this impression is offered as a native type impression. At the publisher’s discretion, that same impression may also be offered as `Banner`, `Video`, and/or `Audio` by also including as `Imp` subordinates objects of those types. However, any given bid for the impression must conform to one of the offered types.
 
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>request</code></td>
-    <td>string; required</td>
-    <td>Request payload complying with the <a href="https://iabtechlab.com/standards/openrtb-native/">Native Ad Specification</a>. The root node of the payload, "native", was dropped in the Native Ads Specification 1.1. <br>For Native 1.0, this is a JSON-encoded string consisting of a unnamed root object, with a single subordinate object named 'native', which is the Native Markup Request object, section 4.1 of OpenRTB Native 1.0 specification. <br>For Native 1.1 and higher, this is a JSON-encoded string consisting of an unnamed root object which is itself the Native Markup Request Object, section 4.1 of OpenRTB Native 1.1+ .</td>
-  </tr>
-  <tr>
-    <td><code>ver</code></td>
-    <td>string; recommended</td>
-	  <td>Version of the Dynamic Native Ads API to which <code>request</code> complies; highly recommended for efficient parsing.</td>
-  </tr>
-  <tr>
-    <td><code>api</code></td>
-    <td>integer array</td>
-    <td>List of supported API frameworks for this impression. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--api-frameworks-">List: API Frameworks</a> in AdCOM. If an API is not explicitly listed, it is assumed not to be supported.</td>
-  </tr>
-  <tr>
-    <td><code>battr</code></td>
-    <td>integer array</td>
-    <td>Blocked creative attributes. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--creative-attributes-">List: Creative Attributes</a> in AdCOM.</td>
-   <tr>
-  </tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for exchange-specific extensions to OpenRTB.</td>
-     </td>
-     </td>
-  </tr>
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `request` | string; required | Request payload complying with the [Native Ad Specification](https://iabtechlab.com/standards/openrtb-native/) . The root node of the payload, "native", was dropped in the Native Ads Specification 1.1. For Native 1.0, this is a JSON-encoded string consisting of a unnamed root object, with a single subordinate object named 'native', which is the Native Markup Request object, section 4.1 of OpenRTB Native 1.0 specification. For Native 1.1 and higher, this is a JSON-encoded string consisting of an unnamed root object which is itself the Native Markup Request Object, section 4.1 of OpenRTB Native 1.1+ . |
+| `ver` | string; recommended | Version of the Dynamic Native Ads API to which `request` complies; highly recommended for efficient parsing. |
+| `api` | integer array | List of supported API frameworks for this impression. Refer to [List: API Frameworks](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--api-frameworks-) in AdCOM. If an API is not explicitly listed, it is assumed not to be supported. |
+| `battr` | integer array | Blocked creative attributes. Refer to [List: Creative Attributes](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--creative-attributes-) in AdCOM. | `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
+|  |
+
 
 
 ### 3.2.10 - Object: Format <a name="objectformat"></a>
 
 This object represents an allowed size (i.e., height and width combination) or Flex Ad parameters for a banner impression. These are typically used in an array where multiple sizes are permitted. It is recommended that either the `w`/`h` pair or the `wratio`/`hratio`/`wmin` set (i.e., for Flex Ads) be specified.
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>w</code></td>
-    <td>integer</td>
-    <td>Width in device-independent pixels (DIPS).</td>
-  </tr>
-  <tr>
-    <td><code>h</code></td>
-    <td>integer</td>
-    <td>Height in device-independent pixels (DIPS).</td>
-  </tr>
-  <tr>
-    <td><code>wratio</code></td>
-    <td>integer</td>
-    <td>Relative width when expressing size as a ratio.</td>
-  </tr>
-  <tr>
-    <td><code>hratio</code></td>
-    <td>integer</td>
-    <td>Relative height when expressing size as a ratio.</td>
-   <tr>
-  </tr>
-    <td><code>wmin</code></td>
-    <td>integer</td>
-    <td>The minimum width in device-independent pixels (DIPS) at which the ad will be displayed the size is expressed as a ratio.</td>
-   </tr>
-   <tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for exchange-specific extensions to OpenRTB.</td>
-     </td>
-     </td>
-  </tr>
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `w` | integer | Width in device-independent pixels (DIPS). |
+| `h` | integer | Height in device-independent pixels (DIPS). |
+| `wratio` | integer | Relative width when expressing size as a ratio. |
+| `hratio` | integer | Relative height when expressing size as a ratio. | `wmin` | integer | The minimum width in device-independent pixels (DIPS) at which the ad will be displayed the size is expressed as a ratio. |
+|  |
+| `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
+
 
 ### 3.2.11 - Object: Pmp <a name="objectpmp"></a>
 
 This object is the private marketplace container for direct deals between buyers and sellers that may pertain to this impression. The actual deals are represented as a collection of `Deal` objects. Refer to Section 7.3 for more details.
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>private_auction</code></td>
-    <td>integer; default 0</td>
-    <td>Indicator of auction eligibility to seats named in the Direct Deals object, where 0=all bids are accepted, 1=bids are restricted to the deals specified and the terms thereof.</td>
-  </tr>
-  <tr>
-    <td><code>deals</code></td>
-    <td>object array</td>
-	  <td>Array of <code>Deal</code> (Section 3.2.12) objects that convey the specific deals applicable to this impression.</td>
-  </tr>
-  <tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for exchange-specific extensions to OpenRTB.</td>
-     </td>
-     </td>
-  </tr>
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `private_auction` | integer; default 0 | Indicator of auction eligibility to seats named in the Direct Deals object, where 0=all bids are accepted, 1=bids are restricted to the deals specified and the terms thereof. |
+| `deals` | object array | Array of `Deal` (Section 3.2.12) objects that convey the specific deals applicable to this impression. |
+| `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
+
 
 ### 3.2.12 - Object: Deal <a name="objectdeal"></a>
 
 This object constitutes a specific deal that was struck between a buyer and a seller. Its presence with the `Pmp` collection indicates that this impression is available under the terms of that deal. Refer to Section 7.3 for more details.
 
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>id</code></td>
-    <td>string; required</td>
-    <td>A unique identifier for the direct deal.</td>
-  </tr>
-  <tr>
-    <td><code>bidfloor</code></td>
-    <td>float; default 0</td>
-    <td>Minimum bid for this impression expressed in CPM.</td>
-  </tr>
-  <tr>
-    <td><code>bidfloorcur</code></td>
-    <td>string; default "USD"</td>
-    <td>Currency specified using ISO-4217 alpha codes. This may be different from bid currency returned by bidder if this is allowed by the exchange. This field does not inherit from `Imp.bidfloorcur`; it is either explicitly specified or defaults to USD.</td>
-  </tr>
-  <tr>
-    <td><code>at</code></td>
-    <td>integer</td>
-    <td>Optional override of the overall auction type of the bid request, where 1 = First Price, 2 = Second Price Plus, 3 = the value passed in <code>bidfloor</code> is the agreed upon deal price. Additional auction types can be defined by the exchange.</td>
-  </tr>
-  <tr>
-    <td><code>wseat</code></td>
-    <td>string array</td>
-    <td>Allowed list of buyer seats (e.g., advertisers, agencies) allowed to bid on this deal. IDs of seats and the buyer’s customers to which they refer must be coordinated between bidders and the exchange <i>a priori</i>. Omission implies no seat restrictions.</td>
-  </tr>
-  <tr>
-    <td><code>wadomain</code></td>
-    <td>string array</td>  
-    <td>Array of advertiser domains (e.g., advertiser.com) allowed to bid on this deal. Omission implies no advertiser restrictions.</td>
-   </tr>
-   <tr>
-    <td><code>guar</code></td>
-    <td>integer, default 0</td>  
-    <td>Indicates that the deal is of type `guaranteed` and the bidder must bid on the deal, where 0 = not a guaranteed deal, 1 = guaranteed deal.</td>
-  </tr>
-  <tr>
-    <td><code>mincpmpersec</code></td>
-    <td>float</td>  
-    <td>Minimum CPM per second. This is a price floor for video or audio impression opportunities, relative to the duration of bids an advertiser may submit.</td>
-  </tr>
-  <tr>
-    <td><code>durfloors</code></td>
-    <td>object array</td>  
-    <td>Container for floor price by duration information, to be used if a given deal is eligible for video or audio demand. An array of DurFloors objects (see Section 3.2.35).</td>
-  </tr>
-  <tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for exchange-specific extensions to OpenRTB.</td>
-  </tr>
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `id` | string; required | A unique identifier for the direct deal. |
+| `bidfloor` | float; default 0 | Minimum bid for this impression expressed in CPM. |
+| `bidfloorcur` | string; default "USD" | Currency specified using ISO-4217 alpha codes. This may be different from bid currency returned by bidder if this is allowed by the exchange. This field does not inherit from `Imp.bidfloorcur`; it is either explicitly specified or defaults to USD. |
+| `at` | integer | Optional override of the overall auction type of the bid request, where 1 = First Price, 2 = Second Price Plus, 3 = the value passed in `bidfloor` is the agreed upon deal price. Additional auction types can be defined by the exchange. |
+| `wseat` | string array | Allowed list of buyer seats (e.g., advertisers, agencies) allowed to bid on this deal. IDs of seats and the buyer’s customers to which they refer must be coordinated between bidders and the exchange a priori . Omission implies no seat restrictions. |
+| `wadomain` | string array | Array of advertiser domains (e.g., advertiser.com) allowed to bid on this deal. Omission implies no advertiser restrictions. |
+| `guar` | integer, default 0 | Indicates that the deal is of type `guaranteed` and the bidder must bid on the deal, where 0 = not a guaranteed deal, 1 = guaranteed deal. |
+| `mincpmpersec` | float | Minimum CPM per second. This is a price floor for video or audio impression opportunities, relative to the duration of bids an advertiser may submit. |
+| `durfloors` | object array | Container for floor price by duration information, to be used if a given deal is eligible for video or audio demand. An array of DurFloors objects (see Section 3.2.35). |
+| `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
+
 
 ### 3.2.13 - Object: Site <a name="objectsite"></a>
 
 This object should be included if the ad supported content is a website as opposed to a non-browser application or Digital Out of Home (DOOH) inventory. A bid request must not contain more than one of a `Site`, `App` or `DOOH` object. At a minimum, it is useful to provide a site ID or page URL, but this is not strictly required.
 
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>id</code></td>
-    <td>string; recommended</td>
-    <td>Exchange-specific site ID.</td>
-  </tr>
-  <tr>
-    <td><code>name</code></td>
-    <td>string</td>
-    <td>Site name (may be aliased at the publisher's request).</td>
-  </tr>
-  <tr>
-    <td><code>domain</code></td>
-    <td>string</td>
-    <td>Domain of the site (e.g., "mysite.foo.com").</td>
-  </tr>
-  <tr>
-    <td><code>cattax</code></td>
-    <td>integer; default 1</td>
-    <td>The taxonomy in use. Refer to the AdCOM <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_categorytaxonomies">List: Category Taxonomies</a> for values. If no cattax field is supplied IAB Cotent Category Taxonomy 1.0 is assumed.</td>
-   <tr>
-  </tr>
-    <td><code>cat</code></td>
-    <td>string array</td>
-    <td>Array of IAB Tech Lab content categories of the site. The taxonomy to be used is defined by the cattax field.</td>
-   </tr>
-   <tr>
-    <td><code>sectioncat</code></td>
-    <td>string array</td>
-    <td>Array of IAB Tech Lab content categories that describe the current section of the site. The taxonomy to be used is defined by the cattax field.</td>
-  </tr>
-  <tr>
-    <td><code>pagecat</code></td>
-    <td>string array</td>
-    <td>Array of IAB Tech Lab content categories that describe the current page or view of the site. The taxonomy to be used is definied by the cattax field.</td>
-  </tr>
-  <tr>
-    <td><code>page</code></td>
-    <td>string</td>
-    <td>URL of the page where the impression will be shown.</td>
-   <tr>
-  </tr>
-    <td><code>ref</code></td>
-    <td>string</td>
-    <td>Referrer URL that caused navigation to the current page.</td>
-   </tr>
-   <tr>
-    <td><code>search</code></td>
-    <td>string</td>
-    <td>Search string that caused navigation to the current page.</td>
-  <tr>
-  </tr>
-    <td><code>mobile</code></td>
-    <td>integer</td>
-    <td>Indicates if the site has been programmed to optimize layout when viewed on mobile devices, where 0=no, 1=yes.</td>
-   </tr>
-   <tr>
-    <td><code>privacypolicy</code></td>
-    <td>integer</td>
-    <td>Indicates if the site has a privacy policy, where 0 = no, 1 = yes.</td>
-  </tr>
-  <tr>
-    <td><code>publisher</code></td>
-    <td>object</td>
-    <td>Details about the Publisher (Section 3.2.15) of the site.</td>
-  </tr>
-  <tr>
-    <td><code>content</code></td>
-    <td>object</td>
-    <td>Details about the Content (Section 3.2.16) within the site.</td>
-   <tr>
-  </tr>
-    <td><code>keywords</code></td>
-    <td>string</td>
-    <td>Comma separated list of keywords about the site. Only one of <code>keywords</code> or <code>kwarray</code> may be present.</td>
-   </tr>
-   <tr>
-    <td><code>kwarray</code></td>
-    <td>string array</td>
-    <td>Array of keywords about the site. Only one of <code>keywords</code> or <code>kwarray</code> may be present.</td>
-  <tr>
-  <tr>
-    <td><code>inventorypartnerdomain</code></td>
-    <td>string</td>
-    <td>A domain to be used for inventory authorization in the case of inventory sharing arrangements between a site owner and content owner. This field is typically used by authorization crawlers to establish the domain of the content owner, who has the right to monetize some portion of ad inventory within the site. The content owner's domain should be listed in the site owner's ads.txt file as an <code>inventorypartnerdomain</code>. Authorization for supply from the <code>inventorypartnerdomain</code> will be published in the ads.txt file on the root of that domain. Refer to <a href="https://iabtechlab.com/wp-content/uploads/2022/04/Ads.txt-1.1.pdf">the ads.txt 1.1 spec</a> for more details.</td>
-  </tr>
-  </tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for exchange-specific extensions to OpenRTB.</td>
-     </td>
-     </td>
-  </tr>
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `id` | string; recommended | Exchange-specific site ID. |
+| `name` | string | Site name (may be aliased at the publisher's request). |
+| `domain` | string | Domain of the site (e.g., "mysite.foo.com"). |
+| `cattax` | integer; default 1 | The taxonomy in use. Refer to the AdCOM [List: Category Taxonomies](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_categorytaxonomies) for values. If no cattax field is supplied IAB Cotent Category Taxonomy 1.0 is assumed. | `cat` | string array | Array of IAB Tech Lab content categories of the site. The taxonomy to be used is defined by the cattax field. |
+|  |
+| `sectioncat` | string array | Array of IAB Tech Lab content categories that describe the current section of the site. The taxonomy to be used is defined by the cattax field. |
+| `pagecat` | string array | Array of IAB Tech Lab content categories that describe the current page or view of the site. The taxonomy to be used is definied by the cattax field. |
+| `page` | string | URL of the page where the impression will be shown. | `ref` | string | Referrer URL that caused navigation to the current page. |
+|  |
+| `search` | string | Search string that caused navigation to the current page. | `mobile` | integer | Indicates if the site has been programmed to optimize layout when viewed on mobile devices, where 0=no, 1=yes. |
+|  |
+| `privacypolicy` | integer | Indicates if the site has a privacy policy, where 0 = no, 1 = yes. |
+| `publisher` | object | Details about the Publisher (Section 3.2.15) of the site. |
+| `content` | object | Details about the Content (Section 3.2.16) within the site. | `keywords` | string | Comma separated list of keywords about the site. Only one of `keywords` or `kwarray` may be present. |
+|  |
+| `kwarray` | string array | Array of keywords about the site. Only one of `keywords` or `kwarray` may be present. | `inventorypartnerdomain` | string | A domain to be used for inventory authorization in the case of inventory sharing arrangements between a site owner and content owner. This field is typically used by authorization crawlers to establish the domain of the content owner, who has the right to monetize some portion of ad inventory within the site. The content owner's domain should be listed in the site owner's ads.txt file as an `inventorypartnerdomain` . Authorization for supply from the `inventorypartnerdomain` will be published in the ads.txt file on the root of that domain. Refer to [the ads.txt 1.1 spec](https://iabtechlab.com/wp-content/uploads/2022/04/Ads.txt-1.1.pdf) for more details. | `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
+| `inventorypartnerdomain` | string | A domain to be used for inventory authorization in the case of inventory sharing arrangements between a site owner and content owner. This field is typically used by authorization crawlers to establish the domain of the content owner, who has the right to monetize some portion of ad inventory within the site. The content owner's domain should be listed in the site owner's ads.txt file as an `inventorypartnerdomain` . Authorization for supply from the `inventorypartnerdomain` will be published in the ads.txt file on the root of that domain. Refer to [the ads.txt 1.1 spec](https://iabtechlab.com/wp-content/uploads/2022/04/Ads.txt-1.1.pdf) for more details. |
+| `inventorypartnerdomain` | string | A domain to be used for inventory authorization in the case of inventory sharing arrangements between a site owner and content owner. This field is typically used by authorization crawlers to establish the domain of the content owner, who has the right to monetize some portion of ad inventory within the site. The content owner's domain should be listed in the site owner's ads.txt file as an `inventorypartnerdomain` . Authorization for supply from the `inventorypartnerdomain` will be published in the ads.txt file on the root of that domain. Refer to [the ads.txt 1.1 spec](https://iabtechlab.com/wp-content/uploads/2022/04/Ads.txt-1.1.pdf) for more details. |
+
 
 
 ### 3.2.14 - Object: App <a name="objectapp"></a>
@@ -1816,105 +853,27 @@ This object should be included if the ad supported content is a website as oppos
 This object should be included if the ad supported content is a non-browser application (typically in mobile) as opposed to a website. A bid request must not contain more than one of a `Site`, `App` or `DOOH` object. At a minimum, it is useful to provide an App ID or bundle, but this is not strictly required.
 
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>id</code></td>
-    <td>string; recommended</td>
-    <td>Exchange-specific app ID.</td>
-  </tr>
-  <tr>
-    <td><code>name</code></td>
-    <td>string</td>
-    <td>App name (may be aliased at the publisher's request).</td>
- </tr>
-  <tr>
-    <td><code>bundle</code></td>
-    <td>string</td>
-    <td>The store ID of the app in an app store. See <a href="https://iabtechlab.com/wp-content/uploads/2020/08/IAB-Tech-Lab-OTT-store-assigned-App-Identification-Guidelines-2020.pdf">OTT/CTV Store Assigned App Identification Guidelines</a> for more details about expected strings for CTV app stores. For mobile apps in Google Play Store, these should be bundle or package names (e.g. com.foo.mygame). For apps in Apple App Store, these should be a numeric ID.</td>
-  </tr>
-  <tr>
-    <td><code>domain</code></td>
-    <td>string</td>
-    <td>Domain of the app (e.g., "mygame.foo.com").</td>
-</tr>
-  <tr>
-    <td><code>storeurl</code></td>
-    <td>string</td>
-    <td>App store URL for an installed app; for IQG 2.1 compliance.</td>
-  </tr>
-  <tr>
-    <td><code>cattax</code></td>
-    <td>integer; default 1</td>
-    <td>The taxonomy in use. Refer to the AdCOM <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_categorytaxonomies">List: Category Taxonomies</a> for values.</td>
-   <tr>
-  </tr>
-    <td><code>cat</code></td>
-    <td>string array</td>
-    <td>Array of IAB Tech Lab content categories of the app. The taxonomy to be used is defined by the cattax field. If no cattax field is supplied Content Category Taxonomy 1.0 is assumed.</td>
-   </tr>
-   <tr>
-    <td><code>sectioncat</code></td>
-    <td>string array</td>
-    <td>Array of IAB Tech Lab content categories that describe the current section of the app. The taxonomy to be used is defined by the cattax field.</td>
-  </tr>
-  <tr>
-    <td><code>pagecat</code></td>
-    <td>string array</td>
-    <td>Array of IAB Tech Lab content categories that describe the current page or view of the app. The taxonomy to be used is definied by the cattax field.</td>
-  </tr>
-  <tr>
-    <td><code>ver</code></td>
-    <td>string</td>
-    <td>Application version.</td>
-   <tr>
-  </tr>
-    <td><code>privacypolicy</code></td>
-    <td>integer</td>
-    <td>Indicates if the app has a privacy policy, where 0 = no, 1 = yes.</td>
-   </tr>
-   <tr>
-    <td><code>paid</code></td>
-    <td>integer</td>
-    <td>0 = app is free, 1 = the app is a paid version.</td>
-  <tr>
-  </tr>
-    <td><code>publisher</code></td>
-    <td>object</td>
-    <td>Details about the Publisher (Section 3.2.15) of the app.</td>
-  </tr>
-  <tr>
-    <td><code>content</code></td>
-    <td>object</td>
-    <td>Details about the Content (Section 3.2.16) within the app.</td>
-   <tr>
-  </tr>
-    <td><code>keywords</code></td>
-    <td>string</td>
-    <td>Comma separated list of keywords about the app. Only one of <code>keywords</code> or <code>kwarray</code> may be present.</td>
-   </tr>
-   <tr>
-    <td><code>kwarray</code></td>
-    <td>string array</td>
-    <td>Array of keywords about the app. Only one of <code>keywords</code> or <code>kwarray</code> may be present.</td>
-  <tr>
-  <tr>
-    <td><code>inventorypartnerdomain</code></td>
-    <td>string</td>
-    <td>A domain to be used for inventory authorization in the case of inventory sharing arrangements between an app owner and content owner. This field is typically used by authorization crawlers to establish the domain of the content owner, who has the right to monetize some portion of ad inventory within the app. The content owner's domain should be listed in the app owner's app-ads.txt file as an <code>inventorypartnerdomain</code>. Authorization for supply from the <code>inventorypartnerdomain</code> will be published in the ads.txt file on the root of that domain. Refer to <a href="https://iabtechlab.com/wp-content/uploads/2022/04/Ads.txt-1.1.pdf">the ads.txt 1.1 spec</a> for more details.</td>
-  </tr>
-  </tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for exchange-specific extensions to OpenRTB.</td>
-     </td>
-     </td>
-  </tr>
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `id` | string; recommended | Exchange-specific app ID. |
+| `name` | string | App name (may be aliased at the publisher's request). |
+| `bundle` | string | The store ID of the app in an app store. See [OTT/CTV Store Assigned App Identification Guidelines](https://iabtechlab.com/wp-content/uploads/2020/08/IAB-Tech-Lab-OTT-store-assigned-App-Identification-Guidelines-2020.pdf) for more details about expected strings for CTV app stores. For mobile apps in Google Play Store, these should be bundle or package names (e.g. com.foo.mygame). For apps in Apple App Store, these should be a numeric ID. |
+| `domain` | string | Domain of the app (e.g., "mygame.foo.com"). |
+| `storeurl` | string | App store URL for an installed app; for IQG 2.1 compliance. |
+| `cattax` | integer; default 1 | The taxonomy in use. Refer to the AdCOM [List: Category Taxonomies](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_categorytaxonomies) for values. | `cat` | string array | Array of IAB Tech Lab content categories of the app. The taxonomy to be used is defined by the cattax field. If no cattax field is supplied Content Category Taxonomy 1.0 is assumed. |
+|  |
+| `sectioncat` | string array | Array of IAB Tech Lab content categories that describe the current section of the app. The taxonomy to be used is defined by the cattax field. |
+| `pagecat` | string array | Array of IAB Tech Lab content categories that describe the current page or view of the app. The taxonomy to be used is definied by the cattax field. |
+| `ver` | string | Application version. | `privacypolicy` | integer | Indicates if the app has a privacy policy, where 0 = no, 1 = yes. |
+|  |
+| `paid` | integer | 0 = app is free, 1 = the app is a paid version. | `publisher` | object | Details about the Publisher (Section 3.2.15) of the app. |
+|  |
+| `content` | object | Details about the Content (Section 3.2.16) within the app. | `keywords` | string | Comma separated list of keywords about the app. Only one of `keywords` or `kwarray` may be present. |
+|  |
+| `kwarray` | string array | Array of keywords about the app. Only one of `keywords` or `kwarray` may be present. | `inventorypartnerdomain` | string | A domain to be used for inventory authorization in the case of inventory sharing arrangements between an app owner and content owner. This field is typically used by authorization crawlers to establish the domain of the content owner, who has the right to monetize some portion of ad inventory within the app. The content owner's domain should be listed in the app owner's app-ads.txt file as an `inventorypartnerdomain` . Authorization for supply from the `inventorypartnerdomain` will be published in the ads.txt file on the root of that domain. Refer to [the ads.txt 1.1 spec](https://iabtechlab.com/wp-content/uploads/2022/04/Ads.txt-1.1.pdf) for more details. | `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
+| `inventorypartnerdomain` | string | A domain to be used for inventory authorization in the case of inventory sharing arrangements between an app owner and content owner. This field is typically used by authorization crawlers to establish the domain of the content owner, who has the right to monetize some portion of ad inventory within the app. The content owner's domain should be listed in the app owner's app-ads.txt file as an `inventorypartnerdomain` . Authorization for supply from the `inventorypartnerdomain` will be published in the ads.txt file on the root of that domain. Refer to [the ads.txt 1.1 spec](https://iabtechlab.com/wp-content/uploads/2022/04/Ads.txt-1.1.pdf) for more details. |
+| `inventorypartnerdomain` | string | A domain to be used for inventory authorization in the case of inventory sharing arrangements between an app owner and content owner. This field is typically used by authorization crawlers to establish the domain of the content owner, who has the right to monetize some portion of ad inventory within the app. The content owner's domain should be listed in the app owner's app-ads.txt file as an `inventorypartnerdomain` . Authorization for supply from the `inventorypartnerdomain` will be published in the ads.txt file on the root of that domain. Refer to [the ads.txt 1.1 spec](https://iabtechlab.com/wp-content/uploads/2022/04/Ads.txt-1.1.pdf) for more details. |
+
 
 
 
@@ -1924,236 +883,59 @@ This object describes the entity who directly supplies inventory to and is paid 
 
 
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>id</code></td>
-    <td>string</td>
-    <td>Exchange-specific seller ID. Every ID must map to only a single entity that is paid for inventory transacted via that ID. Corresponds to a <code>seller_id</code> of a seller in the exchange’s sellers.json file.</td>
-  </tr>
-  <tr>
-    <td><code>name</code></td>
-    <td>string</td>
-    <td>Seller name (may be aliased at the seller's request).</td>
-  </tr>
-  <tr>
-    <td><code>cattax</code></td>
-    <td>integer; default 1</td>
-    <td>The taxonomy in use. Refer to the AdCOM <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_categorytaxonomies">List: Category Taxonomies</a> for values.</td>
-  <tr>
-  </tr>
-    <td><code>cat</code></td>
-    <td>string array</td>
-    <td>Array of IAB Tech Lab content categories of the publisher. The taxonomy to be used is defined by the cattax field. If no cattax field is supplied Content Category Taxonomy 1.0 is assumed.</td>
-  </tr>
-  <tr>
-    <td><code>domain</code></td>
-    <td>string</td>
-    <td>Highest level domain of the seller (e.g., "seller.com").</td>
-  </tr>
-  <tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for exchange-specific extensions to OpenRTB.</td>
-     </td>
-     </td>
-  </tr>
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `id` | string | Exchange-specific seller ID. Every ID must map to only a single entity that is paid for inventory transacted via that ID. Corresponds to a `seller_id` of a seller in the exchange’s sellers.json file. |
+| `name` | string | Seller name (may be aliased at the seller's request). |
+| `cattax` | integer; default 1 | The taxonomy in use. Refer to the AdCOM [List: Category Taxonomies](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_categorytaxonomies) for values. | `cat` | string array | Array of IAB Tech Lab content categories of the publisher. The taxonomy to be used is defined by the cattax field. If no cattax field is supplied Content Category Taxonomy 1.0 is assumed. |
+|  |
+| `domain` | string | Highest level domain of the seller (e.g., "seller.com"). |
+| `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
+
 
 
 ### 3.2.16 - Object: Content <a name="objectcontent"></a>
 
 This object describes the content in which the impression will appear, which may be syndicated or non-syndicated content. This object may be useful when syndicated content contains impressions and does not necessarily match the publisher’s general content. The exchange might or might not have knowledge of the page where the content is running, because of the syndication method. For example, might be a video impression embedded in an iframe on an unknown web property or device.
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>id</code></td>
-    <td>string</td>
-    <td>Publisher-provided ID uniquely identifying the content.</td>
-  </tr>
-  <tr>
-    <td><code>episode</code></td>
-    <td>integer</td>
-    <td>Episode number.</td>
-  </tr>
-  <tr>
-    <td><code>title</code></td>
-    <td>string</td>
-    <td>Content title. <br>*Video Examples:* “Search Committee” (television), “A New Hope” (movie), or “Endgame” (made for web).<br> *Non-Video Example:* “Why an Antarctic Glacier Is Melting So Quickly” (Time magazine article).</td>
-  </tr>
-  <tr>
-    <td><code>series</code></td>
-    <td>string</td>
-    <td>Content series.<br>*Video Examples:* “The Office” (television), “Star Wars” (movie), or “Arby ‘N’ The Chief” (made for web).<br>*Non-Video Example:* “Ecocentric” (Time Magazine blog).</td>
-  </tr>
-  <tr>
-    <td><code>season</code></td>
-    <td>string</td>
-    <td>Content season (e.g., “Season 3”).</td>
-  </tr>
-  <tr>
-    <td><code>artist</code></td>
-    <td>string</td>
-    <td>Artist credited with the content.</td>
-  </tr>
-  <tr>
-    <td><code>genre</code></td>
-    <td>string</td>
-    <td>Genre that best describes the content (e.g., rock, pop, etc).</td>
-  </tr>
-  <tr>
-    <td><code>gtax</code></td>
-    <td>int; default 9</td>
-    <td>The taxonomy in use. Refer to list <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_categorytaxonomies">List: Category Taxonomies</a> in AdCOM 1.0 for values. <br><br>
-    If no gtax field is supplied rows listed, Content Category Taxonomy 3.1 is assumed</td>
-  </tr>
-  <tr>
-    <td><code>genres</code></td>
-    <td>string</td>
-    <td>Unique ID(s) for the genre of the content as listed in the taxonomy defined by the gtax field. If no gtax field is supplied, subset of rows listed in <a href="https://github.com/InteractiveAdvertisingBureau/Taxonomies/blob/main/Taxonomy%20Mappings/CTV%20Genre%20Mapping.tsv">CTV Genre Mapping</a> of <a href="https://github.com/InteractiveAdvertisingBureau/Taxonomies/blob/main/Content%20Taxonomies/Content%20Taxonomy%203.1.tsv">Content Category Taxonomy 3.1</a> are assumed <br><br>
-See  <a href="https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/2.6-202506/implementation.md#genre">Section 7.13 of Implementation Guidance</a> for additional detail.
-  </tr>
-  <tr>
-    <td><code>album</code></td>
-    <td>string</td>
-    <td>Album to which the content belongs; typically for audio.</td>
-  </tr>
-  <tr>
-    <td><code>isrc</code></td>
-    <td>string</td>
-    <td>International Standard Recording Code conforming to ISO- 3901.</td>
-  </tr>
-  <tr>
-    <td><code>producer</code></td>
-    <td>object</td>
-    <td>Details about the content <code>Producer</code> (Section 3.2.17).</td>
-  </tr>
-  <tr>
-    <td><code>url</code></td>
-    <td>string</td>
-    <td>URL of the content, for buy-side contextualization or review.</td>
-  </tr>
-  <tr>
-    <td><code>cattax</code></td>
-    <td>integer; default 1</td>
-    <td>The taxonomy in use. Refer to list <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_categorytaxonomies">List: Category Taxonomies</a> in AdCOM 1.0 for values.</td>
-  </tr>
-  <tr>
-    <td><code>cat</code></td>
-    <td>string array</td>
-    <td>Array of IAB Tech Lab content categories that describe the content. The taxonomy to be used is defined by the cattax field. If no cattax field is supplied Content Category Taxonomy 1.0 is assumed.</td>
-  </tr>
-  <tr>
-    <td><code>prodq</code></td>
-    <td>integer</td>
-    <td>Production quality. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--production-qualities-">List: Production Qualities</a> in AdCOM 1.0.</td>
-  </tr>
-  <tr>
-    <td><code>context</code></td>
-    <td>integer</td>
-    <td>Type of content (game, video, text, etc.). Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--content-contexts-">List: Content Contexts</a> in AdCOM 1.0.</td>
-  </tr>
-  <tr>
-    <td><code>contentrating</code></td>
-    <td>string</td>
-    <td>Content rating (e.g., MPAA).</td>
-  </tr>
-  <tr>
-    <td><code>userrating</code></td>
-    <td>string</td>
-    <td>User rating of the content (e.g., number of stars, likes, etc.).</td>
-  </tr>
-  <tr>
-    <td><code>qagmediarating</code></td>
-    <td>integer</td>
-    <td>Media rating per IQG guidelines. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--media-ratings-">List: Media Ratings</a> in AdCOM 1.0.</td>
-  </tr>
-  <tr>
-    <td><code>keywords</code></td>
-    <td>string</td>
-    <td>Comma separated list of keywords describing the content. Only one of <code>keywords</code> or <code>kwarray</code> may be present.</td>
-  </tr>
-  <tr>
-    <td><code>kwarray</code></td>
-    <td>string array</td>
-    <td>Array of keywords about the site. Only one of <code>keywords</code> or <code>kwarray</code> may be present.</td>
-  </tr>
-  <tr>
-    <td><code>livestream</code></td>
-    <td>integer</td>
-    <td>0 = not live, 1 = content is live (e.g., stream, live blog).</td>
-  </tr>
-  <tr>
-    <td><code>recording</code></td>
-    <td>integer</td>
-    <td>An enumeration indicating how the content was recorded where 0 = pre-recorded content and 1 = real-time. See  <a href="https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/develop/implementation.md#715---additional-telemetry-for-live-events">Section 7.15 of Implementation Guidance</a> for additional detail. 
-</td>
-  </tr>
-<tr>
-    <td><code>airdate</code></td>
-    <td>integer</td>
-    <td>UNIX timestamp indicating when the content was first broadcast or made available to the public in the geographic region where it aired 
-(i.e. 1752057600). <br><br>
-Content airing for the first time at the time of the bid request should use a value of -1. <br><br>
-Content that aired prior to Jan 1, 1970 should use a value of -2.<br><br>
-See  <a href="https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/develop/implementation.md#715---additional-telemetry-for-live-events-">Section 7.15 of Implementation Guidance</a> for additional detail. 
-</td>
-  </tr>
-  <tr>
-    <td><code>sourcerelationship</code></td>
-    <td>integer</td>
-    <td>0 = indirect, 1 = direct.</td>
-  </tr>
-  <tr>
-    <td><code>len</code></td>
-    <td>integer</td>
-    <td>Length of content in seconds; appropriate for video or audio.</td>
-  </tr>
-  <tr>
-    <td><code>language</code></td>
-    <td>string</td>
-    <td>Content language using ISO-639-1-alpha-2. Only one of <code>language</code> or <code>langb</code> should be present.</td>
-  </tr>
-  <tr>
-    <td><code>langb</code></td>
-    <td>string</td>
-    <td>Content language using IETF BCP 47. Only one of <code>language</code> or <code>langb</code> should be present.</td>
-  </tr>
-  <tr>
-    <td><code>embeddable</code></td>
-    <td>integer</td>
-    <td>Indicator of whether the content is embeddable (e.g., an embeddable video player), where 0 = no, 1 = yes.</td>
-  </tr>
-  <tr>
-    <td><code>data</code></td>
-    <td>object array</td>
-    <td>Additional content data. Each <code>Data</code> object (Section 3.2.21) represents a different data source.</td>
-  </tr>
-  <tr>
-    <td><code>network</code></td>
-    <td>object</td>
-    <td>Details about the network (Section 3.2.23) the content is on.</td>
-  </tr>
-  <tr>
-    <td><code>channel</code></td>
-    <td>object</td>
-    <td>Details about the channel (Section 3.2.24) the content is on.</td>
-  </tr>
-  <tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for exchange-specific extensions to OpenRTB.</td>
-  </tr>
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `id` | string | Publisher-provided ID uniquely identifying the content. |
+| `episode` | integer | Episode number. |
+| `title` | string | Content title. *Video Examples:* “Search Committee” (television), “A New Hope” (movie), or “Endgame” (made for web). *Non-Video Example:* “Why an Antarctic Glacier Is Melting So Quickly” (Time magazine article). |
+| `series` | string | Content series. *Video Examples:* “The Office” (television), “Star Wars” (movie), or “Arby ‘N’ The Chief” (made for web). *Non-Video Example:* “Ecocentric” (Time Magazine blog). |
+| `season` | string | Content season (e.g., “Season 3”). |
+| `artist` | string | Artist credited with the content. |
+| `genre` | string | Genre that best describes the content (e.g., rock, pop, etc). |
+| `gtax` | int; default 9 | The taxonomy in use. Refer to list [List: Category Taxonomies](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_categorytaxonomies) in AdCOM 1.0 for values. If no gtax field is supplied rows listed, Content Category Taxonomy 3.1 is assumed |
+| `genres` | string array | Unique ID(s) for the genre of the content as listed in the taxonomy defined by the gtax field. If no gtax field is supplied, subset of rows listed in [CTV Genre Mapping](https://github.com/InteractiveAdvertisingBureau/Taxonomies/blob/main/Taxonomy%20Mappings/CTV%20Genre%20Mapping.tsv) of [Content Category Taxonomy 3.1](https://github.com/InteractiveAdvertisingBureau/Taxonomies/blob/main/Content%20Taxonomies/Content%20Taxonomy%203.1.tsv) are assumed See [Section 7.13 of Implementation Guidance](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/2.6-202506/implementation.md#genre) for additional detail. |
+| `album` | string | Album to which the content belongs; typically for audio. |
+| `isrc` | string | International Standard Recording Code conforming to ISO- 3901. |
+| `producer` | object | Details about the content `Producer` (Section 3.2.17). |
+| `url` | string | URL of the content, for buy-side contextualization or review. |
+| `cattax` | integer; default 1 | The taxonomy in use. Refer to list [List: Category Taxonomies](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_categorytaxonomies) in AdCOM 1.0 for values. |
+| `cat` | string array | Array of IAB Tech Lab content categories that describe the content. The taxonomy to be used is defined by the cattax field. If no cattax field is supplied Content Category Taxonomy 1.0 is assumed. |
+| `prodq` | integer | Production quality. Refer to [List: Production Qualities](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--production-qualities-) in AdCOM 1.0. |
+| `context` | integer | Type of content (game, video, text, etc.). Refer to [List: Content Contexts](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--content-contexts-) in AdCOM 1.0. |
+| `contentrating` | string | Content rating (e.g., MPAA). |
+| `userrating` | string | User rating of the content (e.g., number of stars, likes, etc.). |
+| `qagmediarating` | integer | Media rating per IQG guidelines. Refer to [List: Media Ratings](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--media-ratings-) in AdCOM 1.0. |
+| `keywords` | string | Comma separated list of keywords describing the content. Only one of `keywords` or `kwarray` may be present. |
+| `kwarray` | string array | Array of keywords about the site. Only one of `keywords` or `kwarray` may be present. |
+| `livestream` | integer | 0 = not live, 1 = content is live (e.g., stream, live blog). |
+| `recording` | integer | An enumeration indicating how the content was recorded where 0 = pre-recorded content and 1 = real-time. See [Section 7.15 of Implementation Guidance](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/develop/implementation.md#715---additional-telemetry-for-live-events) for additional detail. |
+| `airdate` | integer | UNIX timestamp indicating when the content was first broadcast or made available to the public in the geographic region where it aired 
+(i.e. 1752057600). Content airing for the first time at the time of the bid request should use a value of -1. Content that aired prior to Jan 1, 1970 should use a value of -2. See [Section 7.15 of Implementation Guidance](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/develop/implementation.md#715---additional-telemetry-for-live-events-) for additional detail. |
+| `sourcerelationship` | integer | 0 = indirect, 1 = direct. |
+| `len` | integer | Length of content in seconds; appropriate for video or audio. |
+| `language` | string | Content language using ISO-639-1-alpha-2. Only one of `language` or `langb` should be present. |
+| `langb` | string | Content language using IETF BCP 47. Only one of `language` or `langb` should be present. |
+| `embeddable` | integer | Indicator of whether the content is embeddable (e.g., an embeddable video player), where 0 = no, 1 = yes. |
+| `data` | object array | Additional content data. Each `Data` object (Section 3.2.21) represents a different data source. |
+| `network` | object | Details about the network (Section 3.2.23) the content is on. |
+| `channel` | object | Details about the channel (Section 3.2.24) the content is on. |
+| `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
+
 
 
 ### 3.2.17 - Object: Producer <a name="objectproducer"></a>
@@ -2161,226 +943,58 @@ See  <a href="https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/de
 This object defines the producer of the content in which the ad will be shown. This is particularly useful when the content is syndicated and may be distributed through different publishers and thus when the producer and publisher are not necessarily the same entity.
 
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>id</code></td>
-    <td>string</td>
-    <td>Content producer or originator ID. Useful if content is syndicated and may be posted on a site using embed tags.</td>
-  </tr>
-  <tr>
-    <td><code>name</code></td>
-    <td>string</td>
-    <td>Content producer or originator name (e.g., “Warner Bros”).</td>
- </tr>
-  <tr>
-    <td><code>cattax</code></td>
-    <td>integer; default 1</td>
-    <td>The taxonomy in use. Refer to the AdCOM 1.0 list <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_categorytaxonomies">List: Category Taxonomies</a> for values.</td>
-   <tr>
-  </tr>
-    <td><code>cat</code></td>
-    <td>string array</td>
-    <td>Array of IAB Tech Lab content categories that describe the content producer. 
-The taxonomy to be used is defined by the cattax field. If no cattax field is supplied Content Category Taxonomy 1.0 is assumed.</td>
-   </tr>
-   <tr>
-    <td><code>domain</code></td>
-    <td>string</td>
-    <td>Highest level domain of the content producer (e.g., "producer.com").</td>
-</tr>
-  <tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for exchange-specific extensions to OpenRTB.</td>
-     </td>
-     </td>
-  </tr>
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `id` | string | Content producer or originator ID. Useful if content is syndicated and may be posted on a site using embed tags. |
+| `name` | string | Content producer or originator name (e.g., “Warner Bros”). |
+| `cattax` | integer; default 1 | The taxonomy in use. Refer to the AdCOM 1.0 list [List: Category Taxonomies](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_categorytaxonomies) for values. | `cat` | string array | Array of IAB Tech Lab content categories that describe the content producer. 
+The taxonomy to be used is defined by the cattax field. If no cattax field is supplied Content Category Taxonomy 1.0 is assumed. |
+|  |
+| `domain` | string | Highest level domain of the content producer (e.g., "producer.com"). |
+| `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
+
 
 
 ### 3.2.18 - Object: Device <a name="objectdevice"></a>
 
 This object provides information pertaining to the device through which the user is interacting. Device information includes its hardware, platform, location, and carrier data. The device can refer to a mobile handset, a desktop computer, set top box, or other digital device.
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>geo</code></td>
-    <td>object; recommended</td>
-    <td>Location of the device assumed to be the user’s current location defined by a <code>Geo</code> object (Section 3.2.19).</td>
-  </tr>
-  <tr>
-    <td><code>dnt</code></td>
-    <td>integer; recommended</td>
-    <td>Standard “Do Not Track” flag as set in the header by the browser, where 0 = tracking is unrestricted, 1 = do not track.</td>
- </tr>
-  <tr>
-    <td><code>lmt</code></td>
-    <td>integer; recommended</td>
-    <td>“Limit Ad Tracking” signal commercially endorsed (e.g., iOS, Android), where 0 = tracking is unrestricted, 1 = tracking must be limited per commercial guidelines.</td>
-  </tr>
-  <tr>
-    <td><code>ua</code></td>
-    <td>string</td>
-    <td>Browser user agent string. This field represents a raw user agent string from the browser. For backwards compatibility, exchanges are recommended to always populate <code>ua</code> with the User-Agent string, when available from the end user’s device, even if an alternative representation, such as the User-Agent Client-Hints, is available and is used to populate <code>sua</code>. No inferred or approximated user agents are expected in this field. <br>If a client supports User-Agent Client Hints, and <code>sua</code> field is present, bidders are recommended to rely on <code>sua</code> for detecting device type, browser type and version and other purposes that rely on the user agent information, and ignore <code>ua</code> field. This is because the <code>ua</code> may contain a frozen or reduced user agent string.</td>
-</tr>
-  <tr>
-    <td><code>sua</code></td>
-    <td>object</td>
-    <td>Structured user agent information defined by a <code>UserAgent</code> object (see Section 3.2.29). If both <code>ua</code> and <code>sua</code> are present in the bid request, <code>sua</code> should be considered the more accurate representation of the device attributes. This is because the <code>ua</code> may contain a frozen or reduced user agent string.</td>
-  </tr>
-  <tr>
-    <td><code>ip</code></td>
-    <td>string</td>
-    <td>IPv4 address closest to device.</td>
-   </tr>
-   <tr>
-    <td><code>ipv6</code></td>
-    <td>string</td>
-    <td>IP address closest to device as IPv6.</td>
-  </tr>
-  <tr>
-    <td><code>devicetype</code></td>
-    <td>integer</td>
-    <td>The general type of device. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--device-types-">List: Device Types</a> in AdCOM 1.0.</td>
-  </tr>
-  <tr>
-    <td><code>make</code></td>
-    <td>string</td>
-    <td>Device make (e.g., “Apple”).</td>
-   </tr>
-  <tr>
-    <td><code>model</code></td>
-    <td>string</td>
-    <td>Device model (e.g., “iPhone”).</td>
-   </tr>
-   <tr>
-    <td><code>os</code></td>
-    <td>string</td>
-    <td>Device operating system (e.g., “iOS”).</td>
-  </tr>
-  <tr>
-    <td><code>osv</code></td>
-    <td>string</td>
-    <td>Device operating system version (e.g., “3.1.2”).</td>
-  </tr>
-  <tr>
-    <td><code>hwv</code></td>
-    <td>string</td>
-    <td>Hardware version of the device (e.g., “5S” for iPhone 5S).</td>
-   </tr>
-  <tr>
-    <td><code>h</code></td>
-    <td>integer</td>
-    <td>Physical height of the screen in pixels.</td>
-   </tr>
-   <tr>
-    <td><code>w</code></td>
-    <td>integer</td>
-    <td>Physical width of the screen in pixels.</td>
-   </tr>
-   <tr>
-    <td><code>ppi</code></td>
-    <td>integer</td>
-    <td>Screen size as pixels per linear inch.</td>
-   </tr>
-   <tr>
-    <td><code>pxratio</code></td>
-    <td>float</td>
-    <td>The ratio of physical pixels to device-independent pixels (DIPS).</td>
-  </tr>
-   <tr>
-    <td><code>js</code></td>
-    <td>integer</td>
-    <td>Support for JavaScript, where 0 = no, 1 = yes.</td>
-   </tr>
-   <tr>
-    <td><code>geofetch</code></td>
-    <td>integer</td>
-    <td>Indicates if the geolocation API will be available to JavaScript code running in the banner, where 0 = no, 1 = yes.</td>
-   </tr>
-   <tr>
-    <td><code>flashver</code></td>
-    <td>string</td>
-    <td>Version of Flash supported by the browser.</td>
-   </tr>
-   <tr>
-    <td><code>language</code></td>
-    <td>string</td>
-    <td>Browser language using ISO-639-1-alpha-2. Only one of <code>language</code> or <code>langb</code> should be present.</td>
-  </tr>
-  <tr>
-    <td><code>langb</code></td>
-    <td>string</td>
-    <td>Browser language using IETF BCP 47. Only one of <code>language</code> or <code>langb</code> should be present.</td>
-   </tr>
-   <tr>
-    <td><code>carrier</code></td>
-    <td>string</td>
-    <td>Carrier or ISP (e.g., “VERIZON”) using exchange curated string names which should be published to bidders *a priori*.</td>
-   </tr>
-   <tr>
-    <td><code>mccmnc</code></td>
-    <td>string</td>
-    <td>Mobile carrier as the concatenated MCC-MNC code (e.g., “310-005” identifies Verizon Wireless CDMA in the USA). Refer to https://en.wikipedia.org/wiki/Mobile_country_code for further examples. Note that the dash between the MCC and MNC parts is required to remove parsing ambiguity. The MCC-MNC values represent the SIM installed on the device and do not change when a device is roaming. Roaming may be inferred by a combination of the MCC-MNC, geo, IP and other data signals.</td>
-   </tr>
-  <tr>
-    <td><code>connectiontype</code></td>
-    <td>integer</td>
-    <td>Network connection type. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--connection-types-">List: Connection Types</a> in AdCOM 1.0.</td>
-  </tr>
-  <tr>
-    <td><code>ifa</code></td>
-    <td>string</td>
-    <td>ID sanctioned for advertiser use in the clear (i.e., not hashed)
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `geo` | object; recommended | Location of the device assumed to be the user’s current location defined by a `Geo` object (Section 3.2.19). |
+| `dnt` | integer; recommended | Standard “Do Not Track” flag as set in the header by the browser, where 0 = tracking is unrestricted, 1 = do not track. |
+| `lmt` | integer; recommended | “Limit Ad Tracking” signal commercially endorsed (e.g., iOS, Android), where 0 = tracking is unrestricted, 1 = tracking must be limited per commercial guidelines. |
+| `ua` | string | Browser user agent string. This field represents a raw user agent string from the browser. For backwards compatibility, exchanges are recommended to always populate `ua` with the User-Agent string, when available from the end user’s device, even if an alternative representation, such as the User-Agent Client-Hints, is available and is used to populate `sua` . No inferred or approximated user agents are expected in this field. If a client supports User-Agent Client Hints, and `sua` field is present, bidders are recommended to rely on `sua` for detecting device type, browser type and version and other purposes that rely on the user agent information, and ignore `ua` field. This is because the `ua` may contain a frozen or reduced user agent string. |
+| `sua` | object | Structured user agent information defined by a `UserAgent` object (see Section 3.2.29). If both `ua` and `sua` are present in the bid request, `sua` should be considered the more accurate representation of the device attributes. This is because the `ua` may contain a frozen or reduced user agent string. |
+| `ip` | string | IPv4 address closest to device. |
+| `ipv6` | string | IP address closest to device as IPv6. |
+| `devicetype` | integer | The general type of device. Refer to [List: Device Types](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--device-types-) in AdCOM 1.0. |
+| `make` | string | Device make (e.g., “Apple”). |
+| `model` | string | Device model (e.g., “iPhone”). |
+| `os` | string | Device operating system (e.g., “iOS”). |
+| `osv` | string | Device operating system version (e.g., “3.1.2”). |
+| `hwv` | string | Hardware version of the device (e.g., “5S” for iPhone 5S). |
+| `h` | integer | Physical height of the screen in pixels. |
+| `w` | integer | Physical width of the screen in pixels. |
+| `ppi` | integer | Screen size as pixels per linear inch. |
+| `pxratio` | float | The ratio of physical pixels to device-independent pixels (DIPS). |
+| `js` | integer | Support for JavaScript, where 0 = no, 1 = yes. |
+| `geofetch` | integer | Indicates if the geolocation API will be available to JavaScript code running in the banner, where 0 = no, 1 = yes. |
+| `flashver` | string | Version of Flash supported by the browser. |
+| `language` | string | Browser language using ISO-639-1-alpha-2. Only one of `language` or `langb` should be present. |
+| `langb` | string | Browser language using IETF BCP 47. Only one of `language` or `langb` should be present. |
+| `carrier` | string | Carrier or ISP (e.g., “VERIZON”) using exchange curated string names which should be published to bidders *a priori*. |
+| `mccmnc` | string | Mobile carrier as the concatenated MCC-MNC code (e.g., “310-005” identifies Verizon Wireless CDMA in the USA). Refer to https://en.wikipedia.org/wiki/Mobile_country_code for further examples. Note that the dash between the MCC and MNC parts is required to remove parsing ambiguity. The MCC-MNC values represent the SIM installed on the device and do not change when a device is roaming. Roaming may be inferred by a combination of the MCC-MNC, geo, IP and other data signals. |
+| `connectiontype` | integer | Network connection type. Refer to [List: Connection Types](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--connection-types-) in AdCOM 1.0. |
+| `ifa` | string | ID sanctioned for advertiser use in the clear (i.e., not hashed) Unless prior arrangements have been made between the buyer and the seller directly, the value in this field is expected to be an ID derived from a call to an advertising API provided by the device’s Operating System. |
+| `didsha1` | string; DEPRECATED | Deprecated as of OpenRTB 2.6. |
+| `didmd5` | string; DEPRECATED | Deprecated as of OpenRTB 2.6. |
+| `dpidsha1` | string; DEPRECATED | Deprecated as of OpenRTB 2.6. |
+| `dpidmd5` | string; DEPRECATED | Deprecated as of OpenRTB 2.6. |
+| `macsha1` | string; DEPRECATED | Deprecated as of OpenRTB 2.6. |
+| `macmd5` | string; DEPRECATED | Deprecated as of OpenRTB 2.6. |
+| `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
 
-  <br>Unless prior arrangements have been made between the buyer and the seller directly, the value in this field is expected to be an ID derived from a call to an advertising API provided by the device’s Operating System.</br></td>
-  </tr>
-  <tr>
-    <td><code>didsha1</code></td>
-    <td>string; DEPRECATED</td>
-    <td>Deprecated as of OpenRTB 2.6.</td>
-  </tr>
-  <tr>
-    <td><code>didmd5</code></td>
-    <td>string; DEPRECATED</td>
-    <td>Deprecated as of OpenRTB 2.6.</td>
-  </tr>
-  <tr>
-    <td><code>dpidsha1</code></td>
-    <td>string; DEPRECATED</td>
-    <td>Deprecated as of OpenRTB 2.6.</td>
-  </tr>
-  <tr>
-    <td><code>dpidmd5</code></td>
-    <td>string; DEPRECATED</td>
-    <td>Deprecated as of OpenRTB 2.6.</td>
-  </tr>
-  <tr>
-    <td><code>macsha1</code></td>
-    <td>string; DEPRECATED</td>
-    <td>Deprecated as of OpenRTB 2.6.</td>
-  </tr>
-  <tr>
-    <td><code>macmd5</code></td>
-    <td>string; DEPRECATED</td>
-    <td>Deprecated as of OpenRTB 2.6.</td>
-  </tr>
-  <tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for exchange-specific extensions to OpenRTB.</td>
-  </tr>
-  </table>
 
 
 ### 3.2.19 - Object: Geo <a name="objectgeo"></a>
@@ -2390,85 +1004,23 @@ This object encapsulates various methods for specifying a geographic location. W
 The `lat`/`lon` attributes should only be passed if they conform to the accuracy depicted in the `type` attribute. For example, the centroid of a geographic region such as postal code should not be passed.
 
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>lat</code></td>
-    <td>float</td>
-    <td>Latitude from -90.0 to +90.0, where negative is south.</td>
-  </tr>
-  <tr>
-    <td><code>lon</code></td>
-    <td>float</td>
-    <td>Longitude from -180.0 to +180.0, where negative is west.</td>
- </tr>
-  <tr>
-    <td><code>type</code></td>
-    <td>integer</td>
-    <td>Source of location data; recommended when passing <code>lat</code>/<code>lon</code>. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--location-types-">List: Location Types</a> in AdCOM 1.0.</td>
-  </tr>
-  <tr>
-    <td><code>accuracy</code></td>
-    <td>integer</td>
-    <td>Estimated location accuracy in meters; recommended when <code>lat</code>/<code>lon</code> are specified and derived from a device’s location services (i.e., type = 1). Note that this is the accuracy as reported from the device. Consult OS specific documentation (e.g., Android, iOS) for exact interpretation.</td>
-</tr>
-  <tr>
-    <td><code>lastfix</code></td>
-    <td>integer</td>
-    <td>Number of seconds since this geolocation fix was established. Note that devices may cache location data across multiple fetches. Ideally, this value should be from the time the actual fix was taken.</td>
-  </tr>
-  <tr>
-    <td><code>ipservice</code></td>
-    <td>integer</td>
-    <td>Service or provider used to determine geolocation from IP address if applicable (i.e., type = 2). Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--ip-location-services-">List: IP Location Services</a> in AdCOM 1.0.</td>
-   <tr>
-  </tr>
-    <td><code>country</code></td>
-    <td>string</td>
-    <td>Country code using ISO-3166-1-alpha-3.</td>
-   </tr>
-   <tr>
-    <td><code>region</code></td>
-    <td>string</td>
-    <td>Region code using ISO-3166-2; 2-letter state code if USA.</td>
-  </tr>
-  <tr>
-    <td><code>regionfips104</code></td>
-    <td>string</td>
-    <td>Region of a country using FIPS 10-4 notation. While OpenRTB supports this attribute, it was withdrawn by NIST in 2008.</td>
-  </tr>
-  <tr>
-    <td><code>metro</code></td>
-    <td>string</td>
-    <td>Google metro code; similar to but not exactly Nielsen DMAs. See Appendix A for a link to the codes.</td>
-   <tr>
-  </tr>
-    <td><code>city</code></td>
-    <td>string</td>
-    <td>City using United Nations Code for Trade & Transport Locations. See Appendix A for a link to the codes.</td>
-   </tr>
-   <tr>
-    <td><code>zip</code></td>
-    <td>string</td>
-    <td>ZIP or postal code.</td>
-  <tr>
-  </tr>
-    <td><code>utcoffset</code></td>
-    <td>integer</td>
-    <td>Local time as the number +/- of minutes from UTC.</td>
- <tr>
-  </tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for exchange-specific extensions to OpenRTB.</td>
-     </td>
-     </td>
-  </tr>
-  </table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `lat` | float | Latitude from -90.0 to +90.0, where negative is south. |
+| `lon` | float | Longitude from -180.0 to +180.0, where negative is west. |
+| `type` | integer | Source of location data; recommended when passing `lat` / `lon` . Refer to [List: Location Types](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--location-types-) in AdCOM 1.0. |
+| `accuracy` | integer | Estimated location accuracy in meters; recommended when `lat` / `lon` are specified and derived from a device’s location services (i.e., type = 1). Note that this is the accuracy as reported from the device. Consult OS specific documentation (e.g., Android, iOS) for exact interpretation. |
+| `lastfix` | integer | Number of seconds since this geolocation fix was established. Note that devices may cache location data across multiple fetches. Ideally, this value should be from the time the actual fix was taken. |
+| `ipservice` | integer | Service or provider used to determine geolocation from IP address if applicable (i.e., type = 2). Refer to [List: IP Location Services](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--ip-location-services-) in AdCOM 1.0. | `country` | string | Country code using ISO-3166-1-alpha-3. |
+|  |
+| `region` | string | Region code using ISO-3166-2; 2-letter state code if USA. |
+| `regionfips104` | string | Region of a country using FIPS 10-4 notation. While OpenRTB supports this attribute, it was withdrawn by NIST in 2008. |
+| `metro` | string | Google metro code; similar to but not exactly Nielsen DMAs. See Appendix A for a link to the codes. | `city` | string | City using United Nations Code for Trade & Transport Locations. See Appendix A for a link to the codes. |
+|  |
+| `zip` | string | ZIP or postal code. | `utcoffset` | integer | Local time as the number +/- of minutes from UTC. | `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
+|  |
+|  |
+
 
 ### 3.2.20 - Object: User <a name="objectuser"></a>
 
@@ -2476,81 +1028,21 @@ This object contains information known or derived about the human user of the de
 
 
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>id</code></td>
-    <td>string</td>
-    <td>Exchange-specific ID for the user.
-	  
-<br>Unless prior arrangements have been made between the buyer and the seller directly, the value in this field is expected to be derived from an ID sync. (see <a href="https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/develop/2.6.md#appendix-c-cookie-based-id-syncing-">Appendix: Cookie Based ID Syncing)</a></br>
-    </td>
-  </tr>
-  <tr>
-    <td><code>buyeruid</code></td>
-    <td>string</td>
-    <td>Buyer-specific ID for the user as mapped by the exchange for the buyer.
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `id` | string | Exchange-specific ID for the user. Unless prior arrangements have been made between the buyer and the seller directly, the value in this field is expected to be derived from an ID sync. (see [Appendix: Cookie Based ID Syncing)](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/develop/2.6.md#appendix-c-cookie-based-id-syncing-) |
+| `buyeruid` | string | Buyer-specific ID for the user as mapped by the exchange for the buyer. Unless prior arrangements have been made between the buyer and the seller directly, the value in this field is expected to be derived from an ID sync. (see [Appendix: Cookie Based ID Syncing)](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/develop/2.6.md#appendix-c-cookie-based-id-syncing-) |
+| `yob` | integer; DEPRECATED | Deprecated as of OpenRTB 2.6. |
+| `gender` | string; DEPRECATED | Deprecated as of OpenRTB 2.6. |
+| `keywords` | string | Comma separated list of keywords, interests, or intent. Only one of `keywords` or `kwarray` may be present. |
+| `kwarray` | string array | Array of keywords about the user. Only one of `keywords` or `kwarray` may be present. | `customdata` | string | Optional feature to pass bidder data that was set in the exchange’s cookie. The string must be in base85 cookie safe characters and be in any format. Proper JSON encoding must be used to include “escaped” quotation marks. |
+|  |
+| `geo` | object | Location of the user’s home base defined by a `Geo` object (Section 3.2.19). This is not necessarily their current location. |
+| `data` | object array | Additional user data. Each `Data` object (Section 3.2.21) represents a different data source. |
+| `consent` | string | When GDPR regulations are in effect this attribute contains the Transparency and Consent Framework’s [Consent String](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md) data structure. | `eids` | object array | Details for support of a standard protocol for multiple third party identity providers (Section 3.2.27). |
+|  |
+| `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
 
-<br>Unless prior arrangements have been made between the buyer and the seller directly, the value in this field is expected to be derived from an ID sync. (see <a href="https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/develop/2.6.md#appendix-c-cookie-based-id-syncing-">Appendix: Cookie Based ID Syncing)</a></br>
-    </td>
- </tr>
-  <tr>
-    <td><code>yob</code></td>
-    <td>integer; DEPRECATED</td>
-    <td>Deprecated as of OpenRTB 2.6.</td>
-  </tr>
-  <tr>
-    <td><code>gender</code></td>
-    <td>string; DEPRECATED</td>
-    <td>Deprecated as of OpenRTB 2.6.</td>
-</tr>
-  <tr>
-    <td><code>keywords</code></td>
-    <td>string</td>
-    <td>Comma separated list of keywords, interests, or intent. Only one of <code>keywords</code> or <code>kwarray</code> may be present.</td>
-  </tr>
-  <tr>
-    <td><code>kwarray</code></td>
-    <td>string array</td>
-    <td>Array of keywords about the user. Only one of <code>keywords</code> or <code>kwarray</code> may be present.</td>
-   <tr>
-  </tr>
-    <td><code>customdata</code></td>
-    <td>string</td>
-    <td>Optional feature to pass bidder data that was set in the exchange’s cookie. The string must be in base85 cookie safe characters and be in any format. Proper JSON encoding must be used to include “escaped” quotation marks.</td>
-   </tr>
-   <tr>
-    <td><code>geo</code></td>
-    <td>object</td>
-    <td>Location of the user’s home base defined by a <code>Geo</code> object (Section 3.2.19). This is not necessarily their current location.</td>
-  </tr>
-  <tr>
-    <td><code>data</code></td>
-    <td>object array</td>
-    <td>Additional user data. Each <code>Data</code> object (Section 3.2.21) represents a different data source.</td>
-  </tr>
-  <tr>
-    <td><code>consent</code></td>
-    <td>string</td>
-    <td>When GDPR regulations are in effect this attribute contains the Transparency and Consent Framework’s <a href="https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md">Consent String</a> data structure.</td>
-   <tr>
-  </tr>
-    <td><code>eids</code></td>
-    <td>object array</td>
-    <td>Details for support of a standard protocol for multiple third party identity providers (Section 3.2.27).</td>
-   </tr>
-   <tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for exchange-specific extensions to OpenRTB.</td>
-     </td>
-     </td>
-  </tr>
-</table>
 
 
 ### 3.2.21 - Object: Data <a name="objectdata"></a>
@@ -2558,40 +1050,14 @@ This object contains information known or derived about the human user of the de
 The data and segment objects together allow additional data about the related object (e.g., user, content) to be specified. This data may be from multiple sources whether from the exchange itself or third parties as specified by the `id` field. A bid request can mix data objects from multiple providers. The specific data providers in use should be published by the exchange a priori to its bidders.
 
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>id</code></td>
-    <td>string</td>
-    <td>Exchange-specific ID for the data provider.</td>
-  </tr>
-  <tr>
-    <td><code>name</code></td>
-    <td>string</td>
-    <td>Exchange-specific name for the data provider.</td>
-  </tr>
-  <tr>
-    <td><code>cids</code></td>
-    <td>string array</td>
-    <td>An array of Extended Content IDs, representing one or more identifiers for the video or audio content from the ID source specified in the <code>name</code> field of the <code>data</code> object.</td>
- </tr>
-  <tr>
-    <td><code>segment</code></td>
-    <td>object array</td>
-    <td>Array of <code>Segment</code> (Section 3.2.22) objects that contain the actual data values.</td>
- </tr>
-  <tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for exchange-specific extensions to OpenRTB.</td>
-     </td>
-     </td>
-  </tr>
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `id` | string | Exchange-specific ID for the data provider. |
+| `name` | string | Exchange-specific name for the data provider. |
+| `cids` | string array | An array of Extended Content IDs, representing one or more identifiers for the video or audio content from the ID source specified in the `name` field of the `data` object. |
+| `segment` | object array | Array of `Segment` (Section 3.2.22) objects that contain the actual data values. |
+| `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
+
 
 
 ### 3.2.22 - Object: Segment <a name="objectsegment"></a>
@@ -2599,35 +1065,13 @@ The data and segment objects together allow additional data about the related ob
 Segment objects are essentially key-value pairs that convey specific units of data. The parent `Data` object is a collection of such values from a given data provider. The specific segment names and value options must be published by the exchange *a priori* to its bidders.
 
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>id</code></td>
-    <td>string</td>
-    <td>ID of the data segment specific to the data provider.</td>
-  </tr>
-  <tr>
-    <td><code>name</code></td>
-    <td>string</td>
-    <td>Name of the data segment specific to the data provider.</td>
-  </tr>
-  <tr>
-    <td><code>value</code></td>
-    <td>string</td>
-    <td>String representation of the data segment value.</td>
- </tr>
-  <tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for exchange-specific extensions to OpenRTB.</td>
-     </td>
-     </td>
-  </tr>
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `id` | string | ID of the data segment specific to the data provider. |
+| `name` | string | Name of the data segment specific to the data provider. |
+| `value` | string | String representation of the data segment value. |
+| `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
+
 
 
 ### 3.2.23 - Object: Network <a name="objectnetwork"></a>
@@ -2635,35 +1079,13 @@ Segment objects are essentially key-value pairs that convey specific units of da
 This object describes the network an ad will be displayed on. A Network is defined as the parent entity of the `Channel` object’s entity for the purposes of organizing Channels. Examples are companies that own and/or license a collection of content channels (Viacom, Discovery, CBS, WarnerMedia, Turner and others), or studio that creates such content and self-distributes content. Name is a human-readable field while domain and id can be used for reporting and targeting purposes. See 7.6 for further examples.
 
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>id</code></td>
-    <td>string</td>
-    <td>A unique identifier assigned by the publisher. This may not be a unique identifier across all supply sources.</td>
-  </tr>
-  <tr>
-    <td><code>name</code></td>
-    <td>string</td>
-    <td>Network the content is on (e.g., a TV network like “ABC")</td>
-  </tr>
-  <tr>
-    <td><code>domain</code></td>
-    <td>string</td>
-    <td>The primary domain of the network (e.g. “abc.com” in the case of the network ABC). It is recommended to include the top private domain (PSL+1) for DSP targeting normalization purposes.</td>
- </tr>
-  <tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for exchange-specific extensions to OpenRTB.</td>
-     </td>
-     </td>
-  </tr>
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `id` | string | A unique identifier assigned by the publisher. This may not be a unique identifier across all supply sources. |
+| `name` | string | Network the content is on (e.g., a TV network like “ABC") |
+| `domain` | string | The primary domain of the network (e.g. “abc.com” in the case of the network ABC). It is recommended to include the top private domain (PSL+1) for DSP targeting normalization purposes. |
+| `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
+
 
 
 ### 3.2.24 - Object: Channel <a name="objectchannel"></a>
@@ -2671,35 +1093,13 @@ This object describes the network an ad will be displayed on. A Network is defin
 This object describes the channel an ad will be displayed on. A Channel is defined as the entity that curates a content library, or stream within a brand name for viewers. Examples are specific view selectable ‘channels’ within linear and streaming television (MTV, HGTV, CNN, BBC One, etc) or a specific stream of audio content commonly called ‘stations.’ Name is a human-readable field while domain and id can be used for reporting and targeting purposes. See 7.6 for further examples.
 
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>id</code></td>
-    <td>string</td>
-    <td>A unique identifier assigned by the publisher. This may not be a unique identifier across all supply sources.</td>
-  </tr>
-  <tr>
-    <td><code>name</code></td>
-    <td>string</td>
-    <td>Channel the content is on (e.g., a TV channel like “WABC-TV")</td>
-  </tr>
-  <tr>
-    <td><code>domain</code></td>
-    <td>string</td>
-    <td>The primary domain of the channel (e.g. “abc7ny.com” in the case of the local channel WABC-TV). It is recommended to include the top private domain (PSL+1) for DSP targeting normalization purposes.</td>
- </tr>
-  <tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for exchange-specific extensions to OpenRTB.</td>
-     </td>
-     </td>
-  </tr>
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `id` | string | A unique identifier assigned by the publisher. This may not be a unique identifier across all supply sources. |
+| `name` | string | Channel the content is on (e.g., a TV channel like “WABC-TV") |
+| `domain` | string | The primary domain of the channel (e.g. “abc7ny.com” in the case of the local channel WABC-TV). It is recommended to include the top private domain (PSL+1) for DSP targeting normalization purposes. |
+| `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
+
 
 
 ### 3.2.25 - Object: SupplyChain <a name="objectsupplychain"></a>
@@ -2707,35 +1107,13 @@ This object describes the channel an ad will be displayed on. A Channel is defin
 This object is composed of a set of nodes where each node represents a specific entity that participates in the transacting of inventory. The entire chain of nodes from beginning to end represents all entities who are involved in the direct flow of payment for inventory. Detailed implementation examples can be found here: https://github.com/InteractiveAdvertisingBureau/openrtb/blob/master/supplychainobject.md
 
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>complete</code></td>
-    <td>integer; required</td>
-    <td>Flag indicating whether the chain contains all nodes involved in the transaction leading back to the owner of the site, app or other medium of the inventory, where 0 = no, 1 = yes.</td>
-  </tr>
-  <tr>
-    <td><code>nodes</code></td>
-    <td>object array; required</td>
-    <td>Array of <code>SupplyChainNode</code> objects in the order of the chain. In a complete supply chain, the first node represents the initial advertising system and seller ID involved in the transaction, i.e. the owner of the site, app, or other medium. In an incomplete supply chain, it represents the first known node. The last node represents the entity sending this bid request.</td>
-  </tr>
-  <tr>
-    <td><code>ver</code></td>
-    <td>string; required</td>
-    <td>Version of the supply chain specification in use, in the format of “major.minor”. For example, for version 1.0 of the spec, use the string “1.0”.</td>
- </tr>
-  <tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for exchange-specific extensions to OpenRTB.</td>
-     </td>
-     </td>
-  </tr>
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `complete` | integer; required | Flag indicating whether the chain contains all nodes involved in the transaction leading back to the owner of the site, app or other medium of the inventory, where 0 = no, 1 = yes. |
+| `nodes` | object array; required | Array of `SupplyChainNode` objects in the order of the chain. In a complete supply chain, the first node represents the initial advertising system and seller ID involved in the transaction, i.e. the owner of the site, app, or other medium. In an incomplete supply chain, it represents the first known node. The last node represents the entity sending this bid request. |
+| `ver` | string; required | Version of the supply chain specification in use, in the format of “major.minor”. For example, for version 1.0 of the spec, use the string “1.0”. |
+| `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
+
 
 
 ### 3.2.26 - Object: SupplyChainNode <a name="objectsupplychainnode"></a>
@@ -2743,50 +1121,16 @@ This object is composed of a set of nodes where each node represents a specific 
 This object is associated with a `SupplyChain` object as an array of nodes. These nodes define the identity of an entity participating in the supply chain of a bid request. Detailed implementation examples can be found here: https://github.com/InteractiveAdvertisingBureau/openrtb/blob/master/supplychainobject.md. The `SupplyChainNode` object contains the following attributes:
 
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>asi</code></td>
-    <td>string; required</td>
-    <td>The canonical domain name of the SSP, Exchange, Header Wrapper, etc system that bidders connect to. This may be the operational domain of the system, if that is different than the parent corporate domain, to facilitate WHOIS and reverse IP lookups to establish clear ownership of the delegate system. This should be the same value as used to identify sellers in an ads.txt file if one exists.</td>
-  </tr>
-  <tr>
-    <td><code>sid</code></td>
-    <td>string; required</td>
-    <td>The identifier associated with the seller or reseller account within the advertising system. This must contain the same value used in transactions (i.e. OpenRTB bid requests) in the field specified by the SSP/exchange. Typically, in OpenRTB, this is <code>publisher.id</code>. For OpenDirect it is typically the publisher’s organization ID. Should be limited to 64 characters in length.</td>
-  </tr>
-  <tr>
-    <td><code>rid</code></td>
-    <td>string</td>
-    <td>The OpenRTB RequestId of the request as issued by this seller.</td>
- </tr>
-  <tr>
-    <td><code>name</code></td>
-    <td>string</td>
-    <td>The name of the company (the legal entity) that is paid for inventory transacted under the given <code>seller_ID</code>. This value is optional and should NOT be included if it exists in the advertising system’s sellers.json file.</td>
-  </tr>
-  <tr>
-    <td><code>domain</code></td>
-    <td>string</td>
-    <td>The business domain name of the entity represented by this node. This value is optional and should NOT be included if it exists in the advertising system’s sellers.json file.</td>
-  </tr>
-  <tr>
-    <td><code>hp</code></td>
-    <td>integer</td>
-    <td>Indicates whether this node will be involved in the flow of payment for the inventory. When set to 1, the advertising system in the <code>asi</code> field pays the seller in the <code>sid</code> field, who is responsible for paying the previous node in the chain. When set to 0, this node is not involved in the flow of payment for the inventory. For version 1.0 of <code>SupplyChain</code>, this property should always be 1. Implementers should ensure that they propagate this field onwards when constructing <code>SupplyChain</code> objects in bid requests sent to a downstream advertising system.</td>
- </tr>
-  <tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for advertising-system specific extensions to this object.</td>
-     </td>
-     </td>
-  </tr>
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `asi` | string; required | The canonical domain name of the SSP, Exchange, Header Wrapper, etc system that bidders connect to. This may be the operational domain of the system, if that is different than the parent corporate domain, to facilitate WHOIS and reverse IP lookups to establish clear ownership of the delegate system. This should be the same value as used to identify sellers in an ads.txt file if one exists. |
+| `sid` | string; required | The identifier associated with the seller or reseller account within the advertising system. This must contain the same value used in transactions (i.e. OpenRTB bid requests) in the field specified by the SSP/exchange. Typically, in OpenRTB, this is `publisher.id` . For OpenDirect it is typically the publisher’s organization ID. Should be limited to 64 characters in length. |
+| `rid` | string | The OpenRTB RequestId of the request as issued by this seller. |
+| `name` | string | The name of the company (the legal entity) that is paid for inventory transacted under the given `seller_ID` . This value is optional and should NOT be included if it exists in the advertising system’s sellers.json file. |
+| `domain` | string | The business domain name of the entity represented by this node. This value is optional and should NOT be included if it exists in the advertising system’s sellers.json file. |
+| `hp` | integer | Indicates whether this node will be involved in the flow of payment for the inventory. When set to 1, the advertising system in the `asi` field pays the seller in the `sid` field, who is responsible for paying the previous node in the chain. When set to 0, this node is not involved in the flow of payment for the inventory. For version 1.0 of `SupplyChain` , this property should always be 1. Implementers should ensure that they propagate this field onwards when constructing `SupplyChain` objects in bid requests sent to a downstream advertising system. |
+| `ext` | object | Placeholder for advertising-system specific extensions to this object. |
+
 
 
 
@@ -2795,53 +1139,15 @@ This object is associated with a `SupplyChain` object as an array of nodes. Thes
 Extended identifiers support in the OpenRTB specification allows buyers to use audience data in real-time bidding. This object can contain one or more UIDs from a single source or a technology provider. The exchange should ensure that business agreements allow for the sending of this data.
 
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-<tr>
-    <td><code>inserter</code></td>
-    <td>string</td>
-    <td>The canonical domain name of the entity (publisher, publisher monetization company, SSP, Exchange, Header Wrapper, etc.) that caused the ID array element to be added. This may be the operational domain of the system, if that is different from the parent corporate domain, to facilitate WHOIS and reverse IP lookups to establish clear ownership of the delegate system.<br>
-    </br>This should be the same value as used to identify sellers in an ads.txt file if one exists.<br>
-</br>For ad tech intermediaries, this would be the domain as used in ads.txt. For publishers, this would match the domain in the <code>site</code> or <code>app</code> object.
-</td>
- </tr>
-  <tr>
-    <td><code>source</code></td>
-    <td>string</td>
-    <td>Canonical domain of the ID.</td>
-  </tr>
-<tr>
-    <td><code>matcher</code></td>
-    <td>string</td>
-    <td>Technology providing the match method as defined in <code>mm</code>.<br>
-</br>In some cases, this may be the same value as inserter.<br>
-</br>When blank, it is assumed that the <code>matcher</code> is equal to the <code>source</code><br>
-</br>May be omitted when mm=0, 1, or 2.<br>
-</td>
- </tr>
-<tr>
-    <td><code>mm</code></td>
-    <td>int</td>
-    <td>Match method used by the <code>matcher</code>. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/main/AdCOM%20v1.0%20FINAL.md#list-id-match-methods-">List: ID Match Methods</a> in AdCOM 1.0
-    </td>
-  </tr>
-  <tr>
-    <td><code>uids</code></td>
-    <td>object array</td>
-    <td>Array of extended ID <code>UID</code> objects from the given source. Refer to the <code>Extended Identifier UIDs</code> object (Section 3.2.28)</td>
- </tr>
-  <tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for exchange-specific extensions to OpenRTB.</td>
-     </td>
-     </td>
-  </tr>
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `inserter` | string | The canonical domain name of the entity (publisher, publisher monetization company, SSP, Exchange, Header Wrapper, etc.) that caused the ID array element to be added. This may be the operational domain of the system, if that is different from the parent corporate domain, to facilitate WHOIS and reverse IP lookups to establish clear ownership of the delegate system. This should be the same value as used to identify sellers in an ads.txt file if one exists. For ad tech intermediaries, this would be the domain as used in ads.txt. For publishers, this would match the domain in the `site` or `app` object. |
+| `source` | string | Canonical domain of the ID. |
+| `matcher` | string | Technology providing the match method as defined in `mm` . In some cases, this may be the same value as inserter. When blank, it is assumed that the `matcher` is equal to the `source` May be omitted when mm=0, 1, or 2. |
+| `mm` | int | Match method used by the `matcher` . Refer to [List: ID Match Methods](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/main/AdCOM%20v1.0%20FINAL.md#list-id-match-methods-) in AdCOM 1.0 |
+| `uids` | object array | Array of extended ID `UID` objects from the given source. Refer to the `Extended Identifier UIDs` object (Section 3.2.28) |
+| `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
+
 
 
 ### 3.2.28 - Object: UID <a name="objectuid"></a>
@@ -2849,30 +1155,12 @@ Extended identifiers support in the OpenRTB specification allows buyers to use a
 This object contains a single user identifier provided as part of extended identifiers. The exchange should ensure that business agreements allow for the sending of this data.
 
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>id</code></td>
-    <td>string</td>
-    <td>The identifier for the user.</td>
-  </tr>
-  <tr>
-    <td><code>atype</code></td>
-    <td>integer</td>
-    <td>Type of user agent the ID is from. It is highly recommended to set this, as many DSPs separate app-native IDs from browser-based IDs and require a type value for ID resolution. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_agenttypes">List: Agent Types</a> in AdCOM 1.0</td>
- </tr>
-  <tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for vendor specific extensions to this object.</td>
-     </td>
-     </td>
-  </tr>
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `id` | string | The identifier for the user. |
+| `atype` | integer | Type of user agent the ID is from. It is highly recommended to set this, as many DSPs separate app-native IDs from browser-based IDs and require a type value for ID resolution. Refer to [List: Agent Types](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_agenttypes) in AdCOM 1.0 |
+| `ext` | object | Placeholder for vendor specific extensions to this object. |
+
 
 
 
@@ -2881,55 +1169,17 @@ This object contains a single user identifier provided as part of extended ident
 Structured user agent information, which can be used when a client supports [User-Agent Client Hints](https://wicg.github.io/ua-client-hints/). If both `device.ua` and `device.sua` are present in the bid request, `device.sua` should be considered the more accurate representation of the device attributes. This is because the `device.ua` may contain a frozen or reduced user agent string due to deprecation of user agent strings by browsers.
 
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>browsers</code></td>
-    <td>array of <code>BrandVersion</code> objects; recommended</td>
-    <td>Each <code>BrandVersion</code> object (see Section 3.2.30) identifies a browser or similar software component. Implementers should send brands and versions derived from the Sec-CH-UA-Full-Version-List header*.</td>
-  </tr>
-  <tr>
-    <td><code>platform</code></td>
-    <td>BrandVersion object; recommended</td>
-    <td>A <code>BrandVersion</code> object (see Section 3.2.30) that identifies the user agent’s execution platform / OS. Implementers should send a brand derived from the Sec-CH-UA-Platform header, and version derived from the Sec-CH-UA-Platform-Version header *.</td>
-  </tr>
-  <tr>
-    <td><code>mobile</code></td>
-    <td>integer</td>
-    <td>1 if the agent prefers a “mobile” version of the content, if available, i.e. optimized for small screens or touch input. 0 if the agent prefers the “desktop” or “full” content. Implementers should derive this value from the Sec-CH-UA-Mobile header *.</td>
- </tr>
-  <tr>
-    <td><code>architecture</code></td>
-    <td>string</td>
-    <td>Device’s major binary architecture, e.g. “x86” or “arm”. Implementers should retrieve this value from the Sec-CH-UA-Arch header*.</td>
-  </tr>
-  <tr>
-    <td><code>bitness</code></td>
-    <td>string</td>
-    <td>Device’s bitness, e.g. “64” for 64-bit architecture. Implementers should retrieve this value from the Sec-CH-UA-Bitness header*.</td>
-  </tr>
-  <tr>
-    <td><code>model</code></td>
-    <td>string</td>
-    <td>Device model. Implementers should retrieve this value from the Sec-CH-UA-Model header*.</td>
- </tr>
-  <tr>
-    <td><code>source</code></td>
-    <td>integer; default 0</td>
-    <td>The source of data used to create this object, <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--user-agent-source-">List: User-Agent Source</a> in AdCOM 1.0</td>
- </tr>
-  <tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for vendor specific extensions to this object.</td>
-     </td>
-     </td>
-  </tr>
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `browsers` | array of `BrandVersion` objects; recommended | Each `BrandVersion` object (see Section 3.2.30) identifies a browser or similar software component. Implementers should send brands and versions derived from the Sec-CH-UA-Full-Version-List header*. |
+| `platform` | BrandVersion object; recommended | A `BrandVersion` object (see Section 3.2.30) that identifies the user agent’s execution platform / OS. Implementers should send a brand derived from the Sec-CH-UA-Platform header, and version derived from the Sec-CH-UA-Platform-Version header *. |
+| `mobile` | integer | 1 if the agent prefers a “mobile” version of the content, if available, i.e. optimized for small screens or touch input. 0 if the agent prefers the “desktop” or “full” content. Implementers should derive this value from the Sec-CH-UA-Mobile header *. |
+| `architecture` | string | Device’s major binary architecture, e.g. “x86” or “arm”. Implementers should retrieve this value from the Sec-CH-UA-Arch header*. |
+| `bitness` | string | Device’s bitness, e.g. “64” for 64-bit architecture. Implementers should retrieve this value from the Sec-CH-UA-Bitness header*. |
+| `model` | string | Device model. Implementers should retrieve this value from the Sec-CH-UA-Model header*. |
+| `source` | integer; default 0 | The source of data used to create this object, [List: User-Agent Source](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--user-agent-source-) in AdCOM 1.0 |
+| `ext` | object | Placeholder for vendor specific extensions to this object. |
+
 
 * or an equivalent JavaScript accessor from [NavigatorUAData interface](https://wicg.github.io/ua-client-hints/#navigatoruadata). This header or accessor are only available for browsers that support [User-Agent Client Hints](https://wicg.github.io/ua-client-hints/). 
 
@@ -2938,66 +1188,24 @@ Structured user agent information, which can be used when a client supports [Use
 Further identification based on [User-Agent Client Hints](https://wicg.github.io/ua-client-hints/), the `BrandVersion` object is used to identify a device’s browser or similar software component, and the user agent’s execution platform or operating system.
 
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>brand</code></td>
-    <td>string; required</td>
-    <td>A brand identifier, for example, “Chrome” or “Windows”. The value may be sourced from the User-Agent Client Hints headers, representing either the user agent brand (from the Sec-CH-UA-Full-Version header) or the platform brand (from the Sec-CH-UA-Platform header).</td>
-  </tr>
-  <tr>
-    <td><code>version</code></td>
-    <td>array of string</td>
-    <td>A sequence of version components, in descending hierarchical order (major, minor, micro, …)</td>
- </tr>
-  <tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for vendor specific extensions to this object.</td>
-     </td>
-     </td>
-  </tr>
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `brand` | string; required | A brand identifier, for example, “Chrome” or “Windows”. The value may be sourced from the User-Agent Client Hints headers, representing either the user agent brand (from the Sec-CH-UA-Full-Version header) or the platform brand (from the Sec-CH-UA-Platform header). |
+| `version` | array of string | A sequence of version components, in descending hierarchical order (major, minor, micro, …) |
+| `ext` | object | Placeholder for vendor specific extensions to this object. |
+
 
 ### 3.2.31 - Object: Qty <a name="objectqty"></a>
 
 A programmatic impression is often referred to as a ‘spot’ in digital out-of-home and CTV, with an impression being a unique member of the audience viewing it. Therefore, a standard means of passing a multiplier in the bid request, representing the total quantity of impressions, is required. This object includes the impression multiplier, and describes the source of the multiplier value.
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>multiplier</code></td>
-    <td>float; required</td>
-    <td>The quantity of billable events which will be deemed to have occurred if this item is purchased. For example, a DOOH opportunity may be considered to be 14.2 impressions. Equivalent to qtyflt in OpenRTB 3.0.</td>
-  </tr>
-  <tr>
-    <td><code>sourcetype</code></td>
-    <td>integer; recommended</td>
-    <td>The source type of the quantity measurement, ie. publisher. Refer to the list https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list-multiplier-measurement-source-types- </td>
- </tr>
-  <tr>
-    <td><code>vendor</code></td>
-    <td>string; required if sourcetype is present and type = 1</td>
-    <td>The top level business domain name of the measurement vendor providing the quantity measurement.</td>
-     </td>
-     <tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for vendor specific extensions to this object.</td>
-     </td>
-     </td>
-  </tr>
-     </td>
-  </tr>
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `multiplier` | float; required | The quantity of billable events which will be deemed to have occurred if this item is purchased. For example, a DOOH opportunity may be considered to be 14.2 impressions. Equivalent to qtyflt in OpenRTB 3.0. |
+| `sourcetype` | integer; recommended | The source type of the quantity measurement, ie. publisher. Refer to the list https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list-multiplier-measurement-source-types- |
+| `vendor` | string; required if sourcetype is present and type = 1 | The top level business domain name of the measurement vendor providing the quantity measurement. | `ext` | object | Placeholder for vendor specific extensions to this object. |
+| `ext` | object | Placeholder for vendor specific extensions to this object. |
+
 
 
 ### 3.2.32 - Object: DOOH <a name="objectdooh"></a>
@@ -3017,97 +1225,35 @@ This object should be included if the ad supported content is a Digital Out-Of-H
 |ext         |object             |Placeholder for exchange-specific extensions to OpenRTB.                                                                                                                                                                                 |
 ### 3.2.33 - Object: Refresh <a name="objectrefresh"></a>
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-<tr>
-    <td><code>refsettings</code></td>
-    <td>object array; recommended</td>
-    <td>A <code>RefSettings</code> object (see Section 3.2.34) describing the mechanics of how an ad placement automatically refreshes.</td>
-</tr>
-  <tr>
-    <td><code>count</code></td>
-    <td>integer; recommended</td>
-    <td>The number of times this ad slot had been refreshed since last page load.</td>
-<tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for vendor specific extensions to this object.</td>
-     </td>
-     </td>
-  </tr>
- </td>
-     </td>
-  </tr>
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `refsettings` | object array; recommended | A `RefSettings` object (see Section 3.2.34) describing the mechanics of how an ad placement automatically refreshes. |
+| `count` | integer; recommended | The number of times this ad slot had been refreshed since last page load. | `ext` | object | Placeholder for vendor specific extensions to this object. |
+| `ext` | object | Placeholder for vendor specific extensions to this object. |
+
 
 ### 3.2.34 - Object: RefSettings <a name="objectrefsettings"></a>
 
 Information on how often and what triggers an ad slot being refreshed. 
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-<tr>
-    <td><code>reftype</code></td>
-    <td>integer; default 0; recommended</td>
-    <td>The type of the declared auto refresh. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/develop/AdCOM%20v1.0%20FINAL.md#list_autorefreshtriggers">List: Auto Refresh Triggers</a> in AdCOM 1.0
-</td>
-</tr>
-  <tr>
-    <td><code>minint</code></td>
-    <td>integer; recommended</td>
-    <td>The minimum refresh interval in seconds. This applies to all refresh types. This is the (uninterrupted) time the ad creative will be rendered before refreshing to the next creative. If the field is absent, the exposure time is unknown. This field does not account for viewability or external factors such as a user leaving a page.
-</td>
- </td>
- <tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for vendor specific extensions to this object.</td>
-     </td>
-     </td>
-  </tr>
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `reftype` | integer; default 0; recommended | The type of the declared auto refresh. Refer to [List: Auto Refresh Triggers](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/develop/AdCOM%20v1.0%20FINAL.md#list_autorefreshtriggers) in AdCOM 1.0 |
+| `minint` | integer; recommended | The minimum refresh interval in seconds. This applies to all refresh types. This is the (uninterrupted) time the ad creative will be rendered before refreshing to the next creative. If the field is absent, the exposure time is unknown. This field does not account for viewability or external factors such as a user leaving a page. | `ext` | object | Placeholder for vendor specific extensions to this object. |
+| `ext` | object | Placeholder for vendor specific extensions to this object. |
+
 
 ### 3.2.35 - Object: DurFloors <a name="objectdurfloors"></a>
 
 This object allows sellers to specify price floors for video and audio creatives, whose price varies based on time. For example: 1-15 seconds at a floor of $5; 16-30 seconds at a floor of $10, > 31 seconds at a floor of $20. There are no explicit constraints on the defined ranges, nor guarantees that they don't overlap. In cases where multiple ranges may apply, it is up to the buyer and seller to coordinate on which floor is applicable.
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>mindur</code></td>
-    <td>integer</td>
-    <td>An integer indicating the low end of a duration range. If this value is missing, the low end is unbounded. Either mindur or maxdur is required, but not both.</td>
-  </tr>
-  <tr>
-    <td><code>maxdur</code></td>
-    <td>integer</td>
-    <td>An integer indicating the high end of a duration range. If this value is missing, the high end is unbounded. Either mindur or maxdur is required, but not both.</td>
-  </tr>
-  <tr>
-    <td><code>bidfloor</code></td>
-    <td>float; default 0</td>
-    <td>Minimum bid for a given impression opportunity, if bidding with a creative in this duration range, expressed in CPM. For any creatives whose durations are outside of the defined min/max, the `bidfloor` at the `Imp` level will serve as the default floor.</td>
-  </tr>
-  <tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for vendor specific extensions to this object.</td>
-     </td>
-     </td>
-  </tr>
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `mindur` | integer | An integer indicating the low end of a duration range. If this value is missing, the low end is unbounded. Either mindur or maxdur is required, but not both. |
+| `maxdur` | integer | An integer indicating the high end of a duration range. If this value is missing, the high end is unbounded. Either mindur or maxdur is required, but not both. |
+| `bidfloor` | float; default 0 | Minimum bid for a given impression opportunity, if bidding with a creative in this duration range, expressed in CPM. For any creatives whose durations are outside of the defined min/max, the `bidfloor` at the `Imp` level will serve as the default floor. |
+| `ext` | object | Placeholder for vendor specific extensions to this object. |
+
 
 # 4. Bid Response Specification <a name="bidresponsespec"></a>
 
@@ -3129,30 +1275,12 @@ The following table summarizes the objects in the Bid Response model and serves 
 
 
 
-<table>
-  <tr>
-    <td><strong>Object&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Section&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>BidResponse</code></td>
-    <td>4.2.1</td>
-    <td>Top-level object.</td>
-  </tr>
-  <tr>
-    <td><code>SeatBid</code></td>
-    <td>4.2.2</td>
-    <td>Collection of bids made by the bidder on behalf of a specific seat.</td>
- </tr>
-  <tr>
-    <td><code>Bid</code></td>
-    <td>4.2.3</td>
-    <td>An offer to buy a specific impression under certain business terms.</td>
-     </td>
-     </td>
-  </tr>
-</table>
+| Object | Section | Description |
+| --- | --- | --- |
+| `BidResponse` | 4.2.1 | Top-level object. |
+| `SeatBid` | 4.2.2 | Collection of bids made by the bidder on behalf of a specific seat. |
+| `Bid` | 4.2.3 | An offer to buy a specific impression under certain business terms. |
+
 
 
 ## 4.2 - Object Specifications <a name="objectspecs"></a>
@@ -3170,50 +1298,16 @@ To express a “no-bid”, the options are to return an empty response with HTTP
 
 
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>id</code></td>
-    <td>string; required</td>
-    <td>ID of the bid request to which this is a response.</td>
-  </tr>
-  <tr>
-    <td><code>seatbid</code></td>
-    <td>object array</td>
-    <td>Array of seatbid objects; 1+ required if a bid is to be made.</td>
- </tr>
-  <tr>
-    <td><code>bidid</code></td>
-    <td>string</td>
-    <td>Bidder generated response ID to assist with logging/tracking.</td>
-</tr>
-  <tr>
-    <td><code>cur</code></td>
-    <td>string; default "USD"</td>
-    <td>Bid currency using ISO-4217 alpha codes.</td>
-  </tr>
-  <tr>
-    <td><code>customdata</code></td>
-    <td>string</td>
-    <td>Optional feature to allow a bidder to set data in the exchange’s cookie. The string must be in base85 cookie safe characters and be in any format. Proper JSON encoding must be used to include “escaped” quotation marks.</td>
- </tr>
-  <tr>
-    <td><code>nbr</code></td>
-    <td>integer</td>
-    <td>Reason for not bidding. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/openrtb/blob/master/OpenRTB%20v3.0%20FINAL.md#list--no-bid-reason-codes-">List: No-Bid Reason Codes</a> in OpenRTB 3.0.</td>
-</tr>
-  <tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for bidder-specific extensions to OpenRTB.</td>
-     </td>
-     </td>
-  </tr>
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `id` | string; required | ID of the bid request to which this is a response. |
+| `seatbid` | object array | Array of seatbid objects; 1+ required if a bid is to be made. |
+| `bidid` | string | Bidder generated response ID to assist with logging/tracking. |
+| `cur` | string; default "USD" | Bid currency using ISO-4217 alpha codes. |
+| `customdata` | string | Optional feature to allow a bidder to set data in the exchange’s cookie. The string must be in base85 cookie safe characters and be in any format. Proper JSON encoding must be used to include “escaped” quotation marks. |
+| `nbr` | integer | Reason for not bidding. Refer to [List: No-Bid Reason Codes](https://github.com/InteractiveAdvertisingBureau/openrtb/blob/master/OpenRTB%20v3.0%20FINAL.md#list--no-bid-reason-codes-) in OpenRTB 3.0. |
+| `ext` | object | Placeholder for bidder-specific extensions to OpenRTB. |
+
 
 
 
@@ -3222,35 +1316,13 @@ To express a “no-bid”, the options are to return an empty response with HTTP
 A bid response can contain multiple `SeatBid` objects, each on behalf of a different bidder seat and each containing one or more individual bids. If multiple impressions are presented in the request, the `group` attribute can be used to specify if a seat is willing to accept any impressions that it can win (default) or if it is only interested in winning any if it can win them all as a group.
 
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>bid</code></td>
-    <td>object array; required</td>
-    <td>Array of 1+ <code>Bid</code> objects (Section 4.2.3) each related to an impression. Multiple bids can relate to the same impression.</td>
-  </tr>
-  <tr>
-    <td><code>seat</code></td>
-    <td>string</td>
-    <td>ID of the buyer seat (e.g., advertiser, agency) on whose behalf this bid is made.</td>
- </tr>
-  <tr>
-    <td><code>group</code></td>
-    <td>integer; default 0</td>
-    <td>0 = impressions can be won individually; 1 = impressions must be won or lost as a group.</td>
-</tr>
-  <tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for bidder-specific extensions to OpenRTB.</td>
-     </td>
-     </td>
-  </tr>
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `bid` | object array; required | Array of 1+ `Bid` objects (Section 4.2.3) each related to an impression. Multiple bids can relate to the same impression. |
+| `seat` | string | ID of the buyer seat (e.g., advertiser, agency) on whose behalf this bid is made. |
+| `group` | integer; default 0 | 0 = impressions can be won individually; 1 = impressions must be won or lost as a group. |
+| `ext` | object | Placeholder for bidder-specific extensions to OpenRTB. |
+
 
 
 
@@ -3259,185 +1331,42 @@ A bid response can contain multiple `SeatBid` objects, each on behalf of a diffe
 A `SeatBid` object contains one or more `Bid` objects, each of which relates to a specific impression in the bid request via the `impid` attribute and constitutes an offer to buy that impression for a given `price`.
 
 
-<table>
-  <tr>
-    <td><strong>Attribute&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-  <tr>
-    <td><code>id</code></td>
-    <td>string; required</td>
-    <td>Bidder generated bid ID to assist with logging/tracking.</td>
-  </tr>
-  <tr>
-    <td><code>impid</code></td>
-    <td>string; required</td>
-    <td>ID of the <code>Imp</code> object in the related bid request.</td>
- </tr>
-  <tr>
-    <td><code>price</code></td>
-    <td>float; required</td>
-    <td>Bid price expressed as CPM although the actual transaction is for a unit impression only. Note that while the type indicates float, integer math is highly recommended when handling currencies (e.g., BigDecimal in Java).</td>
-</tr>
-  <tr>
-    <td><code>nurl</code></td>
-    <td>string</td>
-    <td>Win notice URL called by the exchange if the bid wins (not necessarily indicative of a delivered, viewed, or billable ad); optional means of serving ad markup. Substitution macros (Section 4.4) may be included in both the URL and optionally returned markup.</td>
-  </tr>
-  <tr>
-    <td><code>burl</code></td>
-    <td>string</td>
-    <td>Billing notice URL called by the exchange when a winning bid becomes billable based on exchange-specific business policy (e.g., typically delivered, viewed, etc.). Substitution macros (Section 4.4) may be included.</td>
- </tr>
-  <tr>
-    <td><code>lurl</code></td>
-    <td>string</td>
-    <td>Loss notice URL called by the exchange when a bid is known to have been lost. Substitution macros (Section 4.4) may be included. Exchange-specific policy may preclude support for loss notices or the disclosure of winning clearing prices resulting in ${AUCTION_PRICE} macros being removed (i.e., replaced with a zero-length string).</td>
- </tr>
-  <tr>
-    <td><code>adm</code></td>
-    <td>string</td>
-    <td>Optional means of conveying ad markup in case the bid wins; supersedes the win notice if markup is included in both. Substitution macros (Section 4.4) may be included.</td>
-  </tr>
-  <tr>
-    <td><code>adid</code></td>
-    <td>string</td>
-    <td>ID of a preloaded ad to be served if the bid wins.</td>
- </tr>
-  <tr>
-    <td><code>adomain</code></td>
-    <td>string array</td>
-    <td>Advertiser domain for block list checking (e.g., “ford.com”). This can be an array of for the case of rotating creatives. Exchanges can mandate that only one domain is allowed.</td>
-</tr>
-  <tr>
-    <td><code>bundle</code></td>
-    <td>string</td>
-    <td>The store ID of the app in an app store (e.g., Apple App Store, Google Play). See <a href="https://iabtechlab.com/wp-content/uploads/2020/08/IAB-Tech-Lab-OTT-store-assigned-App-Identification-Guidelines-2020.pdf">OTT/CTV Store Assigned App Identification Guidelines</a> for more details about expected strings for CTV app stores. For mobile apps in Google Play Store, these should be bundle or package names (e.g. com.foo.mygame). For apps in Apple App Store, these should be a numeric ID.</td>
-  </tr>
-  <tr>
-    <td><code>iurl</code></td>
-    <td>string</td>
-    <td>URL without cache-busting to an image that is representative of the content of the campaign for ad quality/safety checking.</td>
-</tr>
-  <tr>
- <td><code>cid</code></td>
-    <td>string</td>
-    <td>Campaign ID to assist with ad quality checking; the collection of creatives for which <code>iurl</code> should be representative.</td>
- </tr>
-  <tr>
-    <td><code>crid</code></td>
-    <td>string</td>
-    <td>Creative ID to assist with ad quality checking.</td>
- </tr>
-  <tr>
-    <td><code>tactic</code></td>
-    <td>string</td>
-    <td>Tactic ID to enable buyers to label bids for reporting to the exchange the tactic through which their bid was submitted. The specific usage and meaning of the tactic ID should be communicated between buyer and exchanges <i>a priori</i>.</td>
-  </tr>
-  <tr>
-    <td><code>cattax</code></td>
-    <td>integer; default 1</td>
-    <td>The taxonomy in use. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_categorytaxonomies">List: Category Taxonomies</a> for values.</td>
- </tr>
-  <tr>
-    <td><code>cat</code></td>
-    <td>string array</td>
-    <td>IAB Tech Lab content categories of the creative. The taxonomy to be used is defined by the cattax field. If no cattax field is supplied Content Taxonomy 1.0 is assumed </td>
-</tr>
-  <tr>
-    <td><code>attr</code></td>
-    <td>integer array</td>
-    <td>Set of attributes describing the creative. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--creative-attributes-">List: Creative Attributes</a> in AdCOM 1.0.</td>
-  </tr>
-  <tr>
-    <td><code>apis</code></td>
-    <td>integer array</td>
-    <td>List of supported APIs for the markup. If an API is not explicitly listed, it is assumed to be unsupported. Refer to <a href:="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--api-frameworks-">List: API Frameworks</a> in AdCOM 1.0.</td>
-</tr>
-  <tr>
-<td><code>api</code></td>
-    <td>integer; DEPRECATED</td>
-	  <td>NOTE: Deprecated in favor of <code>apis</code>.</td>
- </tr>
-  <tr>
-    <td><code>protocol</code></td>
-    <td>integer</td>
-    <td>Video response protocol of the markup if applicable. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--creative-subtypes---audiovideo-">List: Creative Subtypes - Audio/Video</a> in AdCOM 1.0.</td>
- </tr>
-  <tr>
-    <td><code>qagmediarating</code></td>
-    <td>integer</td>
-    <td>Creative media rating per IQG guidelines. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--media-ratings-">List: Media Ratings</a> in AdCOM 1.0.</td>
-  </tr>
-  <tr>
-    <td><code>language</code></td>
-    <td>string</td>
-    <td>Language of the creative using ISO-639-1-alpha-2. The non- standard code “xx” may also be used if the creative has no linguistic content (e.g., a banner with just a company logo). Only one of <code>language</code> or <code>langb</code> should be present.</td>
- </tr>
-  <tr>
-    <td><code>langb</code></td>
-    <td>string</td>
-    <td>Language of the creative using IETF BCP 47. Only one of <code>language</code> or <code>langb</code> should be present.</td>
-</tr>
-  <tr>
-    <td><code>dealid</code></td>
-    <td>string</td>
-	  <td>Reference to the <code>deal.id</code> from the bid request if this bid pertains to a private marketplace direct deal.</td>
-  </tr>
-  <tr>
-    <td><code>w</code></td>
-    <td>integer</td>
-    <td>Width of the creative in device-independent pixels (DIPS).</td>
-</tr>
-  <tr>
-<td><code>h</code></td>
-    <td>integer</td>
-    <td>Height of the creative in device-independent pixels (DIPS).</td>
- </tr>
-  <tr>
-    <td><code>wratio</code></td>
-    <td>integer</td>
-    <td>Relative width of the creative when expressing size as a ratio. Required for Flex Ads.</td>
- </tr>
-  <tr>
-    <td><code>hratio</code></td>
-    <td>integer</td>
-    <td>Relative height of the creative when expressing size as a ratio. Required for Flex Ads.</td>
-  </tr>
-  <tr>
-    <td><code>exp</code></td>
-    <td>integer</td>
-    <td>Advisory as to the number of seconds the bidder is willing to wait between the auction and the actual impression.</td>
- </tr>
-  <tr>
-    <td><code>dur</code></td>
-    <td>integer</td>
-    <td>Duration of the video or audio creative in seconds.</td>
-</tr>
-  <tr>
-    <td><code>mtype</code></td>
-    <td>integer</td>
-    <td>Type of the creative markup so that it can properly be associated with the right sub-object of the <code>BidRequest.Imp.</code><br>
-Values:<br>  
-1 = Banner<br>
-2 = Video,<br>
-3 = Audio<br>
-4 = Native<br></td>
-  </tr>
-  <tr>
-    <td><code>slotinpod</code></td>
-    <td>integer; default 0</td>
-    <td>Indicates that the bid response is only eligible for a specific position within a video or audio ad pod (e.g. first position, last position, or any). Refer to List: <a href="https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_slotpositioninpod">Slot Position in Pod</a> in AdCOM 1.0 for guidance on the use of this field.</td>
-</tr>
-  <tr>
-    <td><code>ext</code></td>
-    <td>object</td>
-    <td>Placeholder for bidder-specific extensions to OpenRTB.</td>
-     </td>
-     </td>
-  </tr>
-</table>
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `id` | string; required | Bidder generated bid ID to assist with logging/tracking. |
+| `impid` | string; required | ID of the `Imp` object in the related bid request. |
+| `price` | float; required | Bid price expressed as CPM although the actual transaction is for a unit impression only. Note that while the type indicates float, integer math is highly recommended when handling currencies (e.g., BigDecimal in Java). |
+| `nurl` | string | Win notice URL called by the exchange if the bid wins (not necessarily indicative of a delivered, viewed, or billable ad); optional means of serving ad markup. Substitution macros (Section 4.4) may be included in both the URL and optionally returned markup. |
+| `burl` | string | Billing notice URL called by the exchange when a winning bid becomes billable based on exchange-specific business policy (e.g., typically delivered, viewed, etc.). Substitution macros (Section 4.4) may be included. |
+| `lurl` | string | Loss notice URL called by the exchange when a bid is known to have been lost. Substitution macros (Section 4.4) may be included. Exchange-specific policy may preclude support for loss notices or the disclosure of winning clearing prices resulting in ${AUCTION_PRICE} macros being removed (i.e., replaced with a zero-length string). |
+| `adm` | string | Optional means of conveying ad markup in case the bid wins; supersedes the win notice if markup is included in both. Substitution macros (Section 4.4) may be included. |
+| `adid` | string | ID of a preloaded ad to be served if the bid wins. |
+| `adomain` | string array | Advertiser domain for block list checking (e.g., “ford.com”). This can be an array of for the case of rotating creatives. Exchanges can mandate that only one domain is allowed. |
+| `bundle` | string | The store ID of the app in an app store (e.g., Apple App Store, Google Play). See [OTT/CTV Store Assigned App Identification Guidelines](https://iabtechlab.com/wp-content/uploads/2020/08/IAB-Tech-Lab-OTT-store-assigned-App-Identification-Guidelines-2020.pdf) for more details about expected strings for CTV app stores. For mobile apps in Google Play Store, these should be bundle or package names (e.g. com.foo.mygame). For apps in Apple App Store, these should be a numeric ID. |
+| `iurl` | string | URL without cache-busting to an image that is representative of the content of the campaign for ad quality/safety checking. |
+| `cid` | string | Campaign ID to assist with ad quality checking; the collection of creatives for which `iurl` should be representative. |
+| `crid` | string | Creative ID to assist with ad quality checking. |
+| `tactic` | string | Tactic ID to enable buyers to label bids for reporting to the exchange the tactic through which their bid was submitted. The specific usage and meaning of the tactic ID should be communicated between buyer and exchanges a priori . |
+| `cattax` | integer; default 1 | The taxonomy in use. Refer to [List: Category Taxonomies](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_categorytaxonomies) for values. |
+| `cat` | string array | IAB Tech Lab content categories of the creative. The taxonomy to be used is defined by the cattax field. If no cattax field is supplied Content Taxonomy 1.0 is assumed |
+| `attr` | integer array | Set of attributes describing the creative. Refer to [List: Creative Attributes](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--creative-attributes-) in AdCOM 1.0. |
+| `apis` | integer array | List of supported APIs for the markup. If an API is not explicitly listed, it is assumed to be unsupported. Refer to [List: API Frameworks]() in AdCOM 1.0. |
+| `api` | integer; DEPRECATED | NOTE: Deprecated in favor of `apis` . |
+| `protocol` | integer | Video response protocol of the markup if applicable. Refer to [List: Creative Subtypes - Audio/Video](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--creative-subtypes---audiovideo-) in AdCOM 1.0. |
+| `qagmediarating` | integer | Creative media rating per IQG guidelines. Refer to [List: Media Ratings](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--media-ratings-) in AdCOM 1.0. |
+| `language` | string | Language of the creative using ISO-639-1-alpha-2. The non- standard code “xx” may also be used if the creative has no linguistic content (e.g., a banner with just a company logo). Only one of `language` or `langb` should be present. |
+| `langb` | string | Language of the creative using IETF BCP 47. Only one of `language` or `langb` should be present. |
+| `dealid` | string | Reference to the `deal.id` from the bid request if this bid pertains to a private marketplace direct deal. |
+| `w` | integer | Width of the creative in device-independent pixels (DIPS). |
+| `h` | integer | Height of the creative in device-independent pixels (DIPS). |
+| `wratio` | integer | Relative width of the creative when expressing size as a ratio. Required for Flex Ads. |
+| `hratio` | integer | Relative height of the creative when expressing size as a ratio. Required for Flex Ads. |
+| `exp` | integer | Advisory as to the number of seconds the bidder is willing to wait between the auction and the actual impression. |
+| `dur` | integer | Duration of the video or audio creative in seconds. |
+| `mtype` | integer | Type of the creative markup so that it can properly be associated with the right sub-object of the `BidRequest.Imp.` Values: 1 = Banner 2 = Video, 3 = Audio 4 = Native |
+| `slotinpod` | integer; default 0 | Indicates that the bid response is only eligible for a specific position within a video or audio ad pod (e.g. first position, last position, or any). Refer to List: [Slot Position in Pod](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list_slotpositioninpod) in AdCOM 1.0 for guidance on the use of this field. |
+| `ext` | object | Placeholder for bidder-specific extensions to OpenRTB. |
+
 
 
 For each bid, the `nurl` attribute can contain the win notice URL. If the bidder wins the impression, the exchange calls this notice URL to inform the bidder of the win and to convey certain information using substitution macros (see Section 4.5) such as the clearing price. The win notice return or the `adm` attribute can be used to serve markup (see Section 4.4). In either case, the exchange will also apply the aforementioned substitution to any macros found in the markup.
@@ -3490,65 +1419,22 @@ These same substitution macros can also be placed in the ad markup. The exchange
 
 
 
-<table>
-  <tr>
-    <td><strong>Macro&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-  </tr>
-  <tr>
-    <td><code>${AUCTION_ID}</code></td>
-    <td>ID of the bid request; from <code>BidRequest.id</code> attribute.</td>
-  </tr>
-  <tr>
-    <td><code>${AUCTION_BID_ID}</code></td>
-    <td>ID of the bid; from <code>BidResponse.bidid</code> attribute.</td>
- </tr>
-  <tr>
-    <td><code>${AUCTION_IMP_ID}</code></td>
-    <td>ID of the impression just won; from <code>imp.id</code> attribute.</td>
-</tr>
-  <tr>
-    <td><code>${AUCTION_SEAT_ID}</code></td>
-    <td>ID of the bidder seat for whom the bid was made.</td>
-  </tr>
-  <tr>
-    <td><code>${AUCTION_AD_ID}</code></td>
-    <td>ID of the ad markup the bidder wishes to serve; from <code>bid.adid</code> attribute.</td>
- </tr>
-  <tr>
-    <td><code>${AUCTION_PRICE}</code></td>
-    <td>Clearing price using the same currency and units as the bid.</td>
- </tr>
-  <tr>
-    <td><code>${AUCTION_CURRENCY}</code></td>
-    <td>The currency used in the bid (explicit or implied); for confirmation only.</td>
-  </tr>
-  <tr>
-    <td><code>${AUCTION_MBR}</code></td>
-    <td>Market Bid Ratio defined as: clearance price / bid price.</td>
- </tr>
-  <tr>
-    <td><code>${AUCTION_LOSS}</code></td>  
-    <td>Loss reason codes. Refer to <a href="https://github.com/InteractiveAdvertisingBureau/openrtb/blob/master/OpenRTB%20v3.0%20FINAL.md#list--loss-reason-codes-">List: Loss Reason Codes</a> in OpenRTB 3.0.</td>
-</tr>
-  <tr>
-    <td><code>${AUCTION_MIN_TO_WIN}</code></td>
-    <td>Minimum bid to win the exchange's auction, using the same currency and units as the bid.</td>
-     </td>
-     </td>
-  </tr>
-  <tr>
-    <td><code>${AUCTION_MULTIPLIER}</code></td>
-    <td>The total quantity of impressions won; for confirmation only. This should always be less than or equal to the multiplier value sent in the bid request. This value is a float value greater than zero and may be less than one. Should be used to confirm that the buyer expects and understands the multiplier value.</td>
-     </td>
-     </td>
-  </tr>
-  <tr>
-    <td><code>${AUCTION_IMP_TS}</code></td>
-    <td>Timestamp when the impression was fulfilled (e.g. when the ad is displayed) in Unix format (i.e., milliseconds since the epoch).
-This may be used by platforms that cannot fire a notification as soon as the impression takes place. If omitted, it is assumed the impression took place a few seconds before the notification is fired.</td>
- </tr>
-</table>
+| Macro | Description |
+| --- | --- |
+| `${AUCTION_ID}` | ID of the bid request; from `BidRequest.id` attribute. |
+| `${AUCTION_BID_ID}` | ID of the bid; from `BidResponse.bidid` attribute. |
+| `${AUCTION_IMP_ID}` | ID of the impression just won; from `imp.id` attribute. |
+| `${AUCTION_SEAT_ID}` | ID of the bidder seat for whom the bid was made. |
+| `${AUCTION_AD_ID}` | ID of the ad markup the bidder wishes to serve; from `bid.adid` attribute. |
+| `${AUCTION_PRICE}` | Clearing price using the same currency and units as the bid. |
+| `${AUCTION_CURRENCY}` | The currency used in the bid (explicit or implied); for confirmation only. |
+| `${AUCTION_MBR}` | Market Bid Ratio defined as: clearance price / bid price. |
+| `${AUCTION_LOSS}` | Loss reason codes. Refer to [List: Loss Reason Codes](https://github.com/InteractiveAdvertisingBureau/openrtb/blob/master/OpenRTB%20v3.0%20FINAL.md#list--loss-reason-codes-) in OpenRTB 3.0. |
+| `${AUCTION_MIN_TO_WIN}` | Minimum bid to win the exchange's auction, using the same currency and units as the bid. |
+| `${AUCTION_MULTIPLIER}` | The total quantity of impressions won; for confirmation only. This should always be less than or equal to the multiplier value sent in the bid request. This value is a float value greater than zero and may be less than one. Should be used to confirm that the buyer expects and understands the multiplier value. |
+| `${AUCTION_IMP_TS}` | Timestamp when the impression was fulfilled (e.g. when the ad is displayed) in Unix format (i.e., milliseconds since the epoch).
+This may be used by platforms that cannot fire a notification as soon as the impression takes place. If omitted, it is assumed the impression took place a few seconds before the notification is fired. |
+
 
 
 Note that OpenRTB compliance exchanges must support all macros for which data is available and support substitution in both markup and URLs for win and billing notification.
@@ -3582,68 +1468,24 @@ In the following examples, assume an auction with a floor price of $0.85, and th
 
 For a first-price auction:<br>
 
-<table>
-  <tr>
-    <td><strong>Bid Price&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>${AUCTION_PRICE}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>${AUCTION_MIN_TO_WIN}</strong></td>
-  </tr>
-  <tr>
-    <td><code>$1.00</code></td>
-    <td>$1.00</td>
-    <td>$0.90</td>
-  </tr>
-  <tr>
-    <td><code>$0.90</code></td>
-    <td>Empty string</td>
-    <td>$1.00</td>
- </tr>
-  <tr>
-    <td><code>$0.80</code></td>
-    <td>Empty string</td>
-    <td>$1.00</td>
-</tr>
-  <tr>
-    <td><code>Invalid</code></td>
-    <td>n/a</td>
-    <td>Empty string</td>
-     </td>
-     </td>
-  </tr>
-</table>
+| Bid Price | ${AUCTION_PRICE} | ${AUCTION_MIN_TO_WIN} |
+| --- | --- | --- |
+| `$1.00` | $1.00 | $0.90 |
+| `$0.90` | Empty string | $1.00 |
+| `$0.80` | Empty string | $1.00 |
+| `Invalid` | n/a | Empty string |
+
 
 
 For a second-price auction (where, for the sake of the illustration, the clearing price is the second-best price plus $0.01):<br>
 
-<table>
-  <tr>
-    <td><strong>Bid Price&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>${AUCTION_PRICE}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>${AUCTION_MIN_TO_WIN}</strong></td>
-  </tr>
-  <tr>
-    <td><code>$1.00</code></td>
-    <td>$0.91</td>
-    <td>$0.90</td>
-  </tr>
-  <tr>
-    <td><code>$0.90</code></td>
-    <td>Empty string</td>
-    <td>$0.91</td>
- </tr>
-  <tr>
-    <td><code>$0.80</code></td>
-    <td>Empty string</td>
-    <td>$0.91</td>
-</tr>
-  <tr>
-    <td><code>Invalid</code></td>
-    <td>n/a</td>
-    <td>Empty string</td>
-     </td>
-     </td>
-  </tr>
-</table>
+| Bid Price | ${AUCTION_PRICE} | ${AUCTION_MIN_TO_WIN} |
+| --- | --- | --- |
+| `$1.00` | $0.91 | $0.90 |
+| `$0.90` | Empty string | $0.91 |
+| `$0.80` | Empty string | $0.91 |
+| `Invalid` | n/a | Empty string |
+
 
 
 
@@ -4236,6 +2078,12 @@ Following is an example of a bid response that returns a native ad inline to be 
 - [7.10 - Updated Video Signals](implementation.md#videosignals)
 
 - [7.11 - Guidance on the Use of Floors](implementation.md#floors)
+  
+- [7.12 - ID Match Method Guidance](implementation.md#idmm)
+  
+- [7.13 - Using genres and gtax attributes](implementation.md#genre)
+  
+- [7.14 - Using Extended Content Identifiers](implementation.md#cids)
 
 	
 # Appendix A. Additional Information <a name="appendixa"></a>
@@ -4289,220 +2137,71 @@ This appendix serves as an index of specification changes across 2.x versions. T
 
 	
 **Version 2.6-202210 (Base 2.6 version) to 2.6-202211:**
-<table>
-  <tr>
-    <td><strong>Section&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-  </tr>
-  <tr>
-  <td><code><b>3.1</b></code></td>
-	  <td><b>Object Model</b> Update to model image to show DOOH and Qty objects</td>
-  </tr>
-  <tr>
- <td><code><b>3.2.3</b></code></td>
-    <td><b>Object: Regs</b> Additional fields gpp and gpp_sid to support Global Privacy Protection string</td>
- </tr>
-  <tr>
-	  <td><code><b>3.2.13, 3.2.14</b></code></td>
-	  <td><b>Objects: Site, App</b> Added inventorypartnerdomain (previously ext)</td>
-     <tr>
-  </tr>
- <td><code><b>3.2.31</b></code></td>
-	<td><b>Object: Qty</b> New object to describe source of multiplier value in Digital Out of Home </td>
-  </tr>
-  <tr>
-    <td><code><b>3.2.32</b></code></td>
-    <td><b>Object: DOOH</b> New object to support programmatic buys of Digital Out of Home inventory</td>
- </tr>
-  <tr>
-    <td><code><b>7.9</b></code></td>
-    <td><b>Implementation Notes</b> Addition of notes, examples and best practices for utilizing DOOH</td>
-</tr>
-</table>
+| Section | Description |
+| --- | --- |
+| `3.1` | Object Model Update to model image to show DOOH and Qty objects |
+| `3.2.3` | Object: Regs Additional fields gpp and gpp_sid to support Global Privacy Protection string |
+| `3.2.13, 3.2.14` | Objects: Site, App Added inventorypartnerdomain (previously ext) | `3.2.31` | Object: Qty New object to describe source of multiplier value in Digital Out of Home |
+|  |
+| `3.2.32` | Object: DOOH New object to support programmatic buys of Digital Out of Home inventory |
+| `7.9` | Implementation Notes Addition of notes, examples and best practices for utilizing DOOH |
+
 
 **Version 2.5 to 2.6:**
 	
 	
-<table>
-  <tr>
-    <td><strong>Section&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-  </tr>
-  <tr>
-	  <td><code><b>3.2.1, 3.2.16, 4.2.3, 3.2.18</b></code></td>
-    <td>Added new language field to support IETF BCP 47, IETF BCP 47 offers additional layers of granularity, for example, differentiating written language versions of the same spoken language (e.g. Traditional and Simplified Chinese), https://en.wikipedia.org/wiki/IETF_language_tag</td>
-  </tr>
-   <td><code><b>3.2.3</b></code></td>
-    <td><b>Object: Regs</b> added `gdpr` attribute (previously ext)</td>
- </tr><tr>
-<td><code><b>3.2.20</b></code></td>
-    <td><b>Object: User</b> added `consent` attribute (previously ext)</td>
- </tr><tr>
-  <tr>
-    <td><code><b>5</b></code></td>
-    <td>Removed section (Enumerated Lists) All references now point to AdCOM 1.0 / OpenRTB 3.0 Lists</td>
- </tr>
-  <tr>
-    <td><code><b>3.2.1, 3.2.13, 3.2.14, 3.2.15, 3.2.16, 3.2.17, 4.2.3</b></code></td>
-    <td><b>Objects: BidRequest, Site, App, Publisher, Content, Producer, Bid</b> Use of cattax for all taxonomy references</td>
-</tr>
-  <tr>
-    <td><code><b>3.2.7, 3.2.8</b></code></td>
-    <td><b>Objects: Video, Audio</b> Added rqddurs</td>
-     <tr>
-  </tr>
- <td><code><b>3.2.7, 3.2.8</b></code></td>
- <td><b>Objects: Video, Audio</b> Added maxseq, poddur, podid, podseq, mincpmpersec, slotinpod for pod bidding support</td>
-  </tr>
-  <tr>
-    <td><code><b>4.4, 4.4.1</b></code></td>
-    <td><b>Substition Macros</b> Added AUCTION_MIN_TO_WIN</td>
- </tr>
-  <tr>
-    <td><code><b>4.2.3</b></code></td>
-    <td><b>Object, Bid</b> Added apis</td>
-</tr>
-  <tr>
- <td><code><b>3.2.4</b></code></td>
-    <td><b>Object: Imp</b> Added rwdd</td>
-</tr>
-  <tr>
-    <td><code><b>3.2.1, 3.2.14, 4.2.3</b></code></td>
-    <td><b>Objects: App, Bid, BidRequest</b> Clarified laguage around use of storeid vs bundle</td>
-     <tr>
-  </tr>
- <td><code><b>3.2.4</b></code></td>
- <td><b>Object Imp</b> Added ssai</td>
-  </tr>
-  <tr>
-    <td><code><b>3.2.18</b></code></td>
-    <td><b>Object: Device</b> Clarified language around mccmnc and roaming</td>
- </tr>
-  <tr>
- <td><code><b>3.2.23, 3.2.24</b></code></td>
-    <td><b>Added Objects:</b> Network, Channel, SupplyChain, SupplyChainNode, EIDs and UIDs*</td>
-     <tr>
-  </tr>
- <td><code><b>4.2.3</b></code></td>
- <td><b>Object: Bid</b> Added mtype</td>
-  </tr>
-  <tr>
-    <td><code><b>3.2.6, 3.2.7, 3.2.16</b></code></td>
-    <td><b>Removed previously deprecated attributes</b> Object: Banner, wmax, hmax, wmin, hmin, Object: Video, protocol, Object: Content, videoquality</td>
- </tr>
-  <tr>
-    <td><code><b>7.6</b></code></td>
-    <td>Pod Bidding for Video and Audio implementers guide</td>
-</tr>
-  <tr>
- <td><code><b>7.7</b></code></td>
-    <td>Network and Channel object examples</td>
-</tr>
-  <tr>
-    <td><code><b>3.2.7, 3.2.8, 3.2.18, 3.2.20, 4.2.3</b></code></td>
-    <td><b>Deprecated attributes</b> Object: Video, sequence, Object: Audio, sequence, Ojbect: Device, didsha1, didmd5, dpidsha1, dpidnd5, macsha1, macmd5, Object: User, yob, gender, Object: Bid, api</td>
-     <tr>
-  </tr>
- <td><code><b>7.8</b></code></td>
- <td> Added Counting Billable events and tracked ads</td>
-  </tr>
-  <tr>
-<td><code><b>3.2.29, 3.2.30</b></code></td>
- <td>Object: UserAgent & Object Brand Version added</td>
-  </td>
-  </td>
-  </tr>
-</table>
+| Section | Description |
+| --- | --- |
+| `3.2.1, 3.2.16, 4.2.3, 3.2.18` | Added new language field to support IETF BCP 47, IETF BCP 47 offers additional layers of granularity, for example, differentiating written language versions of the same spoken language (e.g. Traditional and Simplified Chinese), https://en.wikipedia.org/wiki/IETF_language_tag |
+| `3.2.20` | Object: User added `consent` attribute (previously ext) |
+| `5` | Removed section (Enumerated Lists) All references now point to AdCOM 1.0 / OpenRTB 3.0 Lists | `3.2.1, 3.2.13, 3.2.14, 3.2.15, 3.2.16, 3.2.17, 4.2.3` | Objects: BidRequest, Site, App, Publisher, Content, Producer, Bid Use of cattax for all taxonomy references | `3.2.7, 3.2.8` | Objects: Video, Audio Added rqddurs | `3.2.7, 3.2.8` | Objects: Video, Audio Added maxseq, poddur, podid, podseq, mincpmpersec, slotinpod for pod bidding support | `4.4, 4.4.1` | Substition Macros Added AUCTION_MIN_TO_WIN | `4.2.3` | Object, Bid Added apis | `3.2.4` | Object: Imp Added rwdd | `3.2.1, 3.2.14, 4.2.3` | Objects: App, Bid, BidRequest Clarified laguage around use of storeid vs bundle | `3.2.4` | Object Imp Added ssai | `3.2.18` | Object: Device Clarified language around mccmnc and roaming | `3.2.23, 3.2.24` | Added Objects: Network, Channel, SupplyChain, SupplyChainNode, EIDs and UIDs* | `4.2.3` | Object: Bid Added mtype | `3.2.6, 3.2.7, 3.2.16` | Removed previously deprecated attributes Object: Banner, wmax, hmax, wmin, hmin, Object: Video, protocol, Object: Content, videoquality | `7.6` | Pod Bidding for Video and Audio implementers guide | `7.7` | Network and Channel object examples | `3.2.7, 3.2.8, 3.2.18, 3.2.20, 4.2.3` | Deprecated attributes Object: Video, sequence, Object: Audio, sequence, Ojbect: Device, didsha1, didmd5, dpidsha1, dpidnd5, macsha1, macmd5, Object: User, yob, gender, Object: Bid, api | `7.8` | Added Counting Billable events and tracked ads | `3.2.29, 3.2.30` | Object: UserAgent & Object Brand Version added |
+| `5` | Removed section (Enumerated Lists) All references now point to AdCOM 1.0 / OpenRTB 3.0 Lists |
+| `3.2.1, 3.2.13, 3.2.14, 3.2.15, 3.2.16, 3.2.17, 4.2.3` | Objects: BidRequest, Site, App, Publisher, Content, Producer, Bid Use of cattax for all taxonomy references |
+| `3.2.7, 3.2.8` | Objects: Video, Audio Added rqddurs | `3.2.7, 3.2.8` | Objects: Video, Audio Added maxseq, poddur, podid, podseq, mincpmpersec, slotinpod for pod bidding support |
+|  |
+| `4.4, 4.4.1` | Substition Macros Added AUCTION_MIN_TO_WIN |
+| `4.2.3` | Object, Bid Added apis |
+| `3.2.4` | Object: Imp Added rwdd |
+| `3.2.1, 3.2.14, 4.2.3` | Objects: App, Bid, BidRequest Clarified laguage around use of storeid vs bundle | `3.2.4` | Object Imp Added ssai |
+|  |
+| `3.2.18` | Object: Device Clarified language around mccmnc and roaming |
+| `3.2.23, 3.2.24` | Added Objects: Network, Channel, SupplyChain, SupplyChainNode, EIDs and UIDs* | `4.2.3` | Object: Bid Added mtype |
+|  |
+| `3.2.6, 3.2.7, 3.2.16` | Removed previously deprecated attributes Object: Banner, wmax, hmax, wmin, hmin, Object: Video, protocol, Object: Content, videoquality |
+| `7.6` | Pod Bidding for Video and Audio implementers guide |
+| `7.7` | Network and Channel object examples |
+| `3.2.7, 3.2.8, 3.2.18, 3.2.20, 4.2.3` | Deprecated attributes Object: Video, sequence, Object: Audio, sequence, Ojbect: Device, didsha1, didmd5, dpidsha1, dpidnd5, macsha1, macmd5, Object: User, yob, gender, Object: Bid, api | `7.8` | Added Counting Billable events and tracked ads |
+|  |
+| `3.2.29, 3.2.30` | Object: UserAgent & Object Brand Version added |
+
 	
 
 	
 **Version 2.4 to 2.5:**
 	
 	
-<table>
-  <tr>
-    <td><strong>Section&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-    <td><strong>Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong></td>
-  </tr>
-  <tr>
-    <td><code><b>2.4</b></code></td>  
-    <td><b>Section: Data Encoding</b> New section added.</td>
-  </tr>
-  <tr>
-    <td><code><b>3.1<b></code></td>
-    <td><b>Object Model: Bid Request</b> Update to include Source and Metric objects.</td>
- </tr>
-  <tr>
-    <td><code<b>3.2.1</b></code></td>
-    <td><b>Object: BidRequest</b>, Attributes bseat, wlang, and source have been added.</td>
-</tr>
-  <tr>
-    <td><code><b>3.2.2</b></code></td>
-    <td><b>Object: Source</b> New Source object has been added including the Payment ID pchain attribute.</td>
-     <tr>
-  </tr>
- <td><code><b>3.2.4</b></code></td>
- <td><b>Object: Imp</b> Attribute Metric object has been added.</td>
-  </tr>
-  <tr>
-    <td><code><b>3.2.5</b></code></td>
-    <td><b>Object: Metric</b> New Metric object has been added.</td>
- </tr>
-  <tr>
-    <td><code><b>3.2.6</b></code></td>
-    <td><b>Object: Banner</b>, Attribute vcm has been added.</td>
-</tr>
-  <tr>
- <td><code><b>3.2.7</b></code></td>
-    <td><b>Object: Video</b>, Attributes placement and playbackend have been added. Guidance added to use only the first element of attribute playbackmethod in preparation for future converson to an integer.</td>
-</tr>
-  <tr>
-    <td><code><b>3.2.10</b></code></td>
-    <td><b>Object: Format</b> Attributes wratio, hratio, and wmin have been added.</td>
-     <tr>
-  </tr>
- <td><code><b>3.2.4</b></code></td>
- <td><b>Object Imp</b> Added ssai</td>
-  </tr>
-  <tr>
-    <td><code><b>3.2.13</b></code></td>
-    <td><b>Object: Device</b> Attribute mccmnc has been added. Attribute carrier has been clarified to eliminate a reference to using "WIFI" as a carrier.</td>
- </tr>
-  <tr>
- <td><code><b>4.2.3<b></code></td>
-    <td><b>Object: Bid</b> Attributes burl, lurl, tactic, language, wratio, and hratio have been added.</td>
-     <tr>
-  </tr>
- <td><code><b>4.4</b></code></td>
- <td><b>Subsititution Macros:</b> Macros ${AUCTION_MBR} and ${AUCTION_LOSS} have been added. A best practice has been added to use “AUDIT” for unknown values when rendering for test or quality purposes.</td>
-  </tr>
-  <tr>
-    <td><code><b>5.6</b></code></td>
-    <td><b>List: API Frameworks</b> Item 6 has been added.</td>
- </tr>
-  <tr>
-    <td><code><b>5.9</b></code></td>
-    <td><b>List: Video Placement Types</b> New list has been added.</td>
-</tr>
-  <tr>
- <td><code><b>5.10</b></code></td>
-    <td><b>List: Playback Methods</b> Items 5-6 have been added.</td>
-</tr>
-  <tr>
-    <td><code><b>5.11</b></code></td>
-    <td><b>List: Playback Cessation Modes</b> New list has been added.</td>
-     <tr>
-  </tr>
- <td><code><b>5.24</b></code></td>
- <td><b>List: No-Bid Reason Codes</b> Items 9-10 have been added.</td>
-  </tr>
-  <tr>
-<td><code><b>5.25</b></code></td>
- <td><b>List: Loss Reason Codes</b> New list has been added.</td>
-  </td>
-  </td>
-  </tr>
-</table>
+| Section | Description |
+| --- | --- |
+| `2.4` | Section: Data Encoding New section added. |
+| `3.1` | Object Model: Bid Request Update to include Source and Metric objects. |
+| 3.2.1 | Object: BidRequest , Attributes bseat, wlang, and source have been added. |
+| `3.2.2` | Object: Source New Source object has been added including the Payment ID pchain attribute. | `3.2.4` | Object: Imp Attribute Metric object has been added. |
+|  |
+| `3.2.5` | Object: Metric New Metric object has been added. |
+| `3.2.6` | Object: Banner , Attribute vcm has been added. |
+| `3.2.7` | Object: Video , Attributes placement and playbackend have been added. Guidance added to use only the first element of attribute playbackmethod in preparation for future converson to an integer. |
+| `3.2.10` | Object: Format Attributes wratio, hratio, and wmin have been added. | `3.2.4` | Object Imp Added ssai |
+|  |
+| `3.2.13` | Object: Device Attribute mccmnc has been added. Attribute carrier has been clarified to eliminate a reference to using "WIFI" as a carrier. |
+| `4.2.3` | Object: Bid Attributes burl, lurl, tactic, language, wratio, and hratio have been added. | `4.4` | Subsititution Macros: Macros ${AUCTION_MBR} and ${AUCTION_LOSS} have been added. A best practice has been added to use “AUDIT” for unknown values when rendering for test or quality purposes. |
+|  |
+| `5.6` | List: API Frameworks Item 6 has been added. |
+| `5.9` | List: Video Placement Types New list has been added. |
+| `5.10` | List: Playback Methods Items 5-6 have been added. |
+| `5.11` | List: Playback Cessation Modes New list has been added. | `5.24` | List: No-Bid Reason Codes Items 9-10 have been added. |
+|  |
+| `5.25` | List: Loss Reason Codes New list has been added. |
+
 
 # Appendix C. Cookie Based ID Syncing <a name="appendixc"></a>
 Cookie syncing (also known as user syncing, user matching, cookie matching) is the process by which one party learns another party’s user IDs, and thus is foundational to availability of IDs in the cookie-based web environment. Since cookies are domain-specific, the sync process is necessary for one party to know the other’s IDs. 

--- a/2.6.md
+++ b/2.6.md
@@ -657,7 +657,12 @@ The presence of a `Banner` as a subordinate of the `Imp` object indicates that t
 | `format` | object array; recommended | Array of format objects (Section 3.2.10) representing the banner sizes permitted. If none are specified, then use of the `h` and `w` attributes is highly recommended. |
 | `w` | integer | Exact width in device-independent pixels (DIPS); recommended if no `Format` objects are specified. |
 | `h` | integer | Exact height in device-independent pixels (DIPS); recommended if no `Format` objects are specified. |
-| `btype` | integer array | Blocked banner ad types. Values: 1 = XHTML Text Ad, 2 = XHTML Banner Ad, 3 = JavaScript Ad, 4 = iframe. |
+| `btype` | integer array | Blocked banner ad types.<br>
+Values:<br>
+1 = XHTML Text Ad,<br>
+2 = XHTML Banner Ad,<br>
+3 = JavaScript Ad,<br>
+4 = iframe. |
 | `battr` | integer array | Blocked creative attributes. Refer to [List: Creative Attributes](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--creative-attributes-) in AdCOM 1.0. |
 | `pos` | integer | Ad position on screen. Refer to [List: Placement Positions](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--placement-positions-) in AdCOM 1.0. |
 | `mimes` | string array | Content MIME types supported. Popular MIME types may include, `“image/jpeg”` and `“image/gif”` . |

--- a/implementation.md
+++ b/implementation.md
@@ -15,7 +15,6 @@
   - [7.12 - ID Match Method Guidance](#idmm)
   - [7.13 - Using genres and gtax attributes](#genre)
   - [7.14 - Using Extended Content Identifiers](#cids)
-  - [7.15 - Additional Telemetry for Live Events](#lea)
 
 # 7. Implementation Notes <a name="implementationnotes"></a>
 	
@@ -1982,35 +1981,3 @@ While SSPs and DSPs may find use for Extended Content IDs, it is also perfectly 
   }
 }
 ```
-
-## 7.15 - Additional Telemetry for Live Events <a name="lea"></a>
-
-Additional telemetry can be provided by including `recording` and `airdate` attributes. There are some detailed examples below.
-
-- The first airing of a program or event that has played previously on a different channel should use the date the program originally ran (e.g. a show new to channel B should include the original airdate as it ran on channel A).  
-- Where the original airdate is very far in the past (e.g. a classic movie streaming live), the value in the `airdate` attribute should be -2 to denote the program originally aired prior to the start of the UNIX Timestamp enumeration (Jan 1, 1970). 
-
----
-
-## Example Scenarios
-
-| Scenario | `recording` | `airdate` |
-|----------|-------------|-----------|
-| Live (current) basketball game streaming live | 1 | [-1] |
-| Replay of past basketball game, programmed streaming on an ad-supported channel | 1 | [UNIX TIMESTAMP] |
-| Basketball game streaming on-demand (not live) | 0 | [UNIX TIMESTAMP] |
-| International sports coverage (e.g. Olympics, Tour de France, Formula 1) recorded in a different timezone, livestreamed for the first time during primetime hours internationally. <br><br>Event recorded abroad that premiered hours later in North America. | 1 | [UNIX TIMESTAMP] |
-| New episodic content, premiere, with live tune-in | 1 | [-1] |
-| New episodic content, premiere, on demand viewing | 0 | [UNIX TIMESTAMP] |
-| Episodic content, not a premiere, with live tune-in | 1 | [UNIX TIMESTAMP] |
-| Episodic content, not a premiere, on demand viewing | 0 | [UNIX TIMESTAMP] |
-| Live award show streaming live | 1 | [-1] |
-| Replay of award show, programmed streaming on an ad-supported channel | 1 | [UNIX TIMESTAMP] |
-| Award show streaming on-demand (not live) | 0 | [UNIX TIMESTAMP] |
-| Live (current episode) talk show streaming live | 1 | [-1] |
-| Rerun of episode of talk show, programmed streaming on an ad-supported channel | 1 | [UNIX TIMESTAMP] |
-| Talk show streaming on-demand (not live) | 0 | [UNIX TIMESTAMP] |
-| Real-time news streaming live | 1 | [-1] |
-| News streaming on-demand (not live) | 0 | [UNIX TIMESTAMP] |
-| Sitcom rerun, programmed streaming on an ad-supported channel | 1 | [UNIX TIMESTAMP] |
-| Sitcom rerun streaming on-demand (not live) | 0 | [UNIX TIMESTAMP] |


### PR DESCRIPTION
This change simplifies the creation and maintenance of this documentation and reduces the chance for human error. It also enables the use of relative anchor links within the tables.