### PR TITLE
Improve descriptions for some `device` object fields and add a new field called `code`

### DIFF
--- a/2.6.md
+++ b/2.6.md
@@ -967,11 +967,12 @@ This object provides information pertaining to the device through which the user
 | `ip` | string | IPv4 address closest to device. |
 | `ipv6` | string | IP address closest to device as IPv6. |
 | `devicetype` | integer | The general type of device. Refer to [List: Device Types](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--device-types-) in AdCOM 1.0. |
-| `make` | string | Device make (e.g., “Apple”). |
-| `model` | string | Device model (e.g., “iPhone”). |
-| `os` | string | Device operating system (e.g., “iOS”). |
-| `osv` | string | Device operating system version (e.g., “3.1.2”). |
-| `hwv` | string | Hardware version of the device (e.g., “5S” for iPhone 5S). |
+| `make` | string | Marketed manufacturer of the device (e.g., “Apple” or “Google”). |
+| `model` | string | Marketed name of the device or series (e.g., “iPhone” or “Pixel”) |
+| `code` | string | Operating system provided identifier for the device (e.g., “iPhone18,2” for iPhone 17 Pro Max, or “GLBW0” for Pixel 10, or “SM-F766B” for Samsung Z Flip7) |
+| `os` | string | Device operating system (e.g., “iOS” or “Android”). |
+| `osv` | string | Device operating system version (e.g., “26.1” or “16”). |
+| `hwv` | string | Marketed name of the specific device in the series (e.g., “17 Pro Max” for iPhone 17 Pro Max or “10” for Pixel 10). |
 | `h` | integer | Physical height of the screen in pixels. |
 | `w` | integer | Physical width of the screen in pixels. |
 | `ppi` | integer | Screen size as pixels per linear inch. |

--- a/2.6.md
+++ b/2.6.md
@@ -967,12 +967,12 @@ This object provides information pertaining to the device through which the user
 | `ip` | string | IPv4 address closest to device. |
 | `ipv6` | string | IP address closest to device as IPv6. |
 | `devicetype` | integer | The general type of device. Refer to [List: Device Types](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--device-types-) in AdCOM 1.0. |
-| `make` | string | Marketed manufacturer of the device (e.g., “Apple” or “Google”). |
-| `model` | string | Marketed name of the device or series (e.g., “iPhone” or “Pixel”) |
-| `code` | string | Operating system provided identifier for the device (e.g., “iPhone18,2” for iPhone 17 Pro Max, or “GLBW0” for Pixel 10, or “SM-F766B” for Samsung Z Flip7) |
+| `make` | string | Marketed manufacturer of the device (e.g., “Apple”, “Google”, “LG”, or “Xiaomi”). |
+| `model` | string | Marketed name of the device or series (e.g., “iPhone”, “Pixel”, “OLED evo”, or “TV Box”) |
+| `code` | string | Operating system provided identifier for the device (e.g., “iPhone18,2” for iPhone 17 Pro Max, “GLBW0” for Pixel 10, “SM-F766B” for Samsung Z Flip7, “OLED65C54LA” for LG OLED evo AI C5 4K Smart TV 2025, or “MiTV-AFMU0” for Xiaomi TV Box S 3rd Gen) |
 | `os` | string | Device operating system (e.g., “iOS” or “Android”). |
 | `osv` | string | Device operating system version (e.g., “26.1” or “16”). |
-| `hwv` | string | Marketed name of the specific device in the series (e.g., “17 Pro Max” for iPhone 17 Pro Max or “10” for Pixel 10). |
+| `hwv` | string | Marketed name of the specific device in the series (e.g., “17 Pro Max” for iPhone 17 Pro Max, “10” for Pixel 10, “55 inch AI C5 4K Smart TV 2025” for OLED evo AI C5 4K Smart TV 2025, or “S 3rd Gen” for TV Box S 3rd Gen). |
 | `h` | integer | Physical height of the screen in pixels. |
 | `w` | integer | Physical width of the screen in pixels. |
 | `ppi` | integer | Screen size as pixels per linear inch. |

--- a/2.6.md
+++ b/2.6.md
@@ -968,8 +968,8 @@ This object provides information pertaining to the device through which the user
 | `ipv6` | string | IP address closest to device as IPv6. |
 | `devicetype` | integer | The general type of device. Refer to [List: Device Types](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--device-types-) in AdCOM 1.0. |
 | `make` | string | Marketed manufacturer of the device (e.g., “Apple”, “Google”, “LG”, or “Xiaomi”). |
-| `model` | string | Marketed name of the device or series (e.g., “iPhone”, “Pixel”, “OLED evo”, or “TV Box”) |
-| `code` | string | Operating system provided identifier for the device (e.g., “iPhone18,2” for iPhone 17 Pro Max, “GLBW0” for Pixel 10, “SM-F766B” for Samsung Z Flip7, “OLED65C54LA” for LG OLED evo AI C5 4K Smart TV 2025, or “MiTV-AFMU0” for Xiaomi TV Box S 3rd Gen) |
+| `model` | string | Marketed name of the device or series (e.g., “iPhone”, “Pixel”, “OLED evo”, or “TV Box”). |
+| `code` | string | Operating system provided identifier for the device (e.g., “iPhone18,2” for iPhone 17 Pro Max, “GLBW0” for Pixel 10, “SM-F766B” for Samsung Z Flip7, “OLED65C54LA” for LG OLED evo AI C5 4K Smart TV 2025, or “MiTV-AFMU0” for Xiaomi TV Box S 3rd Gen). |
 | `os` | string | Device operating system (e.g., “iOS” or “Android”). |
 | `osv` | string | Device operating system version (e.g., “26.1” or “16”). |
 | `hwv` | string | Marketed name of the specific device in the series (e.g., “17 Pro Max” for iPhone 17 Pro Max, “10” for Pixel 10, “55 inch AI C5 4K Smart TV 2025” for OLED evo AI C5 4K Smart TV 2025, or “S 3rd Gen” for TV Box S 3rd Gen). |


### PR DESCRIPTION
1. Circular definitions are removed. i.e. field name is no longer used in the description.
2. Clarifies the difference between the well-known marketing name and the manufacturer's provided model code. i.e. `GLBW0` for Pixel 10.
3. Introduces the word “series” to explain the difference between `model` and `hmv` with examples to show the different values.
4. Expands the examples to include more modern devices from a broader range of vendors.