### PR TITLE
Fix invalid banner object in Banner Bid Response example

### DIFF
--- a/implementation.md
+++ b/implementation.md
@@ -1341,9 +1341,7 @@ In DOOH, there can be significant delay between winning an auction, and the crea
 					"id": "1",
 					"impid": "102",
 					"price": 9.43,
-					"banner": {
-						"img": "http://adserver.com/creative112.jpg"
-					},
+					"adm": "<a href=\"http://adserver.com/click?bidid=abc1123\" target=\"_blank\"><img src=\"http://adserver.com/creative112.jpg\" width=\"1080\" height=\"1920\"/></a>",
 					"burl": "http://adserver.com/billingnotice?impid=102& bidid=abc1123&price=${AUCTION_PRICE}&multiplier=${AUCTION_MULTIPLIER}",
 					"adomain": [
 						"advertiserdomain.com"


### PR DESCRIPTION
Fixes #125.

## Summary

The Banner Bid Response example in section 7.9.6.2 shows a `banner`
object nested inside the `Bid` object, with a non-standard `img` field:

```json
"banner": {
  "img": "http://adserver.com/creative112.jpg"
}
```

The `Object: Bid` table in 2.6.md (section 4.2.3) defines no `banner`
attribute at all, and `img` is not a defined attribute of any OpenRTB or
AdCOM object. Per section 4.3.2, "Markup Served in the Bid", ad markup
returned directly in the bid is conveyed via the `adm` attribute — which
this example was missing entirely. Every other bid-response example in
this document (video, native) does include `adm`.

I checked every other `"banner": {` occurrence in both `2.6.md` and
`implementation.md` — they're all legitimate `Imp.banner` objects on the
bid *request* side, where `banner` is correctly defined. This is the only
one on the response side.

## Fix

Replaces the invalid `banner` object with an `adm` string containing
representative banner markup, preserving the original example's creative
URL and dimensions, consistent with how the rest of the spec conveys
in-bid markup.

## Test plan
- [x] Validated the corrected JSON code block parses as valid JSON.