### PR TITLE
Add JSON Schema (Draft 2020-12) for OpenRTB 2.6

### DIFF
--- a/2.6.md
+++ b/2.6.md
@@ -517,7 +517,7 @@ The following table summarizes the objects in the Bid Request model and serves a
 | `Segment` | 3.2.22 | Specific data point about a user from a specific data source. |
 | `Network` | 3.2.23 | Network on which an ad will be displayed. |
 | `Channel` | 3.2.24 | Channel on which an ad will be displayed. |
-| `SupplyChain` | 3.2.25 | Chain of nodes from beginning to end representing the entities involved in the direct flow of payment for inventory. |
+| `SupplyChain` | 3.2.25 | Chain of nodes from beginning to end representing the entities that took custody of a bid request. |
 | `SupplyChainNode` | 3.2.26 | Nodes defining the identity of an entity participating in the supply chain of a bid request. |
 | `EIDs` | 3.2.27 | Extended identifiers support. |
 | `UIDs` | 3.2.28 | Extended identifiers user id support. |

--- a/2.6.md
+++ b/2.6.md
@@ -1101,21 +1101,21 @@ This object describes the channel an ad will be displayed on. A Channel is defin
 
 ### 3.2.25 - Object: SupplyChain <a name="objectsupplychain"></a>
 
-This object is composed of a set of nodes where each node represents a specific entity that participates in the transacting of inventory. The entire chain of nodes from beginning to end represents all entities who are involved in the direct flow of payment for inventory. Detailed implementation examples can be found here: https://github.com/InteractiveAdvertisingBureau/openrtb/blob/master/supplychainobject.md
+This object is composed of a set of nodes where each node represents a specific entity that participates in the transacting of inventory. The entire chain of nodes from beginning to end represents all entities who take custody of a given bid request. Detailed implementation guidance, including JSON examples can be found in the [Supply Chain Validation GitHub Repository](https://github.com/InteractiveAdvertisingBureau/Supply-Chain-Validation/blob/main/Explainer%20Guide.md)
 
 
 | Attribute | Type | Description |
 | --- | --- | --- |
-| `complete` | integer; required | Flag indicating whether the chain contains all nodes involved in the transaction leading back to the owner of the site, app or other medium of the inventory, where 0 = no, 1 = yes. |
+| `ver` | string; required | Version of the supply chain specification in use, in the format of “major.minor”. For example, for version 1.1 of the spec, use the string “1.1”. |
+| `complete` | integer; required | Flag indicating whether the chain contains all nodes involved in the transaction leading back to the owner of the site, app or other medium of the inventory, where <br><br> 0 = not complete <br> 1 = payment complete <br> 2 = payment and tech complete |
 | `nodes` | object array; required | Array of `SupplyChainNode` objects in the order of the chain. In a complete supply chain, the first node represents the initial advertising system and seller ID involved in the transaction, i.e. the owner of the site, app, or other medium. In an incomplete supply chain, it represents the first known node. The last node represents the entity sending this bid request. |
-| `ver` | string; required | Version of the supply chain specification in use, in the format of “major.minor”. For example, for version 1.0 of the spec, use the string “1.0”. |
 | `ext` | object | Placeholder for exchange-specific extensions to OpenRTB. |
 
 
 
 ### 3.2.26 - Object: SupplyChainNode <a name="objectsupplychainnode"></a>
 
-This object is associated with a `SupplyChain` object as an array of nodes. These nodes define the identity of an entity participating in the supply chain of a bid request. Detailed implementation examples can be found here: https://github.com/InteractiveAdvertisingBureau/openrtb/blob/master/supplychainobject.md. The `SupplyChainNode` object contains the following attributes:
+This object is associated with a `SupplyChain` object as an array of nodes. These nodes define the identity of an entity participating in the supply chain of a bid request. Detailed implementation examples can be found [Supply Chain Validation GitHub Repository](https://github.com/InteractiveAdvertisingBureau/Supply-Chain-Validation/blob/main/Explainer%20Guide.md). The `SupplyChainNode` object contains the following attributes:
 
 
 | Attribute | Type | Description |
@@ -1125,7 +1125,7 @@ This object is associated with a `SupplyChain` object as an array of nodes. Thes
 | `rid` | string | The OpenRTB RequestId of the request as issued by this seller. |
 | `name` | string | The name of the company (the legal entity) that is paid for inventory transacted under the given `seller_ID`. This value is optional and should NOT be included if it exists in the advertising system’s sellers.json file. |
 | `domain` | string | The business domain name of the entity represented by this node. This value is optional and should NOT be included if it exists in the advertising system’s sellers.json file. |
-| `hp` | integer | Indicates whether this node will be involved in the flow of payment for the inventory. When set to 1, the advertising system in the `asi` field pays the seller in the `sid` field, who is responsible for paying the previous node in the chain. When set to 0, this node is not involved in the flow of payment for the inventory. For version 1.0 of `SupplyChain`, this property should always be 1. Implementers should ensure that they propagate this field onwards when constructing `SupplyChain` objects in bid requests sent to a downstream advertising system. |
+| `hp` | integer | Indicates whether this node will be involved in the flow of payment for the inventory. When set to 1, the advertising system in the asi field pays the seller in the sid field, who is responsible for paying the previous node in the chain. When set to 0, this node is not involved in the flow of payment for the inventory. See [Implementation Guidance](https://github.com/InteractiveAdvertisingBureau/Supply-Chain-Validation/blob/main/Explainer%20Guide.md) for additional detail|
 | `ext` | object | Placeholder for advertising-system specific extensions to this object. |
 
 

--- a/implementation.md
+++ b/implementation.md
@@ -17,6 +17,7 @@
   - [7.14 - Using Extended Content Identifiers](#cids)
   - [7.15 - Signaling the "liveness" of Programming](#liveness)
   - [7.16 - Discount Macros](#discountmacros)
+  - [7.17 - CTV Ad Portfolio Signaling](#ctvadportfoliosignaling)
 
 # 7. Implementation Notes <a name="implementationnotes"></a>
 	
@@ -2117,3 +2118,7 @@ Support sending discount information back to DSPs using the following macros:
 | `${AUCTION_PRICE}` | `8.0` | Final clearing price |
 | `${AUCTION_DISCOUNT_PCT}` | `20.0` | Discount percentage |
 | `${AUCTION_DISCOUNT_CPM}` | `2.0` | Discount amount |
+
+## 7.17 CTV Ad Portfolio Signaling <a name="ctvadportfoliosignaling"></a>
+
+Implementation guideance for signaling ad formats such as pause screen, menu, overlay, squeezeback, in scene and screensaver can be found <a href="https://github.com/InteractiveAdvertisingBureau/Ad-Format-Guidelines-for-Digital-Video-CTV/blob/main/Signaling-Implementation-Guidelines.md">here.</a>

--- a/jsonschema/App.json
+++ b/jsonschema/App.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/App.json",
+  "title": "OpenRTB 2.6 App",
+  "description": "Details about the publisher's non-browser application.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Exchange-specific app ID."
+    },
+    "name": {
+      "type": "string",
+      "description": "App name (may be aliased at the publisher's request)."
+    },
+    "bundle": {
+      "type": "string",
+      "description": "The store ID of the app in an app store."
+    },
+    "domain": {
+      "type": "string",
+      "description": "Domain of the app (e.g., \"mygame.foo.com\")."
+    },
+    "storeurl": {
+      "type": "string",
+      "description": "App store URL for an installed app."
+    },
+    "cattax": {
+      "type": "integer",
+      "default": 1,
+      "description": "The taxonomy in use for cat fields."
+    },
+    "cat": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Array of IAB content categories of the app."
+    },
+    "sectioncat": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Array of IAB content categories for the current section."
+    },
+    "pagecat": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Array of IAB content categories for the current page."
+    },
+    "ver": {
+      "type": "string",
+      "description": "Application version."
+    },
+    "privacypolicy": {
+      "type": "integer",
+      "enum": [
+        0,
+        1
+      ],
+      "description": "Indicates if the app has a privacy policy."
+    },
+    "paid": {
+      "type": "integer",
+      "enum": [
+        0,
+        1
+      ],
+      "description": "0 = app is free, 1 = the app is a paid version."
+    },
+    "publisher": {
+      "$ref": "Publisher.json",
+      "description": "Details about the Publisher of the app."
+    },
+    "content": {
+      "$ref": "Content.json",
+      "description": "Details about the Content within the app."
+    },
+    "keywords": {
+      "type": "string",
+      "description": "Comma separated list of keywords about the app."
+    },
+    "kwarray": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Array of keywords about the app."
+    },
+    "inventorypartnerdomain": {
+      "type": "string",
+      "description": "A domain for inventory authorization in inventory sharing arrangements."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for exchange-specific extensions to OpenRTB.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/jsonschema/Audio.json
+++ b/jsonschema/Audio.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/Audio.json",
+  "title": "OpenRTB 2.6 Audio",
+  "description": "Represents an audio type impression.",
+  "type": "object",
+  "required": [
+    "mimes"
+  ],
+  "properties": {
+    "mimes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "description": "Content MIME types supported (e.g., \"audio/mp4\")."
+    },
+    "minduration": {
+      "type": "integer",
+      "default": 0,
+      "description": "Minimum audio ad duration in seconds."
+    },
+    "maxduration": {
+      "type": "integer",
+      "description": "Maximum audio ad duration in seconds."
+    },
+    "poddur": {
+      "type": "integer",
+      "description": "Total time in seconds for a dynamic audio ad pod."
+    },
+    "protocols": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "description": "Array of supported audio protocols."
+    },
+    "startdelay": {
+      "type": "integer",
+      "description": "Start delay in seconds for pre-roll, mid-roll, or post-roll ad placements."
+    },
+    "rqddurs": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "description": "Precise acceptable durations for audio creatives in seconds."
+    },
+    "podid": {
+      "type": "string",
+      "description": "Unique identifier indicating an impression belongs to an audio ad pod."
+    },
+    "podseq": {
+      "type": "integer",
+      "default": 0,
+      "description": "The sequence (position) of the audio ad pod within a content stream."
+    },
+    "slotinpod": {
+      "type": "integer",
+      "default": 0,
+      "description": "Guaranteed delivery position in the pod."
+    },
+    "mincpmpersec": {
+      "type": "number",
+      "description": "Minimum CPM per second for the dynamic portion of an audio ad pod."
+    },
+    "battr": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "description": "Blocked creative attributes."
+    },
+    "maxextended": {
+      "type": "integer",
+      "description": "Maximum extended ad duration if extension is allowed."
+    },
+    "minbitrate": {
+      "type": "integer",
+      "description": "Minimum bit rate in Kbps."
+    },
+    "maxbitrate": {
+      "type": "integer",
+      "description": "Maximum bit rate in Kbps."
+    },
+    "delivery": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "description": "Supported delivery methods."
+    },
+    "companionad": {
+      "type": "array",
+      "items": {
+        "$ref": "Banner.json"
+      },
+      "description": "Array of Banner objects if companion ads are available."
+    },
+    "api": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "description": "List of supported API frameworks."
+    },
+    "companiontype": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "description": "Supported companion ad types."
+    },
+    "maxseq": {
+      "type": "integer",
+      "description": "Maximum number of ads in an ad pod."
+    },
+    "feed": {
+      "type": "integer",
+      "description": "Type of audio feed."
+    },
+    "stitched": {
+      "type": "integer",
+      "enum": [
+        0,
+        1
+      ],
+      "description": "Indicates if the ad is stitched with audio content."
+    },
+    "nvol": {
+      "type": "integer",
+      "description": "Volume normalization mode."
+    },
+    "durfloors": {
+      "type": "array",
+      "items": {
+        "$ref": "DurFloors.json"
+      },
+      "description": "Floor prices for audio creatives of various durations."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for exchange-specific extensions to OpenRTB.",
+      "additionalProperties": true
+    },
+    "sequence": {
+      "type": "integer",
+      "description": "DEPRECATED. Use slotinpod instead. Position in ad pod sequence.",
+      "deprecated": true
+    }
+  }
+}

