### PR TITLE
Fix Data/Segment and Video api object-model errors in Section 6.2 examples

### DIFF
--- a/2.6.md
+++ b/2.6.md
@@ -1731,7 +1731,7 @@ The following example illustrates a bid request for a video impression with two 
         "maxextended": 30,
         "minbitrate": 300,
         "maxbitrate": 1500,
-        "apis": [
+        "api": [
           1,
           2
         ],

--- a/2.6.md
+++ b/2.6.md
@@ -1611,7 +1611,11 @@ This example builds the first and adds parameters to describe support for an exp
       {
         "id": "23423424",
         "name": "data-provider1-age",
-        "value": "30-40"
+        "segment": [
+          {
+            "value": "30-40"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
Fixes #46. Contributes to #128 (2 of its 3 reported items — see note below).

## Summary

Two independently-reported, verified inconsistencies between the
Section 6.2 BidRequest examples and the object model defined elsewhere
in the spec:

**1. Example 2 – Expandable Creative:** the third `user.data` entry had
a bare `"value"` attribute directly on the `Data` object:

```json
{
  "id": "23423424",
  "name": "data-provider1-age",
  "value": "30-40"
}
```

`Object: Data` (§3.2.21) defines no `value` attribute. `value` belongs
to the `Segment` object (§3.2.22), which `Data` carries via its
`segment` array — `Segment` objects are, per their own description,
"essentially key-value pairs that convey specific units of data" for a
data provider.

**2. Example 4 – Video:** the video object used `"apis"` as the field
name for supported API frameworks. `Object: Video` (§3.2.7) defines
this attribute as `api` (singular) — unlike `Bid`, where `api` was
deprecated in favor of `apis`, `Video` was never renamed and still uses
`api`.

## Note on #128's third item

#128 also reported a `user` object shown nested inside `site` in
Example 1 – Simple Banner. Checked current `develop` content: `user` is
already a top-level sibling of `site`, correctly structured — this item
no longer applies (may have already been fixed, or was based on an
older revision). Not part of this PR.

## Fix

Two commits, one per logical change per the contribution guide:
1. Wrap the stray `value` in a `segment` array on the `Data` object.
2. Rename `apis` → `api` on the `Video` object.

## Test plan
- [x] Validated both corrected example JSON blocks parse as valid JSON.