### PR TITLE
livestream signaling fixes

### DIFF
--- a/2.6.md
+++ b/2.6.md
@@ -920,7 +920,7 @@ This object describes the content in which the impression will appear, which may
 | `qagmediarating` | integer | Media rating per IQG guidelines. Refer to [List: Media Ratings](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--media-ratings-) in AdCOM 1.0. |
 | `keywords` | string | Comma separated list of keywords describing the content. Only one of `keywords` or `kwarray` may be present. |
 | `kwarray` | string array | Array of keywords about the site. Only one of `keywords` or `kwarray` may be present. |
-| `livestream` | int | An enumeration indicating the method of broadcast of the content where: <br><br>0 = the broadcast is not scheduled (e.g. it is VOD or otherwise user initiated). <br>1 = the broadcast is scheduled. |
+| `livestream` | int | An enumeration indicating the method of broadcast of the content where: <br><br>0 = the broadcast is not scheduled (e.g. it is VOD or otherwise user initiated). <br>1 = the broadcast is scheduled (also referred to as linear viewing). |
 | `sourcerelationship` | integer | 0 = indirect, 1 = direct. |
 | `len` | integer | Length of content in seconds; appropriate for video or audio. |
 | `language` | string | Content language using ISO-639-1-alpha-2. Only one of `language` or `langb` should be present. |

