### PR TITLE
Adding a protobuf extension range for Index Exchange extensions

### DIFF
--- a/proto/src/main/com/iabtechlab/openrtb/v2/openrtb.proto
+++ b/proto/src/main/com/iabtechlab/openrtb/v2/openrtb.proto
@@ -36,6 +36,7 @@ import "google/protobuf/struct.proto";
 // 500-999: Prototype space (intentionally unclaimed)
 // 1000-1999: Google
 // 2000-2999: Amazon
+// 3000-3999: Index Exchange
 
 // OpenRTB 2.0: The top-level bid request object contains a globally unique bid
 // request or auction ID. This id attribute is required as is at least one


### PR DESCRIPTION
Reserved range 3000-3999 for Index Exchange openrtb.proto extensions.