### PR TITLE
SupplyChainNode.hp: payment responsibility references the preceding hp=1 node

### DIFF
--- a/2.6.md
+++ b/2.6.md
@@ -1125,7 +1125,7 @@ This object is associated with a `SupplyChain` object as an array of nodes. Thes
 | `rid` | string | The OpenRTB RequestId of the request as issued by this seller. |
 | `name` | string | The name of the company (the legal entity) that is paid for inventory transacted under the given `seller_ID`. This value is optional and should NOT be included if it exists in the advertising system’s sellers.json file. |
 | `domain` | string | The business domain name of the entity represented by this node. This value is optional and should NOT be included if it exists in the advertising system’s sellers.json file. |
-| `hp` | integer | Indicates whether this node will be involved in the flow of payment for the inventory. When set to 1, the advertising system in the asi field pays the seller in the sid field, who is responsible for paying the previous node in the chain. When set to 0, this node is not involved in the flow of payment for the inventory. See [Implementation Guidance](https://github.com/InteractiveAdvertisingBureau/Supply-Chain-Validation/blob/main/Explainer%20Guide.md) for additional detail|
+| `hp` | integer | Indicates whether this node will be involved in the flow of payment for the inventory. When set to 1, the advertising system in the asi field pays the seller in the sid field, who is responsible for paying the preceding hp=1 node in the chain. When set to 0, this node is not involved in the flow of payment for the inventory and is not part of the payment linkage between hp=1 nodes. See [Implementation Guidance](https://github.com/InteractiveAdvertisingBureau/Supply-Chain-Validation/blob/main/Explainer%20Guide.md) for additional detail|
 | `ext` | object | Placeholder for advertising-system specific extensions to this object. |
 
 

--- a/proto/src/main/com/iabtechlab/openrtb/v2/openrtb.proto
+++ b/proto/src/main/com/iabtechlab/openrtb/v2/openrtb.proto
@@ -298,8 +298,9 @@ message BidRequest {
     // Indicates whether this node will be involved in the flow of payment
     // for the inventory. When set to 1, the advertising system in the asi
     // field pays the seller in the sid field, who is responsible for paying
-    // the previous node in the chain. When set to 0, this node is not
-    // involved in the flow of payment for the inventory. For version 1.0 of
+    // the preceding hp=1 node in the chain. When set to 0, this node is not
+    // involved in the flow of payment for the inventory and is not part of
+    // the payment linkage between hp=1 nodes. For version 1.0 of
     // SupplyChain, this property should always be 1. It is explicitly
     // required to be included as it is expected that future versions of the
     // specification will introduce non-payment handling nodes. Implementers


### PR DESCRIPTION
The hp description states that when hp=1, the seller in sid is "responsible for paying the previous node in the chain." With SupplyChain 1.1, an hp=0 node can precede the first payment node — the Supply Chain Validation Implementation Guidance notes implementers should expect one or more hp=0 nodes in front of the first payment handling node — and in that arrangement the previous node is not paid by the seller, so the description is incorrect as written.

The Implementation Guidance validation methods (section 4.6) already use the correct formulation: the payment linkage runs between hp=1 nodes ("should match the advertising system in the preceding hp=1 node"). This change aligns the field description to it and adds that hp=0 nodes are not part of the payment linkage. For version 1.0 chains, where all nodes are payment handling, the preceding hp=1 node is the previous node, so nothing changes.

Part of the public comment feedback for InteractiveAdvertisingBureau/Supply-Chain-Validation#1.