### PR TITLE
Fix dead Google metro codes link (#153)

### DIFF
--- a/2.6.md
+++ b/2.6.md
@@ -2119,7 +2119,7 @@ code.google.com/p/protobuf
 	
 - Google Metro Codes
 	
- 	code.google.com/apis/adwords/docs/appendix/metrocodes.html
+ 	https://developers.google.com/google-ads/api/reference/data/geotargets
 	
 - U.N. Code for Trade and Transport Locations:
 	

--- a/proto/src/main/com/iabtechlab/openrtb/v2/openrtb.proto
+++ b/proto/src/main/com/iabtechlab/openrtb/v2/openrtb.proto
@@ -1969,7 +1969,7 @@ message BidRequest {
 
     // Google metro code; similar to but not exactly Nielsen DMAs. See Appendix
     // A for a link to the codes.
-    // (http://code.google.com/apis/adwords/docs/appendix/metrocodes.html).
+    // (https://developers.google.com/google-ads/api/reference/data/geotargets).
     string metro = 6;
 
     // City using United Nations Code for Trade & Transport Locations. See


### PR DESCRIPTION
This PR updates the dead Google metro codes link in the 2.6 specification and the proto file comments to the current Google Ads API geotargets documentation. Fixes #153.