--- a/jsonschema/Banner.json
+++ b/jsonschema/Banner.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/Banner.json",
+  "title": "OpenRTB 2.6 Banner",
+  "description": "Represents the most general type of impression including simple static images, expandable ad units, or in-banner video.",
+  "type": "object",
+  "properties": {
+    "format": {
+      "type": "array",
+      "items": {
+        "$ref": "Format.json"
+      },
+      "description": "Array of Format objects representing the banner sizes permitted."
+    },
+    "w": {
+      "type": "integer",
+      "description": "Exact width in device-independent pixels (DIPS)."
+    },
+    "h": {
+      "type": "integer",
+      "description": "Exact height in device-independent pixels (DIPS)."
+    },
+    "btype": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "description": "Blocked banner ad types. 1 = XHTML Text Ad, 2 = XHTML Banner Ad, 3 = JavaScript Ad, 4 = iframe."
+    },
+    "battr": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "description": "Blocked creative attributes. Refer to AdCOM 1.0 List: Creative Attributes."
+    },
+    "pos": {
+      "type": "integer",
+      "description": "Ad position on screen. Refer to AdCOM 1.0 List: Placement Positions."
+    },
+    "mimes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Content MIME types supported (e.g., \"image/jpeg\", \"image/gif\")."
+    },
+    "topframe": {
+      "type": "integer",
+      "enum": [
+        0,
+        1
+      ],
+      "description": "Indicates if the banner is in the top frame as opposed to an iframe."
+    },
+    "expdir": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "description": "Directions in which the banner may expand. Refer to AdCOM 1.0 List: Expandable Directions."
+    },
+    "api": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "description": "List of supported API frameworks for this impression. Refer to AdCOM 1.0 List: API Frameworks."
+    },
+    "id": {
+      "type": "string",
+      "description": "Unique identifier for this banner object. Recommended when Banner objects are used with a Video object for companion ads."
+    },
+    "vcm": {
+      "type": "integer",
+      "enum": [
+        0,
+        1
+      ],
+      "description": "Companion banner rendering mode relative to the associated video, where 0 = concurrent, 1 = end-card."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for exchange-specific extensions to OpenRTB.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/jsonschema/Bid.json
+++ b/jsonschema/Bid.json
@@ -1,0 +1,169 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/Bid.json",
+  "title": "OpenRTB 2.6 Bid",
+  "description": "An offer to buy a specific impression under certain business terms.",
+  "type": "object",
+  "required": [
+    "id",
+    "impid",
+    "price"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Bidder generated bid ID to assist with logging/tracking."
+    },
+    "impid": {
+      "type": "string",
+      "description": "ID of the Imp object in the related bid request."
+    },
+    "price": {
+      "type": "number",
+      "description": "Bid price expressed as CPM although the actual transaction is for a unit impression only.",
+      "minimum": 0
+    },
+    "nurl": {
+      "type": "string",
+      "description": "Win notice URL called by the exchange if the bid wins."
+    },
+    "burl": {
+      "type": "string",
+      "description": "Billing notice URL called by the exchange when a winning bid becomes billable."
+    },
+    "lurl": {
+      "type": "string",
+      "description": "Loss notice URL called by the exchange when a bid is known to have been lost."
+    },
+    "adm": {
+      "type": "string",
+      "description": "Optional means of conveying ad markup in case the bid wins."
+    },
+    "adid": {
+      "type": "string",
+      "description": "ID of a preloaded ad to be served if the bid wins."
+    },
+    "adomain": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Advertiser domain for block list checking (e.g., \"ford.com\")."
+    },
+    "bundle": {
+      "type": "string",
+      "description": "The store ID of the app in an app store."
+    },
+    "iurl": {
+      "type": "string",
+      "description": "URL without cache-busting to an image representative of the content of the campaign."
+    },
+    "cid": {
+      "type": "string",
+      "description": "Campaign ID to assist with ad quality checking."
+    },
+    "crid": {
+      "type": "string",
+      "description": "Creative ID to assist with ad quality checking."
+    },
+    "tactic": {
+      "type": "string",
+      "description": "Tactic ID to enable buyers to label bids for reporting to the exchange."
+    },
+    "cattax": {
+      "type": "integer",
+      "default": 1,
+      "description": "The taxonomy in use. Refer to AdCOM 1.0 List: Category Taxonomies."
+    },
+    "cat": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "IAB Tech Lab content categories of the creative."
+    },
+    "attr": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "description": "Set of attributes describing the creative. Refer to AdCOM 1.0 List: Creative Attributes."
+    },
+    "apis": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "description": "List of supported APIs for the markup. Refer to AdCOM 1.0 List: API Frameworks."
+    },
+    "protocol": {
+      "type": "integer",
+      "description": "Video response protocol of the markup if applicable."
+    },
+    "qagmediarating": {
+      "type": "integer",
+      "description": "Creative media rating per IQG guidelines. Refer to AdCOM 1.0 List: Media Ratings."
+    },
+    "language": {
+      "type": "string",
+      "description": "Language of the creative using ISO-639-1-alpha-2."
+    },
+    "langb": {
+      "type": "string",
+      "description": "Language of the creative using IETF BCP 47."
+    },
+    "dealid": {
+      "type": "string",
+      "description": "Reference to the deal.id from the bid request if this bid pertains to a private marketplace direct deal."
+    },
+    "w": {
+      "type": "integer",
+      "description": "Width of the creative in device-independent pixels (DIPS)."
+    },
+    "h": {
+      "type": "integer",
+      "description": "Height of the creative in device-independent pixels (DIPS)."
+    },
+    "wratio": {
+      "type": "integer",
+      "description": "Relative width of the creative when expressing size as a ratio. Required for Flex Ads."
+    },
+    "hratio": {
+      "type": "integer",
+      "description": "Relative height of the creative when expressing size as a ratio. Required for Flex Ads."
+    },
+    "exp": {
+      "type": "integer",
+      "description": "Advisory as to the number of seconds the bidder is willing to wait between auction and actual impression."
+    },
+    "dur": {
+      "type": "integer",
+      "description": "Duration of the video or audio creative in seconds."
+    },
+    "mtype": {
+      "type": "integer",
+      "enum": [
+        1,
+        2,
+        3,
+        4
+      ],
+      "description": "Type of the creative markup. 1 = Banner, 2 = Video, 3 = Audio, 4 = Native."
+    },
+    "slotinpod": {
+      "type": "integer",
+      "default": 0,
+      "description": "Indicates that the bid response is only eligible for a specific position within a video or audio ad pod."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for bidder-specific extensions to OpenRTB.",
+      "additionalProperties": true
+    },
+    "api": {
+      "type": "integer",
+      "description": "DEPRECATED. Use apis instead. API framework of the creative.",
+      "deprecated": true
+    }
+  }
+}