--- a/2.6.md
+++ b/2.6.md
@@ -920,7 +920,7 @@ This object describes the content in which the impression will appear, which may
 | `qagmediarating` | integer | Media rating per IQG guidelines. Refer to [List: Media Ratings](https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/AdCOM%20v1.0%20FINAL.md#list--media-ratings-) in AdCOM 1.0. |
 | `keywords` | string | Comma separated list of keywords describing the content. Only one of `keywords` or `kwarray` may be present. |
 | `kwarray` | string array | Array of keywords about the site. Only one of `keywords` or `kwarray` may be present. |
-| `livestream` | integer | 0 = not live, 1 = content is live (e.g., stream, live blog)|
+| `livestream` | int | An enumeration indicating the method of broadcast of the content where: <br><br>0 = the broadcast is not scheduled (e.g. it is VOD or otherwise user initiated). <br>1 = the broadcast is scheduled. |
 | `sourcerelationship` | integer | 0 = indirect, 1 = direct. |
 | `len` | integer | Length of content in seconds; appropriate for video or audio. |
 | `language` | string | Content language using ISO-639-1-alpha-2. Only one of `language` or `langb` should be present. |
@@ -929,7 +929,6 @@ This object describes the content in which the impression will appear, which may
 | `data` | object array | Additional content data. Each `Data` object (Section 3.2.21) represents a different data source. |
 | `network` | object | Details about the network (Section 3.2.23) the content is on. |
 | `channel` | object | Details about the channel (Section 3.2.24) the content is on. |
-| `live` | int | An enumeration indicating the method of broadcast of the content where: <br><br>0 = the broadcast is not scheduled (e.g. it is VOD or otherwise user initiated). <br>1 = the broadcast is scheduled. |
 | `realtime` | int | An enumeration indicating if the event is happening in real time while it is being watched where: <br><br>0 = not happening in real time (e.g., a replay). <br>1 = yes, happening in real time (e.g., a live sports game). |
 | `firstbroadcast` | int | An enumeration indicating whether this broadcast is the first time the content is available to an audience where: <br><br>0 = not first time being broadcast <br>1 = first time being broadcast |
 | `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |

--- a/implementation.md
+++ b/implementation.md
@@ -2021,15 +2021,15 @@ While SSPs and DSPs may find use for Extended Content IDs, it is also perfectly 
 
 ### 7.15.3 JSON Examples
 **Scenario 1: Live Sports (Appointment Viewing)**
-In this case, we use live: 1 and realtime: 1 to indicate a broadcast happening right now. 
+In this case, we use livestream: 1, realtime: 1, and firstbroadcast: 1 to indicate a broadcast happening right now. 
 
 ```
 {
   "id": "live-sports-990",
   "title": "Savannah Bananas vs The Party Animals",
-  "live": 1,
+  "livestream": 1,
   "realtime": 1,
-  "firstbroadcast": "2024-06-12T19:00:00Z",
+  "firstbroadcast": 1,
   "context": 1,
   "genres": [
     "Sports"
@@ -2038,22 +2038,22 @@ In this case, we use live: 1 and realtime: 1 to indicate a broadcast happening r
   }
 }
 ```
-**Scenario 2: Reality  TV**
-Reality TV often falls into two categories: Live Broadcasts (like a finale or a competition where viewers vote in real-time) and Standard Episodes (pre-recorded "VOD" style).
+**Scenario 2: Episodic TV**
+Episodic TV, as an example, may fall into 2 categories: live linear viewing of pre-recorded content or on-demand viewing.
 
-**Scenario 2.1: Live Reality Competition Finale**
-Live-streaming finale where the content is being produced and delivered in real-time.
+**Scenario 2.1: Linear Viewing**
+Appointment viewing of non-realtime content.
 
 ```
 {
-  "id": "reality-fin-2026",
-  "title": "The Voice: Grand Finale",
-  "series": "The Voice",
+  "id": "abcde12345",
+  "title": "Week 4 Auditions",
+  "series": "America's Got Talent (AGT)",
   "season": "25",
-  "episode": 20,
-  "live": 1,
-  "realtime": 1,
-  "firstbroadcast": "2026-03-20T20:00:00Z",
+  "episode": 4,
+  "livestream": 1,
+  "realtime": 0,
+  "firstbroadcast": 1,
   "context": 1,
   "genres": [
     "Reality TV",
@@ -2066,13 +2066,13 @@ Live-streaming finale where the content is being produced and delivered in real-
     "name": "NBCUniversal",
     "domain": "nbc.com"
   },
-  "keywords": "singing,finale,live-vote",
+  "keywords": "singing,dancing,music",
   "language": "en",
   "len": 7200
 }
 ```
-**Scenario 2.2: Pre-recorded Reality Episode (VOD)**
-This represents a standard "fly-on-the-wall" reality show (e.g., Keeping Up with the Kardashians style) that was filmed months ago and is being watched on-demand.
+**Scenario 2.2: On-Demand Viewing (VOD)**
+On-demand viewing of non-realtime content.
 ```
 {
   "id": "rel-ep-302",
@@ -2082,7 +2082,7 @@ This represents a standard "fly-on-the-wall" reality show (e.g., Keeping Up with
   "episode": 2,
   "live": 0,
   "realtime": 0,
-  "firstbroadcast": "2025-11-12T21:00:00Z",
+  "firstbroadcast": 0,
   "context": 1,
   "genres": [
     "Reality TV",

--- a/implementation.md
+++ b/implementation.md
@@ -1995,7 +1995,7 @@ While SSPs and DSPs may find use for Extended Content IDs, it is also perfectly 
 
 **Full Transparency for All Buyer Tiers**
 - The seller wants to provide granular transparency across Open Market, PMP, and PG buyers.
-- Content attributes (`live`, `realtime`, `genres`) are fully disclosed in the bid request.
+- Content attributes (`livestream`, `realtime`, `genres`) are fully disclosed in the bid request.
 - DSPs can match and spend budgets for all campaigns specifically targeting real-time live events and season premieres. All parties benefit from the DSP's ability to handle the unique traffic patterns and concurrency of Live TV.
 
 **Accelerated Delivery with Offline Disclosure**
@@ -2039,9 +2039,9 @@ In this case, we use livestream: 1, realtime: 1, and firstbroadcast: 1 to indica
 }
 ```
 **Scenario 2: Episodic TV**
-Episodic TV, as an example, may fall into 2 categories: live linear viewing of pre-recorded content or on-demand viewing.
+Episodic TV, as an example, may fall into 2 categories: scheduled broadcast of pre-recorded content or on-demand viewing.
 
-**Scenario 2.1: Linear Viewing**
+**Scenario 2.1: Scheduled Broadcast**
 Appointment viewing of non-realtime content.
 
 ```


### PR DESCRIPTION
* never intended to have a separate `live` attribute -- it's a clarification to the definition of `livestream`
* `firstbroadcast` is a boolean
* tried to make examples a bit more relevant (though AGT is not the best example, because folks may not be aware that the auditions are pre-taped vs the live final episodes)