### PR TITLE
Revise user.id description

### DIFF
--- a/2.6.md
+++ b/2.6.md
@@ -1030,7 +1030,7 @@ This object contains information known or derived about the human user of the de
 
 | Attribute | Type | Description |
 | --- | --- | --- |
-| `id` | string | Exchange-specific ID for the user.<br>Unless prior arrangements have been made between the buyer and the seller directly, the value in this field is expected to be derived from an ID sync. (see [Appendix: Cookie Based ID Syncing)](#appendixc) |
+| `id` | string | Exchange-specific ID for the user.<br>Unless prior arrangements have been made between the buyer and the seller directly, the value in this field is expected to be the exchange’s user ID from its cookie. |
 | `buyeruid` | string | Buyer-specific ID for the user as mapped by the exchange for the buyer.<br>Unless prior arrangements have been made between the buyer and the seller directly, the value in this field is expected to be derived from an ID sync. (see [Appendix: Cookie Based ID Syncing)](#appendixc) |
 | `yob` | integer; DEPRECATED | Deprecated as of OpenRTB 2.6. |
 | `gender` | string; DEPRECATED | Deprecated as of OpenRTB 2.6. |


### PR DESCRIPTION
Per discussion in IABTL Slack, #psc-ids, June 10th, this PR corrects the incorrect statement that about user.id -- "the value in this field is expected to be derived from an ID sync. (see Appendix: Cookie Based ID Syncing)"

user.id is the exchange's cookie ID. They innately know it (excepting S2S integration scenarios upstream), it's not ordinarily  derived from an ID sync.

This implements the adjustment to the description as discussed.