--- a/jsonschema/BidRequest.json
+++ b/jsonschema/BidRequest.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/BidRequest.json",
+  "title": "OpenRTB 2.6 BidRequest",
+  "description": "Top-level bid request object containing an exchange unique bid request or auction ID.",
+  "type": "object",
+  "required": [
+    "id",
+    "imp"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "ID of the bid request, assigned by the exchange, and unique for the exchange's subsequent tracking of the responses."
+    },
+    "imp": {
+      "type": "array",
+      "items": {
+        "$ref": "Imp.json"
+      },
+      "minItems": 1,
+      "description": "Array of Imp objects representing the impressions offered. At least 1 Imp object is required."
+    },
+    "site": {
+      "$ref": "Site.json",
+      "description": "Details about the publisher's website. Only applicable and recommended for websites."
+    },
+    "app": {
+      "$ref": "App.json",
+      "description": "Details about the publisher's app (non-browser applications). Only applicable and recommended for apps."
+    },
+    "dooh": {
+      "$ref": "DOOH.json",
+      "description": "This object should be included if the ad supported content is a Digital Out-Of-Home screen."
+    },
+    "device": {
+      "$ref": "Device.json",
+      "description": "Details about the user's device to which the impression will be delivered."
+    },
+    "user": {
+      "$ref": "User.json",
+      "description": "Details about the human user of the device; the advertising audience."
+    },
+    "test": {
+      "type": "integer",
+      "default": 0,
+      "enum": [
+        0,
+        1
+      ],
+      "description": "Indicator of test mode in which auctions are not billable, where 0 = live mode, 1 = test mode."
+    },
+    "at": {
+      "type": "integer",
+      "default": 2,
+      "description": "Auction type, where 1 = First Price, 2 = Second Price Plus. Exchange-specific auction types can be defined using values 500 and greater."
+    },
+    "tmax": {
+      "type": "integer",
+      "description": "Maximum time in milliseconds the exchange allows for bids to be received including Internet latency to avoid timeout."
+    },
+    "wseat": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Allowed list of buyer seats allowed to bid on this impression."
+    },
+    "bseat": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Block list of buyer seats restricted from bidding on this impression."
+    },
+    "allimps": {
+      "type": "integer",
+      "default": 0,
+      "enum": [
+        0,
+        1
+      ],
+      "description": "Flag to indicate if Exchange can verify that the impressions offered represent all of the impressions available in context. 0 = no or unknown, 1 = yes."
+    },
+    "cur": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Array of allowed currencies for bids on this bid request using ISO-4217 alpha codes."
+    },
+    "wlang": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Allowed list of languages for creatives using ISO-639-1-alpha-2."
+    },
+    "wlangb": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Allowed list of languages for creatives using IETF BCP 47."
+    },
+    "acat": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Allowed advertiser categories using the specified category taxonomy."
+    },
+    "bcat": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Blocked advertiser categories using the specified category taxonomy."
+    },
+    "cattax": {
+      "type": "integer",
+      "default": 1,
+      "description": "The taxonomy in use for bcat/acat. Refer to the AdCOM 1.0 list: Category Taxonomies."
+    },
+    "badv": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Block list of advertisers by their domains (e.g., \"ford.com\")."
+    },
+    "bapp": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Block list of applications by their app store IDs."
+    },
+    "source": {
+      "$ref": "Source.json",
+      "description": "A Source object that provides data about the inventory source and which entity makes the final decision."
+    },
+    "regs": {
+      "$ref": "Regs.json",
+      "description": "A Regs object that specifies any industry, legal, or governmental regulations in force for this request."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for exchange-specific extensions to OpenRTB.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/jsonschema/BidResponse.json
+++ b/jsonschema/BidResponse.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/BidResponse.json",
+  "title": "OpenRTB 2.6 BidResponse",
+  "description": "Top-level bid response object.",
+  "type": "object",
+  "required": [
+    "id"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "ID of the bid request to which this is a response."
+    },
+    "seatbid": {
+      "type": "array",
+      "items": {
+        "$ref": "SeatBid.json"
+      },
+      "description": "Array of seatbid objects; 1+ required if a bid is to be made."
+    },
+    "bidid": {
+      "type": "string",
+      "description": "Bidder generated response ID to assist with logging/tracking."
+    },
+    "cur": {
+      "type": "string",
+      "default": "USD",
+      "description": "Bid currency using ISO-4217 alpha codes."
+    },
+    "customdata": {
+      "type": "string",
+      "description": "Optional feature to allow a bidder to set data in the exchange's cookie."
+    },
+    "nbr": {
+      "type": "integer",
+      "description": "Reason for not bidding. Refer to OpenRTB 3.0 List: No-Bid Reason Codes."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for bidder-specific extensions to OpenRTB.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/jsonschema/BrandVersion.json
+++ b/jsonschema/BrandVersion.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/BrandVersion.json",
+  "title": "OpenRTB 2.6 BrandVersion",
+  "description": "Identifies a device's browser or similar software component, or the platform/OS.",
+  "type": "object",
+  "required": [
+    "brand"
+  ],
+  "properties": {
+    "brand": {
+      "type": "string",
+      "description": "A brand identifier (e.g., \"Chrome\" or \"Windows\")."
+    },
+    "version": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "A sequence of version components, in descending hierarchical order."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for vendor specific extensions.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/jsonschema/Channel.json
+++ b/jsonschema/Channel.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/Channel.json",
+  "title": "OpenRTB 2.6 Channel",
+  "description": "Describes the channel an ad will be displayed on.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "A unique identifier assigned by the publisher."
+    },
+    "name": {
+      "type": "string",
+      "description": "Channel the content is on (e.g., \"WABC-TV\")."
+    },
+    "domain": {
+      "type": "string",
+      "description": "The primary domain of the channel."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for exchange-specific extensions to OpenRTB.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/jsonschema/Content.json
+++ b/jsonschema/Content.json
@@ -1,0 +1,180 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/Content.json",
+  "title": "OpenRTB 2.6 Content",
+  "description": "Describes the content in which the impression will appear.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Publisher-provided ID uniquely identifying the content."
+    },
+    "episode": {
+      "type": "integer",
+      "description": "Episode number."
+    },
+    "title": {
+      "type": "string",
+      "description": "Content title."
+    },
+    "series": {
+      "type": "string",
+      "description": "Content series."
+    },
+    "season": {
+      "type": "string",
+      "description": "Content season (e.g., \"Season 3\")."
+    },
+    "artist": {
+      "type": "string",
+      "description": "Artist credited with the content."
+    },
+    "genre": {
+      "type": "string",
+      "description": "Genre that best describes the content."
+    },
+    "gtax": {
+      "type": "integer",
+      "default": 9,
+      "description": "The taxonomy in use for genres."
+    },
+    "genres": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Unique ID(s) for the genre of the content."
+    },
+    "album": {
+      "type": "string",
+      "description": "Album to which the content belongs; typically for audio."
+    },
+    "isrc": {
+      "type": "string",
+      "description": "International Standard Recording Code conforming to ISO-3901."
+    },
+    "producer": {
+      "$ref": "Producer.json",
+      "description": "Details about the content Producer."
+    },
+    "url": {
+      "type": "string",
+      "description": "URL of the content, for buy-side contextualization or review."
+    },
+    "cattax": {
+      "type": "integer",
+      "default": 1,
+      "description": "The taxonomy in use for cat fields."
+    },
+    "cat": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Array of IAB content categories that describe the content."
+    },
+    "prodq": {
+      "type": "integer",
+      "description": "Production quality. Refer to AdCOM 1.0 List: Production Qualities."
+    },
+    "context": {
+      "type": "integer",
+      "description": "Type of content. Refer to AdCOM 1.0 List: Content Contexts."
+    },
+    "contentrating": {
+      "type": "string",
+      "description": "Content rating (e.g., MPAA)."
+    },
+    "userrating": {
+      "type": "string",
+      "description": "User rating of the content."
+    },
+    "qagmediarating": {
+      "type": "integer",
+      "description": "Media rating per IQG guidelines."
+    },
+    "keywords": {
+      "type": "string",
+      "description": "Comma separated list of keywords describing the content."
+    },
+    "kwarray": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Array of keywords about the content."
+    },
+    "livestream": {
+      "type": "integer",
+      "enum": [
+        0,
+        1
+      ],
+      "description": "0 = not scheduled (VOD), 1 = scheduled (linear)."
+    },
+    "sourcerelationship": {
+      "type": "integer",
+      "enum": [
+        0,
+        1
+      ],
+      "description": "0 = indirect, 1 = direct."
+    },
+    "len": {
+      "type": "integer",
+      "description": "Length of content in seconds."
+    },
+    "language": {
+      "type": "string",
+      "description": "Content language using ISO-639-1-alpha-2."
+    },
+    "langb": {
+      "type": "string",
+      "description": "Content language using IETF BCP 47."
+    },
+    "embeddable": {
+      "type": "integer",
+      "enum": [
+        0,
+        1
+      ],
+      "description": "Indicator of whether the content is embeddable."
+    },
+    "data": {
+      "type": "array",
+      "items": {
+        "$ref": "Data.json"
+      },
+      "description": "Additional content data."
+    },
+    "network": {
+      "$ref": "Network.json",
+      "description": "Details about the network the content is on."
+    },
+    "channel": {
+      "$ref": "Channel.json",
+      "description": "Details about the channel the content is on."
+    },
+    "realtime": {
+      "type": "integer",
+      "enum": [
+        0,
+        1
+      ],
+      "description": "0 = not real time, 1 = happening in real time."
+    },
+    "firstbroadcast": {
+      "type": "integer",
+      "enum": [
+        0,
+        1
+      ],
+      "description": "0 = not first broadcast, 1 = first broadcast."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for exchange-specific extensions to OpenRTB.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/jsonschema/DOOH.json
+++ b/jsonschema/DOOH.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/DOOH.json",
+  "title": "OpenRTB 2.6 DOOH",
+  "description": "Details of the Digital Out-Of-Home inventory calling for the impression.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Exchange provided id for a placement or logical grouping."
+    },
+    "name": {
+      "type": "string",
+      "description": "Name of the DOOH placement."
+    },
+    "venuetype": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "The type of out-of-home venue."
+    },
+    "venuetypetax": {
+      "type": "integer",
+      "default": 1,
+      "description": "The venue taxonomy in use."
+    },
+    "publisher": {
+      "$ref": "Publisher.json",
+      "description": "Details about the publisher of the placement."
+    },
+    "domain": {
+      "type": "string",
+      "description": "Domain of the inventory owner."
+    },
+    "keywords": {
+      "type": "string",
+      "description": "Comma separated list of keywords about the DOOH placement."
+    },
+    "content": {
+      "$ref": "Content.json",
+      "description": "Details about the Content within the DOOH placement."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for exchange-specific extensions to OpenRTB.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/jsonschema/Data.json
+++ b/jsonschema/Data.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/Data.json",
+  "title": "OpenRTB 2.6 Data",
+  "description": "Allows additional data about the related object (user, content) to be specified.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Exchange-specific ID for the data provider."
+    },
+    "name": {
+      "type": "string",
+      "description": "Exchange-specific name for the data provider."
+    },
+    "cids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Array of Extended Content IDs."
+    },
+    "segment": {
+      "type": "array",
+      "items": {
+        "$ref": "Segment.json"
+      },
+      "description": "Array of Segment objects containing the actual data values."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for exchange-specific extensions to OpenRTB.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/jsonschema/Deal.json
+++ b/jsonschema/Deal.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/Deal.json",
+  "title": "OpenRTB 2.6 Deal",
+  "description": "A specific deal struck between a buyer and a seller.",
+  "type": "object",
+  "required": [
+    "id"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "A unique identifier for the direct deal."
+    },
+    "bidfloor": {
+      "type": "number",
+      "default": 0,
+      "description": "Minimum bid for this impression expressed in CPM.",
+      "minimum": 0
+    },
+    "bidfloorcur": {
+      "type": "string",
+      "default": "USD",
+      "description": "Currency specified using ISO-4217 alpha codes."
+    },
+    "at": {
+      "type": "integer",
+      "description": "Optional override of the overall auction type. 1 = First Price, 2 = Second Price Plus, 3 = agreed upon deal price."
+    },
+    "wseat": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Allowed list of buyer seats allowed to bid on this deal."
+    },
+    "wadomain": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Array of advertiser domains allowed to bid on this deal."
+    },
+    "guar": {
+      "type": "integer",
+      "default": 0,
+      "enum": [
+        0,
+        1
+      ],
+      "description": "Indicates that the deal is guaranteed. 0 = not guaranteed, 1 = guaranteed."
+    },
+    "mincpmpersec": {
+      "type": "number",
+      "description": "Minimum CPM per second for video or audio impression opportunities."
+    },
+    "durfloors": {
+      "type": "array",
+      "items": {
+        "$ref": "DurFloors.json"
+      },
+      "description": "Container for floor price by duration information."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for exchange-specific extensions to OpenRTB.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/jsonschema/Device.json
+++ b/jsonschema/Device.json
@@ -1,0 +1,164 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/Device.json",
+  "title": "OpenRTB 2.6 Device",
+  "description": "Information pertaining to the device through which the user is interacting.",
+  "type": "object",
+  "properties": {
+    "geo": {
+      "$ref": "Geo.json",
+      "description": "Location of the device assumed to be the user's current location."
+    },
+    "dnt": {
+      "type": "integer",
+      "enum": [
+        0,
+        1
+      ],
+      "description": "Standard Do Not Track flag as set in the header by the browser."
+    },
+    "lmt": {
+      "type": "integer",
+      "enum": [
+        0,
+        1
+      ],
+      "description": "Limit Ad Tracking signal commercially endorsed."
+    },
+    "ua": {
+      "type": "string",
+      "description": "Browser user agent string."
+    },
+    "sua": {
+      "$ref": "UserAgent.json",
+      "description": "Structured user agent information."
+    },
+    "ip": {
+      "type": "string",
+      "description": "IPv4 address closest to device."
+    },
+    "ipv6": {
+      "type": "string",
+      "description": "IP address closest to device as IPv6."
+    },
+    "devicetype": {
+      "type": "integer",
+      "description": "The general type of device. Refer to AdCOM 1.0 List: Device Types."
+    },
+    "make": {
+      "type": "string",
+      "description": "Device make (e.g., \"Apple\")."
+    },
+    "model": {
+      "type": "string",
+      "description": "Device model (e.g., \"iPhone\")."
+    },
+    "os": {
+      "type": "string",
+      "description": "Device operating system (e.g., \"iOS\")."
+    },
+    "osv": {
+      "type": "string",
+      "description": "Device operating system version (e.g., \"3.1.2\")."
+    },
+    "hwv": {
+      "type": "string",
+      "description": "Hardware version of the device."
+    },
+    "h": {
+      "type": "integer",
+      "description": "Physical height of the screen in pixels."
+    },
+    "w": {
+      "type": "integer",
+      "description": "Physical width of the screen in pixels."
+    },
+    "ppi": {
+      "type": "integer",
+      "description": "Screen size as pixels per linear inch."
+    },
+    "pxratio": {
+      "type": "number",
+      "description": "The ratio of physical pixels to device-independent pixels."
+    },
+    "js": {
+      "type": "integer",
+      "enum": [
+        0,
+        1
+      ],
+      "description": "Support for JavaScript."
+    },
+    "geofetch": {
+      "type": "integer",
+      "enum": [
+        0,
+        1
+      ],
+      "description": "Indicates if the geolocation API will be available to JavaScript code."
+    },
+    "flashver": {
+      "type": "string",
+      "description": "Version of Flash supported by the browser."
+    },
+    "language": {
+      "type": "string",
+      "description": "Browser language using ISO-639-1-alpha-2."
+    },
+    "langb": {
+      "type": "string",
+      "description": "Browser language using IETF BCP 47."
+    },
+    "carrier": {
+      "type": "string",
+      "description": "Carrier or ISP (e.g., \"VERIZON\")."
+    },
+    "mccmnc": {
+      "type": "string",
+      "description": "Mobile carrier as the concatenated MCC-MNC code."
+    },
+    "connectiontype": {
+      "type": "integer",
+      "description": "Network connection type. Refer to AdCOM 1.0 List: Connection Types."
+    },
+    "ifa": {
+      "type": "string",
+      "description": "ID sanctioned for advertiser use in the clear."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for exchange-specific extensions to OpenRTB.",
+      "additionalProperties": true
+    },
+    "didsha1": {
+      "type": "string",
+      "description": "DEPRECATED. Hardware device ID (e.g., IMEI) hashed via SHA1.",
+      "deprecated": true
+    },
+    "didmd5": {
+      "type": "string",
+      "description": "DEPRECATED. Hardware device ID (e.g., IMEI) hashed via MD5.",
+      "deprecated": true
+    },
+    "dpidsha1": {
+      "type": "string",
+      "description": "DEPRECATED. Platform device ID (e.g., Android ID) hashed via SHA1.",
+      "deprecated": true
+    },
+    "dpidmd5": {
+      "type": "string",
+      "description": "DEPRECATED. Platform device ID (e.g., Android ID) hashed via MD5.",
+      "deprecated": true
+    },
+    "macsha1": {
+      "type": "string",
+      "description": "DEPRECATED. MAC address of the device hashed via SHA1.",
+      "deprecated": true
+    },
+    "macmd5": {
+      "type": "string",
+      "description": "DEPRECATED. MAC address of the device hashed via MD5.",
+      "deprecated": true
+    }
+  }
+}

--- a/jsonschema/DurFloors.json
+++ b/jsonschema/DurFloors.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/DurFloors.json",
+  "title": "OpenRTB 2.6 DurFloors",
+  "description": "Allows sellers to specify price floors for video and audio creatives whose price varies based on duration.",
+  "type": "object",
+  "properties": {
+    "mindur": {
+      "type": "integer",
+      "description": "Low end of a duration range. If missing, the low end is unbounded."
+    },
+    "maxdur": {
+      "type": "integer",
+      "description": "High end of a duration range. If missing, the high end is unbounded."
+    },
+    "bidfloor": {
+      "type": "number",
+      "default": 0,
+      "description": "Minimum bid for a given impression opportunity in this duration range, expressed in CPM.",
+      "minimum": 0
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for vendor specific extensions.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/jsonschema/EID.json
+++ b/jsonschema/EID.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/EID.json",
+  "title": "OpenRTB 2.6 EID",
+  "description": "Extended identifier support for multiple third party identity providers.",
+  "type": "object",
+  "properties": {
+    "inserter": {
+      "type": "string",
+      "description": "The canonical domain name of the entity that caused the ID array element to be added."
+    },
+    "source": {
+      "type": "string",
+      "description": "Canonical domain of the ID."
+    },
+    "matcher": {
+      "type": "string",
+      "description": "Technology providing the match method as defined in mm."
+    },
+    "mm": {
+      "type": "integer",
+      "description": "Match method used by the matcher. Refer to AdCOM 1.0 List: ID Match Methods."
+    },
+    "uids": {
+      "type": "array",
+      "items": {
+        "$ref": "UID.json"
+      },
+      "description": "Array of extended ID UID objects from the given source."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for exchange-specific extensions to OpenRTB.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/jsonschema/Format.json
+++ b/jsonschema/Format.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/Format.json",
+  "title": "OpenRTB 2.6 Format",
+  "description": "An allowed size (height and width combination) or Flex Ad parameters for a banner impression.",
+  "type": "object",
+  "properties": {
+    "w": {
+      "type": "integer",
+      "description": "Width in device-independent pixels (DIPS)."
+    },
+    "h": {
+      "type": "integer",
+      "description": "Height in device-independent pixels (DIPS)."
+    },
+    "wratio": {
+      "type": "integer",
+      "description": "Relative width when expressing size as a ratio."
+    },
+    "hratio": {
+      "type": "integer",
+      "description": "Relative height when expressing size as a ratio."
+    },
+    "wmin": {
+      "type": "integer",
+      "description": "The minimum width in DIPS at which the ad will be displayed when expressed as a ratio."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for exchange-specific extensions to OpenRTB.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/jsonschema/Geo.json
+++ b/jsonschema/Geo.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/Geo.json",
+  "title": "OpenRTB 2.6 Geo",
+  "description": "Encapsulates various methods for specifying a geographic location.",
+  "type": "object",
+  "properties": {
+    "lat": {
+      "type": "number",
+      "minimum": -90,
+      "maximum": 90,
+      "description": "Latitude from -90.0 to +90.0, where negative is south."
+    },
+    "lon": {
+      "type": "number",
+      "minimum": -180,
+      "maximum": 180,
+      "description": "Longitude from -180.0 to +180.0, where negative is west."
+    },
+    "type": {
+      "type": "integer",
+      "description": "Source of location data. Refer to AdCOM 1.0 List: Location Types."
+    },
+    "accuracy": {
+      "type": "integer",
+      "description": "Estimated location accuracy in meters."
+    },
+    "lastfix": {
+      "type": "integer",
+      "description": "Number of seconds since this geolocation fix was established."
+    },
+    "ipservice": {
+      "type": "integer",
+      "description": "Service or provider used to determine geolocation from IP address."
+    },
+    "country": {
+      "type": "string",
+      "description": "Country code using ISO-3166-1-alpha-3."
+    },
+    "region": {
+      "type": "string",
+      "description": "Region code using ISO-3166-2; 2-letter state code if USA."
+    },
+    "regionfips104": {
+      "type": "string",
+      "description": "Region of a country using FIPS 10-4 notation (deprecated by NIST in 2008)."
+    },
+    "metro": {
+      "type": "string",
+      "description": "Google metro code; similar to but not exactly Nielsen DMAs."
+    },
+    "city": {
+      "type": "string",
+      "description": "City using United Nations Code for Trade & Transport Locations."
+    },
+    "zip": {
+      "type": "string",
+      "description": "ZIP or postal code."
+    },
+    "utcoffset": {
+      "type": "integer",
+      "description": "Local time as the number +/- of minutes from UTC."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for exchange-specific extensions to OpenRTB.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/jsonschema/Imp.json
+++ b/jsonschema/Imp.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/Imp.json",
+  "title": "OpenRTB 2.6 Imp",
+  "description": "Describes an ad placement or impression being auctioned.",
+  "type": "object",
+  "required": [
+    "id"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "A unique identifier for this impression within the context of the bid request."
+    },
+    "metric": {
+      "type": "array",
+      "items": {
+        "$ref": "Metric.json"
+      },
+      "description": "An array of Metric objects."
+    },
+    "banner": {
+      "$ref": "Banner.json",
+      "description": "A Banner object; required if this impression is offered as a banner ad opportunity."
+    },
+    "video": {
+      "$ref": "Video.json",
+      "description": "A Video object; required if this impression is offered as a video ad opportunity."
+    },
+    "audio": {
+      "$ref": "Audio.json",
+      "description": "An Audio object; required if this impression is offered as an audio ad opportunity."
+    },
+    "native": {
+      "$ref": "Native.json",
+      "description": "A Native object; required if this impression is offered as a native ad opportunity."
+    },
+    "pmp": {
+      "$ref": "Pmp.json",
+      "description": "A Pmp object containing any private marketplace deals in effect for this impression."
+    },
+    "displaymanager": {
+      "type": "string",
+      "description": "Name of ad mediation partner, SDK technology, or player responsible for rendering ad."
+    },
+    "displaymanagerver": {
+      "type": "string",
+      "description": "Version of ad mediation partner, SDK technology, or player responsible for rendering ad."
+    },
+    "instl": {
+      "type": "integer",
+      "default": 0,
+      "enum": [
+        0,
+        1
+      ],
+      "description": "1 = the ad is interstitial or full screen, 0 = not interstitial."
+    },
+    "tagid": {
+      "type": "string",
+      "description": "Identifier for specific ad placement or ad tag that was used to initiate the auction."
+    },
+    "bidfloor": {
+      "type": "number",
+      "default": 0,
+      "description": "Minimum bid for this impression expressed in CPM.",
+      "minimum": 0
+    },
+    "bidfloorcur": {
+      "type": "string",
+      "default": "USD",
+      "description": "Currency specified using ISO-4217 alpha codes."
+    },
+    "clickbrowser": {
+      "type": "integer",
+      "enum": [
+        0,
+        1
+      ],
+      "description": "Indicates the type of browser opened upon clicking the creative in an app, where 0 = embedded, 1 = native."
+    },
+    "secure": {
+      "type": "integer",
+      "enum": [
+        0,
+        1
+      ],
+      "description": "Flag to indicate if the impression requires secure HTTPS URL creative assets and markup."
+    },
+    "iframebuster": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Array of exchange-specific names of supported iframe busters."
+    },
+    "rwdd": {
+      "type": "integer",
+      "default": 0,
+      "enum": [
+        0,
+        1
+      ],
+      "description": "Indicates whether the user receives a reward for viewing the ad."
+    },
+    "ssai": {
+      "type": "integer",
+      "default": 0,
+      "enum": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "description": "Indicates if server-side ad insertion is in use. 0 = unknown, 1 = all client-side, 2 = assets stitched server-side but tracking client-side, 3 = all server-side."
+    },
+    "exp": {
+      "type": "integer",
+      "description": "Advisory as to the number of seconds that may elapse between the auction and the actual impression."
+    },
+    "qty": {
+      "$ref": "Qty.json",
+      "description": "A means of passing a multiplier in the bid request."
+    },
+    "dt": {
+      "type": "number",
+      "description": "Timestamp when the item is estimated to be fulfilled in Unix format (milliseconds since epoch)."
+    },
+    "refresh": {
+      "$ref": "Refresh.json",
+      "description": "Details about ad slots being refreshed automatically."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for exchange-specific extensions to OpenRTB.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/jsonschema/Metric.json
+++ b/jsonschema/Metric.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/Metric.json",
+  "title": "OpenRTB 2.6 Metric",
+  "description": "A quantifiable often historical data point about an impression.",
+  "type": "object",
+  "required": [
+    "type",
+    "value"
+  ],
+  "properties": {
+    "type": {
+      "type": "string",
+      "description": "Type of metric being presented using exchange curated string names."
+    },
+    "value": {
+      "type": "number",
+      "description": "Number representing the value of the metric. Probabilities must be in the range 0.0-1.0."
+    },
+    "vendor": {
+      "type": "string",
+      "description": "Source of the value using exchange curated string names."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for exchange-specific extensions to OpenRTB.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/jsonschema/Native.json
+++ b/jsonschema/Native.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/Native.json",
+  "title": "OpenRTB 2.6 Native",
+  "description": "Container for a native impression conforming to the Dynamic Native Ads API.",
+  "type": "object",
+  "required": [
+    "request"
+  ],
+  "properties": {
+    "request": {
+      "type": "string",
+      "description": "Request payload complying with the Native Ad Specification."
+    },
+    "ver": {
+      "type": "string",
+      "description": "Version of the Dynamic Native Ads API to which request complies."
+    },
+    "api": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "description": "List of supported API frameworks."
+    },
+    "battr": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "description": "Blocked creative attributes."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for exchange-specific extensions to OpenRTB.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/jsonschema/Network.json
+++ b/jsonschema/Network.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/Network.json",
+  "title": "OpenRTB 2.6 Network",
+  "description": "Describes the network an ad will be displayed on.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "A unique identifier assigned by the publisher."
+    },
+    "name": {
+      "type": "string",
+      "description": "Network the content is on (e.g., \"ABC\")."
+    },
+    "domain": {
+      "type": "string",
+      "description": "The primary domain of the network."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for exchange-specific extensions to OpenRTB.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/jsonschema/Pmp.json
+++ b/jsonschema/Pmp.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/Pmp.json",
+  "title": "OpenRTB 2.6 Pmp",
+  "description": "Private marketplace container for direct deals between buyers and sellers.",
+  "type": "object",
+  "properties": {
+    "private_auction": {
+      "type": "integer",
+      "default": 0,
+      "enum": [
+        0,
+        1
+      ],
+      "description": "Indicator of auction eligibility to seats named in the Direct Deals object."
+    },
+    "deals": {
+      "type": "array",
+      "items": {
+        "$ref": "Deal.json"
+      },
+      "description": "Array of Deal objects that convey the specific deals applicable to this impression."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for exchange-specific extensions to OpenRTB.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/jsonschema/Producer.json
+++ b/jsonschema/Producer.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/Producer.json",
+  "title": "OpenRTB 2.6 Producer",
+  "description": "Defines the producer of the content in which the ad will be shown.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Content producer or originator ID."
+    },
+    "name": {
+      "type": "string",
+      "description": "Content producer or originator name."
+    },
+    "cattax": {
+      "type": "integer",
+      "default": 1,
+      "description": "The taxonomy in use for cat fields."
+    },
+    "cat": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Array of IAB content categories for the content producer."
+    },
+    "domain": {
+      "type": "string",
+      "description": "Highest level domain of the content producer."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for exchange-specific extensions to OpenRTB.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/jsonschema/Publisher.json
+++ b/jsonschema/Publisher.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/Publisher.json",
+  "title": "OpenRTB 2.6 Publisher",
+  "description": "The entity who directly supplies inventory to and is paid by the exchange.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Exchange-specific seller ID."
+    },
+    "name": {
+      "type": "string",
+      "description": "Seller name (may be aliased at the seller's request)."
+    },
+    "cattax": {
+      "type": "integer",
+      "default": 1,
+      "description": "The taxonomy in use for cat fields."
+    },
+    "cat": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Array of IAB content categories of the publisher."
+    },
+    "domain": {
+      "type": "string",
+      "description": "Highest level domain of the seller (e.g., \"seller.com\")."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for exchange-specific extensions to OpenRTB.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/jsonschema/Qty.json
+++ b/jsonschema/Qty.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/Qty.json",
+  "title": "OpenRTB 2.6 Qty",
+  "description": "A means of passing a multiplier representing the total quantity of impressions.",
+  "type": "object",
+  "required": [
+    "multiplier"
+  ],
+  "properties": {
+    "multiplier": {
+      "type": "number",
+      "description": "The quantity of billable events which will occur if this item is purchased."
+    },
+    "sourcetype": {
+      "type": "integer",
+      "description": "The source type of the quantity measurement."
+    },
+    "vendor": {
+      "type": "string",
+      "description": "The top level business domain name of the measurement vendor."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for vendor specific extensions.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/jsonschema/README.md
+++ b/jsonschema/README.md
@@ -1,0 +1,88 @@
+# OpenRTB 2.6 JSON Schema
+
+Machine-readable JSON Schema (Draft 2020-12) definitions for all objects in the OpenRTB 2.6 specification.
+
+## What's Included
+
+38 schema files covering the complete OpenRTB 2.6 object model:
+
+**Bid Request** (35 objects): BidRequest, Imp, Banner, Video, Audio, Native, Format, Metric, Pmp, Deal, Site, App, DOOH, Publisher, Content, Producer, Network, Channel, Device, Geo, User, Data, Segment, Regs, Source, SupplyChain, SupplyChainNode, EID, UID, UserAgent, BrandVersion, Qty, Refresh, RefSettings, DurFloors
+
+**Bid Response** (3 objects): BidResponse, SeatBid, Bid
+
+## Usage
+
+Validate an OpenRTB bid request against the schema:
+
+```bash
+# Python
+pip install jsonschema referencing
+python -c "
+import json, jsonschema
+from referencing import Registry, Resource
+from pathlib import Path
+
+# Build a registry of all schemas for $ref resolution
+registry = Registry()
+schema_dir = Path('.')
+for schema_file in schema_dir.glob('*.json'):
+    schema = json.loads(schema_file.read_text())
+    resource = Resource.from_contents(schema)
+    registry = registry.with_resource(schema['$id'], resource)
+
+# Validate
+bid_request = json.load(open('examples/bid-requests/simple-banner.json'))
+schema = json.load(open('BidRequest.json'))
+jsonschema.validate(bid_request, schema, registry=registry)
+print('Valid!')
+"
+```
+
+```bash
+# Node.js (ajv)
+npm install ajv ajv-formats
+node -e "
+const Ajv = require('ajv/dist/2020');
+const fs = require('fs');
+const path = require('path');
+
+const ajv = new Ajv({allErrors: true});
+const schemaDir = '.';
+
+// Load all schemas
+fs.readdirSync(schemaDir)
+  .filter(f => f.endsWith('.json'))
+  .forEach(f => ajv.addSchema(JSON.parse(fs.readFileSync(path.join(schemaDir, f)))));
+
+const validate = ajv.getSchema('https://iabtechlab.com/openrtb/2.6/BidRequest.json');
+const bidRequest = JSON.parse(fs.readFileSync('examples/bid-requests/simple-banner.json'));
+const valid = validate(bidRequest);
+console.log(valid ? 'Valid!' : validate.errors);
+"
+```
+
+## Design Decisions
+
+**Forward-compatible by default.** Schemas do not set `additionalProperties: false` at the top level, honoring OpenRTB 2.6 Section 2.6: implementations "must tolerate receiving new or unexpected fields." Unknown fields pass validation.
+
+**Deprecated fields included.** Fields deprecated in OpenRTB 2.6 (e.g., `Device.didsha1`, `User.yob`, `Video.placement`) are present with `"deprecated": true` for backward compatibility.
+
+**Enums reference AdCOM 1.0.** Integer fields with enumerated values reference the AdCOM 1.0 list by name in their description rather than hardcoding enum arrays, since AdCOM values (especially vendor-specific 500+ ranges) change independently.
+
+**Extension objects are open.** All `ext` properties explicitly allow additional properties for exchange-specific extensions.
+
+## Schema Version
+
+OpenRTB Specification: 2.6
+JSON Schema Draft: 2020-12
+Namespace: `https://iabtechlab.com/openrtb/2.6/`
+
+## References
+
+- [OpenRTB 2.6 Specification](https://github.com/InteractiveAdvertisingBureau/openrtb2.x)
+- [AdCOM 1.0 Specification](https://github.com/InteractiveAdvertisingBureau/AdCOM)
+- [JSON Schema Draft 2020-12](https://json-schema.org/draft/2020-12/json-schema-core)
+
+## License
+
+Licensed under the same terms as the parent repository (Creative Commons Attribution 3.0).

--- a/jsonschema/RefSettings.json
+++ b/jsonschema/RefSettings.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/RefSettings.json",
+  "title": "OpenRTB 2.6 RefSettings",
+  "description": "Information on how often and what triggers an ad slot being refreshed.",
+  "type": "object",
+  "properties": {
+    "reftype": {
+      "type": "integer",
+      "default": 0,
+      "description": "The type of the declared auto refresh. Refer to AdCOM 1.0 List: Auto Refresh Triggers."
+    },
+    "minint": {
+      "type": "integer",
+      "description": "The minimum refresh interval in seconds."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for vendor specific extensions.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/jsonschema/Refresh.json
+++ b/jsonschema/Refresh.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/Refresh.json",
+  "title": "OpenRTB 2.6 Refresh",
+  "description": "Details about ad slots being refreshed automatically.",
+  "type": "object",
+  "properties": {
+    "refsettings": {
+      "type": "array",
+      "items": {
+        "$ref": "RefSettings.json"
+      },
+      "description": "A RefSettings object describing refresh mechanics."
+    },
+    "count": {
+      "type": "integer",
+      "description": "The number of times this ad slot had been refreshed since last page load."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for vendor specific extensions.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/jsonschema/Regs.json
+++ b/jsonschema/Regs.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/Regs.json",
+  "title": "OpenRTB 2.6 Regs",
+  "description": "Contains any legal, governmental, or industry regulations that the sender deems applicable to the request.",
+  "type": "object",
+  "properties": {
+    "coppa": {
+      "type": "integer",
+      "enum": [
+        0,
+        1
+      ],
+      "description": "Flag indicating if this request is subject to the COPPA regulations established by the USA FTC."
+    },
+    "gdpr": {
+      "type": "integer",
+      "enum": [
+        0,
+        1
+      ],
+      "description": "Flag that indicates whether or not the request is subject to GDPR regulations. 0 = No, 1 = Yes."
+    },
+    "us_privacy": {
+      "type": "string",
+      "description": "Communicates signals regarding consumer privacy under US privacy regulation."
+    },
+    "gpp": {
+      "type": "string",
+      "description": "Contains the Global Privacy Platform's consent string."
+    },
+    "gpp_sid": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "description": "Array of the section(s) of the GPP string which should be applied for this transaction."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for exchange-specific extensions to OpenRTB.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/jsonschema/SeatBid.json
+++ b/jsonschema/SeatBid.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/SeatBid.json",
+  "title": "OpenRTB 2.6 SeatBid",
+  "description": "A bid response can contain multiple SeatBid objects, each on behalf of a different bidder seat.",
+  "type": "object",
+  "required": [
+    "bid"
+  ],
+  "properties": {
+    "bid": {
+      "type": "array",
+      "items": {
+        "$ref": "Bid.json"
+      },
+      "minItems": 1,
+      "description": "Array of 1+ Bid objects each related to an impression."
+    },
+    "seat": {
+      "type": "string",
+      "description": "ID of the buyer seat on whose behalf this bid is made."
+    },
+    "group": {
+      "type": "integer",
+      "default": 0,
+      "enum": [
+        0,
+        1
+      ],
+      "description": "0 = impressions can be won individually; 1 = impressions must be won or lost as a group."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for bidder-specific extensions to OpenRTB.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/jsonschema/Segment.json
+++ b/jsonschema/Segment.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/Segment.json",
+  "title": "OpenRTB 2.6 Segment",
+  "description": "Key-value pairs that convey specific units of data about a user or content.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "ID of the data segment specific to the data provider."
+    },
+    "name": {
+      "type": "string",
+      "description": "Name of the data segment specific to the data provider."
+    },
+    "value": {
+      "type": "string",
+      "description": "String representation of the data segment value."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for exchange-specific extensions to OpenRTB.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/jsonschema/Site.json
+++ b/jsonschema/Site.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/Site.json",
+  "title": "OpenRTB 2.6 Site",
+  "description": "Details about the publisher's website.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Exchange-specific site ID."
+    },
+    "name": {
+      "type": "string",
+      "description": "Site name (may be aliased at the publisher's request)."
+    },
+    "domain": {
+      "type": "string",
+      "description": "Domain of the site (e.g., \"mysite.foo.com\")."
+    },
+    "cattax": {
+      "type": "integer",
+      "default": 1,
+      "description": "The taxonomy in use for cat fields."
+    },
+    "cat": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Array of IAB content categories of the site."
+    },
+    "sectioncat": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Array of IAB content categories for the current section."
+    },
+    "pagecat": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Array of IAB content categories for the current page."
+    },
+    "page": {
+      "type": "string",
+      "description": "URL of the page where the impression will be shown."
+    },
+    "ref": {
+      "type": "string",
+      "description": "Referrer URL that caused navigation to the current page."
+    },
+    "search": {
+      "type": "string",
+      "description": "Search string that caused navigation to the current page."
+    },
+    "mobile": {
+      "type": "integer",
+      "enum": [
+        0,
+        1
+      ],
+      "description": "Indicates if the site has been programmed to optimize layout for mobile devices."
+    },
+    "privacypolicy": {
+      "type": "integer",
+      "enum": [
+        0,
+        1
+      ],
+      "description": "Indicates if the site has a privacy policy."
+    },
+    "publisher": {
+      "$ref": "Publisher.json",
+      "description": "Details about the Publisher of the site."
+    },
+    "content": {
+      "$ref": "Content.json",
+      "description": "Details about the Content within the site."
+    },
+    "keywords": {
+      "type": "string",
+      "description": "Comma separated list of keywords about the site."
+    },
+    "kwarray": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Array of keywords about the site."
+    },
+    "inventorypartnerdomain": {
+      "type": "string",
+      "description": "A domain for inventory authorization in inventory sharing arrangements."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for exchange-specific extensions to OpenRTB.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/jsonschema/Source.json
+++ b/jsonschema/Source.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/Source.json",
+  "title": "OpenRTB 2.6 Source",
+  "description": "Describes the nature and behavior of the entity that is the source of the bid request upstream from the exchange.",
+  "type": "object",
+  "properties": {
+    "fd": {
+      "type": "integer",
+      "enum": [
+        0,
+        1
+      ],
+      "description": "Entity responsible for the final impression sale decision, where 0 = exchange, 1 = upstream source."
+    },
+    "tid": {
+      "type": "string",
+      "description": "Transaction ID that must be common across all participants in this bid request."
+    },
+    "pchain": {
+      "type": "string",
+      "description": "Payment ID chain string containing embedded syntax described in the TAG payment ID Protocol v1.0."
+    },
+    "schain": {
+      "$ref": "SupplyChain.json",
+      "description": "This object represents both the links in the supply chain as well as an indicator whether or not the supply chain is complete."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for exchange-specific extensions to OpenRTB.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/jsonschema/SupplyChain.json
+++ b/jsonschema/SupplyChain.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/SupplyChain.json",
+  "title": "OpenRTB 2.6 SupplyChain",
+  "description": "Represents all entities involved in the direct flow of payment for inventory.",
+  "type": "object",
+  "required": [
+    "complete",
+    "nodes",
+    "ver"
+  ],
+  "properties": {
+    "complete": {
+      "type": "integer",
+      "enum": [
+        0,
+        1
+      ],
+      "description": "Flag indicating whether the chain contains all nodes involved in the transaction. 0 = no, 1 = yes."
+    },
+    "nodes": {
+      "type": "array",
+      "items": {
+        "$ref": "SupplyChainNode.json"
+      },
+      "minItems": 1,
+      "description": "Array of SupplyChainNode objects in the order of the chain."
+    },
+    "ver": {
+      "type": "string",
+      "description": "Version of the supply chain specification in use (e.g., \"1.0\")."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for exchange-specific extensions to OpenRTB.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/jsonschema/SupplyChainNode.json
+++ b/jsonschema/SupplyChainNode.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/SupplyChainNode.json",
+  "title": "OpenRTB 2.6 SupplyChainNode",
+  "description": "Defines the identity of an entity participating in the supply chain of a bid request.",
+  "type": "object",
+  "required": [
+    "asi",
+    "sid"
+  ],
+  "properties": {
+    "asi": {
+      "type": "string",
+      "description": "The canonical domain name of the SSP, Exchange, Header Wrapper, etc."
+    },
+    "sid": {
+      "type": "string",
+      "maxLength": 64,
+      "description": "The identifier associated with the seller or reseller account within the advertising system."
+    },
+    "rid": {
+      "type": "string",
+      "description": "The OpenRTB RequestId of the request as issued by this seller."
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the company that is paid for inventory transacted under the given seller_ID."
+    },
+    "domain": {
+      "type": "string",
+      "description": "The business domain name of the entity represented by this node."
+    },
+    "hp": {
+      "type": "integer",
+      "enum": [
+        0,
+        1
+      ],
+      "description": "Indicates whether this node will be involved in the flow of payment for the inventory."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for advertising-system specific extensions.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/jsonschema/UID.json
+++ b/jsonschema/UID.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/UID.json",
+  "title": "OpenRTB 2.6 UID",
+  "description": "A single user identifier provided as part of extended identifiers.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "The identifier for the user."
+    },
+    "atype": {
+      "type": "integer",
+      "description": "Type of user agent the ID is from. Refer to AdCOM 1.0 List: Agent Types."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for vendor specific extensions.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/jsonschema/User.json
+++ b/jsonschema/User.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/User.json",
+  "title": "OpenRTB 2.6 User",
+  "description": "Information known or derived about the human user of the device; the advertising audience.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Exchange-specific ID for the user."
+    },
+    "buyeruid": {
+      "type": "string",
+      "description": "Buyer-specific ID for the user as mapped by the exchange for the buyer."
+    },
+    "keywords": {
+      "type": "string",
+      "description": "Comma separated list of keywords, interests, or intent."
+    },
+    "kwarray": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Array of keywords about the user."
+    },
+    "customdata": {
+      "type": "string",
+      "description": "Optional feature to pass bidder data that was set in the exchange's cookie."
+    },
+    "geo": {
+      "$ref": "Geo.json",
+      "description": "Location of the user's home base."
+    },
+    "data": {
+      "type": "array",
+      "items": {
+        "$ref": "Data.json"
+      },
+      "description": "Additional user data."
+    },
+    "consent": {
+      "type": "string",
+      "description": "TCF Consent String data structure when GDPR regulations are in effect."
+    },
+    "eids": {
+      "type": "array",
+      "items": {
+        "$ref": "EID.json"
+      },
+      "description": "Details for support of multiple third party identity providers."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for exchange-specific extensions to OpenRTB.",
+      "additionalProperties": true
+    },
+    "yob": {
+      "type": "integer",
+      "description": "DEPRECATED. Year of birth as a 4-digit integer.",
+      "deprecated": true
+    },
+    "gender": {
+      "type": "string",
+      "description": "DEPRECATED. Gender, where M = male, F = female, O = known to be other.",
+      "deprecated": true
+    }
+  }
+}

--- a/jsonschema/UserAgent.json
+++ b/jsonschema/UserAgent.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/UserAgent.json",
+  "title": "OpenRTB 2.6 UserAgent",
+  "description": "Structured user agent information from User-Agent Client Hints.",
+  "type": "object",
+  "properties": {
+    "browsers": {
+      "type": "array",
+      "items": {
+        "$ref": "BrandVersion.json"
+      },
+      "description": "Each BrandVersion object identifies a browser or similar software component."
+    },
+    "platform": {
+      "$ref": "BrandVersion.json",
+      "description": "A BrandVersion object identifying the user agent's execution platform/OS."
+    },
+    "mobile": {
+      "type": "integer",
+      "enum": [
+        0,
+        1
+      ],
+      "description": "1 if the agent prefers mobile content, 0 for desktop/full."
+    },
+    "architecture": {
+      "type": "string",
+      "description": "Device's major binary architecture (e.g., \"x86\" or \"arm\")."
+    },
+    "bitness": {
+      "type": "string",
+      "description": "Device's bitness (e.g., \"64\")."
+    },
+    "model": {
+      "type": "string",
+      "description": "Device model from Sec-CH-UA-Model header."
+    },
+    "source": {
+      "type": "integer",
+      "default": 0,
+      "description": "Source of data used to create this object. Refer to AdCOM 1.0 List: User-Agent Source."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for vendor specific extensions.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/jsonschema/Video.json
+++ b/jsonschema/Video.json
@@ -1,0 +1,207 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iabtechlab.com/openrtb/2.6/Video.json",
+  "title": "OpenRTB 2.6 Video",
+  "description": "Represents a video impression. Video in OpenRTB generally assumes compliance with the VAST standard.",
+  "type": "object",
+  "required": [
+    "mimes"
+  ],
+  "properties": {
+    "mimes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "description": "Content MIME types supported (e.g., \"video/mp4\")."
+    },
+    "minduration": {
+      "type": "integer",
+      "default": 0,
+      "description": "Minimum video ad duration in seconds. Mutually exclusive with rqddurs."
+    },
+    "maxduration": {
+      "type": "integer",
+      "description": "Maximum video ad duration in seconds. Mutually exclusive with rqddurs."
+    },
+    "startdelay": {
+      "type": "integer",
+      "description": "Indicates the start delay in seconds for pre-roll, mid-roll, or post-roll ad placements. Refer to AdCOM 1.0 List: Start Delay Modes."
+    },
+    "maxseq": {
+      "type": "integer",
+      "description": "Indicates the maximum number of ads that may be served into a dynamic video ad pod."
+    },
+    "poddur": {
+      "type": "integer",
+      "description": "Indicates the total amount of time in seconds that advertisers may fill for a dynamic video ad pod."
+    },
+    "protocols": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "description": "Array of supported video protocols. Refer to AdCOM 1.0 List: Creative Subtypes - Audio/Video."
+    },
+    "w": {
+      "type": "integer",
+      "description": "Width of the video player in device-independent pixels (DIPS)."
+    },
+    "h": {
+      "type": "integer",
+      "description": "Height of the video player in device-independent pixels (DIPS)."
+    },
+    "podid": {
+      "type": "string",
+      "description": "Unique identifier indicating that an impression opportunity belongs to a video ad pod."
+    },
+    "podseq": {
+      "type": "integer",
+      "default": 0,
+      "description": "The sequence (position) of the video ad pod within a content stream."
+    },
+    "rqddurs": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "description": "Precise acceptable durations for video creatives in seconds. Mutually exclusive with minduration/maxduration."
+    },
+    "plcmt": {
+      "type": "integer",
+      "description": "Video placement type for the impression. Refer to AdCOM 1.0 List: Plcmt Subtypes - Video."
+    },
+    "linearity": {
+      "type": "integer",
+      "description": "Indicates if the impression must be linear, nonlinear, etc. Refer to AdCOM 1.0 List: Linearity Modes."
+    },
+    "skip": {
+      "type": "integer",
+      "enum": [
+        0,
+        1
+      ],
+      "description": "Indicates if the player will allow the video to be skipped, where 0 = no, 1 = yes."
+    },
+    "skipmin": {
+      "type": "integer",
+      "default": 0,
+      "description": "Videos of total duration greater than this number of seconds can be skippable."
+    },
+    "skipafter": {
+      "type": "integer",
+      "default": 0,
+      "description": "Number of seconds a video must play before skipping is enabled."
+    },
+    "slotinpod": {
+      "type": "integer",
+      "default": 0,
+      "description": "Indicates that the seller can guarantee delivery against the indicated slot position in the pod."
+    },
+    "mincpmpersec": {
+      "type": "number",
+      "description": "Minimum CPM per second. Price floor for the dynamic portion of a video ad pod."
+    },
+    "battr": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "description": "Blocked creative attributes. Refer to AdCOM 1.0 List: Creative Attributes."
+    },
+    "maxextended": {
+      "type": "integer",
+      "description": "Maximum extended ad duration if extension is allowed. 0 = not allowed, -1 = unlimited."
+    },
+    "minbitrate": {
+      "type": "integer",
+      "description": "Minimum bit rate in Kbps."
+    },
+    "maxbitrate": {
+      "type": "integer",
+      "description": "Maximum bit rate in Kbps."
+    },
+    "boxingallowed": {
+      "type": "integer",
+      "default": 1,
+      "enum": [
+        0,
+        1
+      ],
+      "description": "Indicates if letter-boxing of 4:3 content into a 16:9 window is allowed."
+    },
+    "playbackmethod": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "description": "Playback methods that may be in use. Refer to AdCOM 1.0 List: Playback Methods."
+    },
+    "playbackend": {
+      "type": "integer",
+      "description": "The event that causes playback to end. Refer to AdCOM 1.0 List: Playback Cessation Modes."
+    },
+    "delivery": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "description": "Supported delivery methods. Refer to AdCOM 1.0 List: Delivery Methods."
+    },
+    "pos": {
+      "type": "integer",
+      "description": "Ad position on screen. Refer to AdCOM 1.0 List: Placement Positions."
+    },
+    "companionad": {
+      "type": "array",
+      "items": {
+        "$ref": "Banner.json"
+      },
+      "description": "Array of Banner objects if companion ads are available."
+    },
+    "api": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "description": "List of supported API frameworks for this impression. Refer to AdCOM 1.0 List: API Frameworks."
+    },
+    "companiontype": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "description": "Supported VAST companion ad types. Refer to AdCOM 1.0 List: Companion Types."
+    },
+    "poddedupe": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "description": "Indicates pod deduplication settings. Refer to AdCOM 1.0 List: Pod Deduplication Settings."
+    },
+    "durfloors": {
+      "type": "array",
+      "items": {
+        "$ref": "DurFloors.json"
+      },
+      "description": "Array of DurFloors objects indicating floor prices for video creatives of various durations."
+    },
+    "ext": {
+      "type": "object",
+      "description": "Placeholder for exchange-specific extensions to OpenRTB.",
+      "additionalProperties": true
+    },
+    "placement": {
+      "type": "integer",
+      "description": "DEPRECATED. Use plcmt instead. Video placement type.",
+      "deprecated": true
+    },
+    "sequence": {
+      "type": "integer",
+      "description": "DEPRECATED. Use slotinpod instead. Position in ad pod sequence.",
+      "deprecated": true
+    }
+  }
+}

--- a/jsonschema/examples/bid-requests/mobile-app.json
+++ b/jsonschema/examples/bid-requests/mobile-app.json
@@ -1,0 +1,52 @@
+{
+  "id": "IxexyLDIIk",
+  "at": 2,
+  "bcat": ["IAB25", "IAB7-39", "IAB8-18", "IAB8-5", "IAB9-9"],
+  "badv": ["apple.com", "go-text.me", "heywire.com"],
+  "imp": [
+    {
+      "id": "1",
+      "bidfloor": 0.5,
+      "instl": 0,
+      "tagid": "agltb3B1Yi1pbmNyDQsSBFNpdGUY7fD0FAw",
+      "banner": {
+        "w": 728,
+        "h": 90,
+        "pos": 1,
+        "btype": [4],
+        "battr": [14],
+        "api": [3]
+      }
+    }
+  ],
+  "app": {
+    "id": "agltb3B1Yi1pbmNyDAsSA0FwcBiJkfIUDA",
+    "name": "Yahoo Weather",
+    "cat": ["IAB15", "IAB15-10"],
+    "ver": "1.0.2",
+    "bundle": "12345",
+    "storeurl": "https://itunes.apple.com/id628677149",
+    "publisher": {
+      "id": "agltb3B1Yi1pbmNyDAsSA0FwcBiJkfTUCV",
+      "name": "yahoo",
+      "domain": "www.yahoo.com"
+    }
+  },
+  "device": {
+    "dnt": 0,
+    "ua": "Mozilla/5.0 (iPhone; CPU iPhone OS 6_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A334 Safari/7534.48.3",
+    "ifa": "AA000DFE74168477C70D291f574D344790E0BB11",
+    "carrier": "VERIZON",
+    "language": "en",
+    "make": "Apple",
+    "model": "iPhone",
+    "os": "iOS",
+    "osv": "6.1",
+    "js": 1,
+    "connectiontype": 3,
+    "devicetype": 1
+  },
+  "user": {
+    "id": "ffffffd5135596709273b3a1a07e466ea2bf4fff"
+  }
+}

--- a/jsonschema/examples/bid-requests/pmp-direct-deal.json
+++ b/jsonschema/examples/bid-requests/pmp-direct-deal.json
@@ -1,0 +1,51 @@
+{
+  "id": "80ce30c53c16e6ede735f123ef6e32361bfc7b22",
+  "at": 1,
+  "cur": ["USD"],
+  "imp": [
+    {
+      "id": "1",
+      "bidfloor": 0.03,
+      "banner": {
+        "h": 250,
+        "w": 300,
+        "pos": 0
+      },
+      "pmp": {
+        "private_auction": 1,
+        "deals": [
+          {
+            "id": "AB-Agency1-0001",
+            "at": 1,
+            "bidfloor": 2.5,
+            "wseat": ["Agency1"]
+          },
+          {
+            "id": "XY-Agency2-0001",
+            "at": 2,
+            "bidfloor": 2,
+            "wseat": ["Agency2"]
+          }
+        ]
+      }
+    }
+  ],
+  "site": {
+    "id": "102855",
+    "domain": "www.foobar.com",
+    "cat": ["IAB3-1"],
+    "page": "http://www.foobar.com/1234.html",
+    "publisher": {
+      "id": "8953",
+      "name": "foobar.com",
+      "cat": ["IAB3-1"],
+      "domain": "foobar.com"
+    }
+  },
+  "device": {
+    "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/537.13 (KHTML, like Gecko) Version/5.1.7 Safari/534.57.2"
+  },
+  "user": {
+    "id": "55816b39711f9b5acf3b90e313ed29e51665623f"
+  }
+}

--- a/jsonschema/examples/bid-requests/simple-banner.json
+++ b/jsonschema/examples/bid-requests/simple-banner.json
@@ -1,0 +1,37 @@
+{
+  "id": "80ce30c53c16e6ede735f123ef6e32361bfc7b22",
+  "at": 1,
+  "cur": [
+    "USD"
+  ],
+  "imp": [
+    {
+      "id": "1",
+      "bidfloor": 0.03,
+      "banner": {
+        "h": 250,
+        "w": 300,
+        "pos": 0
+      }
+    }
+  ],
+  "site": {
+    "id": "102855",
+    "cat": [
+      "IAB3-1"
+    ],
+    "domain": "www.foobar.com",
+    "page": "http://www.foobar.com/1234.html",
+    "publisher": {
+      "id": "8953",
+      "name": "foobar.com",
+      "cat": [
+        "IAB3-1"
+      ],
+      "domain": "foobar.com"
+    }
+  },
+  "user": {
+    "id": "55816b39711f9b5acf3b90e313ed29e51665623f"
+  }
+}

--- a/jsonschema/examples/bid-requests/video.json
+++ b/jsonschema/examples/bid-requests/video.json
@@ -1,0 +1,93 @@
+{
+  "id": "1234567893",
+  "at": 2,
+  "tmax": 120,
+  "imp": [
+    {
+      "id": "1",
+      "bidfloor": 0.03,
+      "video": {
+        "w": 640,
+        "h": 480,
+        "pos": 1,
+        "startdelay": 0,
+        "minduration": 5,
+        "maxduration": 30,
+        "maxextended": 30,
+        "minbitrate": 300,
+        "maxbitrate": 1500,
+        "apis": [1, 2],
+        "protocols": [2, 3],
+        "mimes": [
+          "video/x-flv",
+          "video/mp4",
+          "application/javascript"
+        ],
+        "linearity": 1,
+        "boxingallowed": 1,
+        "playbackmethod": [1, 3],
+        "delivery": [2],
+        "battr": [13, 14],
+        "companionad": [
+          {
+            "id": "1234567893-1",
+            "w": 300,
+            "h": 250,
+            "pos": 1,
+            "battr": [13, 14],
+            "expdir": [2, 4]
+          },
+          {
+            "id": "1234567893-2",
+            "w": 728,
+            "h": 90,
+            "pos": 1,
+            "battr": [13, 14]
+          }
+        ],
+        "companiontype": [1, 2]
+      }
+    }
+  ],
+  "site": {
+    "id": "1345135123",
+    "name": "Site ABCD",
+    "domain": "siteabcd.com",
+    "cat": ["IAB2-1", "IAB2-2"],
+    "page": "http://siteabcd.com/page.htm",
+    "ref": "http://referringsite.com/referringpage.htm",
+    "privacypolicy": 1,
+    "publisher": {
+      "id": "pub12345",
+      "name": "Publisher A"
+    },
+    "content": {
+      "id": "1234567",
+      "series": "All About Cars",
+      "season": "2",
+      "episode": 23,
+      "title": "Car Show",
+      "cat": ["IAB2-2"],
+      "keywords": "keyword-a,keyword-b,keyword-c"
+    }
+  },
+  "device": {
+    "ua": "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.2.16) Gecko/20110319 Firefox/3.6.16",
+    "os": "OS X",
+    "js": 1
+  },
+  "user": {
+    "id": "456789876567897654678987656789",
+    "buyeruid": "545678765467876567898765678987654",
+    "data": [
+      {
+        "id": "6",
+        "name": "Data Provider 1",
+        "segment": [
+          {"id": "12341318394918", "name": "auto intenders"},
+          {"id": "1234131839491234", "name": "auto enthusiasts"}
+        ]
+      }
+    ]
+  }
+}

--- a/jsonschema/examples/bid-responses/ad-served-on-win.json
+++ b/jsonschema/examples/bid-responses/ad-served-on-win.json
@@ -1,0 +1,23 @@
+{
+  "id": "1234567890",
+  "bidid": "abc1123",
+  "cur": "USD",
+  "seatbid": [
+    {
+      "seat": "512",
+      "bid": [
+        {
+          "id": "1",
+          "impid": "102",
+          "price": 9.43,
+          "nurl": "http://adserver.com/winnotice?impid=102",
+          "iurl": "http://adserver.com/pathtosampleimage",
+          "adomain": ["advertiserdomain.com"],
+          "cid": "campaign111",
+          "crid": "creative112",
+          "attr": [1, 2, 3, 4, 5, 6, 7, 12]
+        }
+      ]
+    }
+  ]
+}

--- a/jsonschema/examples/bid-responses/vast-inline.json
+++ b/jsonschema/examples/bid-responses/vast-inline.json
@@ -1,0 +1,16 @@
+{
+  "id": "123",
+  "seatbid": [
+    {
+      "bid": [
+        {
+          "id": "12345",
+          "impid": "2",
+          "price": 3.00,
+          "nurl": "http://example.com/winnoticeurl",
+          "adm": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<VAST version=\"2.0\">\n<Ad id=\"12345\">\n<InLine>\n<AdSystem version=\"1.0\">SpotXchange</AdSystem>\n<AdTitle>\n<![CDATA[Sample VAST]]>\n</AdTitle>\n<Impression>http://sample.com</Impression>\n<Description>\n<![CDATA[A sample VAST feed]]>\n</Description>\n<Creatives>\n<Creative sequence=\"1\" id=\"1\">\n<Linear>\n<Duration>00:00:30</Duration>\n<TrackingEvents></TrackingEvents>\n<VideoClicks>\n<ClickThrough>\n<![CDATA[http://sample.com/openrtbtest]]>\n</ClickThrough>\n</VideoClicks>\n<MediaFiles>\n<MediaFile delivery=\"progressive\" bitrate=\"256\" width=\"640\" height=\"480\" type=\"video/mp4\">\n<![CDATA[http://sample.com/video.mp4]]>\n</MediaFile>\n</MediaFiles>\n</Linear>\n</Creative>\n</Creatives>\n</InLine>\n</Ad>\n</VAST>"
+        }
+      ]
+    }
+  ]
+}

--- a/jsonschema/validate.py
+++ b/jsonschema/validate.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Validate OpenRTB 2.6 JSON documents against the schema."""
+
+import json
+import sys
+from pathlib import Path
+
+try:
+    import jsonschema
+    from referencing import Registry, Resource
+except ImportError:
+    print("Required: pip install jsonschema referencing")
+    sys.exit(1)
+
+
+def build_registry(schema_dir):
+    registry = Registry()
+    for schema_file in Path(schema_dir).glob("*.json"):
+        schema = json.loads(schema_file.read_text())
+        if "$id" in schema:
+            resource = Resource.from_contents(schema)
+            registry = registry.with_resource(schema["$id"], resource)
+    return registry
+
+
+def validate_file(filepath, schema_name, registry, schema_dir):
+    schema = json.loads((Path(schema_dir) / schema_name).read_text())
+    data = json.loads(Path(filepath).read_text())
+    jsonschema.validate(data, schema, registry=registry)
+
+
+def main():
+    schema_dir = Path(__file__).parent
+    registry = build_registry(schema_dir)
+
+    if len(sys.argv) > 1:
+        filepath = sys.argv[1]
+        schema_name = sys.argv[2] if len(sys.argv) > 2 else "BidRequest.json"
+        try:
+            validate_file(filepath, schema_name, registry, schema_dir)
+            print(f"PASS: {filepath}")
+        except jsonschema.ValidationError as e:
+            print(f"FAIL: {filepath}\n  {e.message}")
+            sys.exit(1)
+    else:
+        failures = 0
+        for example in sorted((schema_dir / "examples" / "bid-requests").glob("*.json")):
+            try:
+                validate_file(example, "BidRequest.json", registry, schema_dir)
+                print(f"  PASS: {example.name}")
+            except jsonschema.ValidationError as e:
+                print(f"  FAIL: {example.name} -> {e.message}")
+                failures += 1
+
+        for example in sorted((schema_dir / "examples" / "bid-responses").glob("*.json")):
+            try:
+                validate_file(example, "BidResponse.json", registry, schema_dir)
+                print(f"  PASS: {example.name}")
+            except jsonschema.ValidationError as e:
+                print(f"  FAIL: {example.name} -> {e.message}")
+                failures += 1
+
+        sys.exit(1 if failures else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Machine-readable JSON Schema (Draft 2020-12) definitions for all 38 objects in the OpenRTB 2.6 specification. Enables programmatic validation of bid requests and responses, IDE autocompletion, and automated tooling generation.

Continuation of #178 (accidentally closed — I made my forked repo private which caused GitHub to close the PR and sever the fork relationship, making it non-reopenable).

- 38 schema files covering the complete BidRequest (35 objects) and BidResponse (3 objects) model
- Forward-compatible design honoring Section 2.6 requirement to tolerate unknown fields
- Deprecated field annotations for backward compatibility
- Validation script and example files from Section 6 of the spec

## Motivation

Issue #101 requested JSON Schema support. Currently no machine-readable schema exists for OpenRTB 2.6, forcing every exchange and bidder to manually interpret the spec. This closes that gap and enables validation tooling, SDK generation, and editor support across the ecosystem.

## What's Included

```
jsonschema/
├── README.md                          # Usage docs for Python + Node.js
├── validate.py                        # Validation script
├── examples/
│   ├── bid-requests/                  # 4 examples from spec Section 6
│   └── bid-responses/                 # 2 examples from spec Section 6
└── [38 schema files]                  # One per OpenRTB 2.6 object
```

## Design Decisions

1. No `additionalProperties: false` — spec requires implementations tolerate unknown fields
2. Enum values reference AdCOM 1.0 by name rather than hardcoding (vendor-specific 500+ ranges change independently)
3. `ext` objects explicitly allow additional properties for exchange extensions
4. Deprecated fields included with `"deprecated": true` (Device.didsha1/didmd5/etc, User.yob/gender, Video.placement/sequence, Bid.api)
5. `$id` namespace: `https://iabtechlab.com/openrtb/2.6/`

## Validation

All 6 spec examples pass schema validation:
```
$ python3 validate.py
  PASS: mobile-app.json
  PASS: pmp-direct-deal.json
  PASS: simple-banner.json
  PASS: video.json
  PASS: ad-served-on-win.json
  PASS: vast-inline.json
```

Resolves #101