### PR TITLE
Fix Appendix A Google Metro Codes link to point at the actual metro/DMA data

### DIFF
--- a/2.6.md
+++ b/2.6.md
@@ -2121,7 +2121,7 @@ code.google.com/p/protobuf
 	
 - Google Metro Codes
 	
- 	https://developers.google.com/google-ads/api/reference/data/geotargets
+ 	https://storage.googleapis.com/adx-rtb-dictionaries/geo-table.csv (see rows where Target_Type is "DMA Region"; referenced from Google's Authorized Buyers RTB guide: https://developers.google.com/authorized-buyers/rtb/openrtb-guide)
 	
 - U.N. Code for Trade and Transport Locations:
 	


### PR DESCRIPTION
Fixes #180.

## Summary

`Geo.metro` (§3.2.19) is documented as a "Google metro code; similar to
but not exactly Nielsen DMAs," directing readers to Appendix A for the
codes. Appendix A's "Google Metro Codes" entry links to the [Google Ads
geotargets reference](https://developers.google.com/google-ads/api/reference/data/geotargets),
whose CSV has no metro or DMA concept at all — its Target Types are
Country, State, City, Postal Code, etc. (confirmed by the issue reporter
by downloading and inspecting the CSV directly).

## Investigation

Google's own [Authorized Buyers RTB guide](https://developers.google.com/authorized-buyers/rtb/openrtb-guide)
instead references a different file, `geo-table.csv`, for RTB geo
targeting. I downloaded and inspected that file directly (not just the
issue's excerpt) to verify before proposing a fix:

- 210 rows have `Target_Type` = `"DMA Region"`, with `Criteria_ID`s in
  the 200500–200881 range.
- Their names are exactly Nielsen DMA codes offset by 200000:
  - `200501` → `"New York, NY"` (Nielsen DMA 501)
  - `200803` → `"Los Angeles, CA"` (Nielsen DMA 803)
  - `200602` → `"Chicago, IL"` (Nielsen DMA 602)
  - `200807` → `"San Francisco-Oakland-San Jose, CA"` (Nielsen DMA 807)

This matches the spec's own description — "similar to but not exactly
Nielsen DMAs" — exactly.

## Fix

Updates the Appendix A link to `geo-table.csv`, notes which rows to use
(`Target_Type` = `"DMA Region"`), and cites the Google guide that
references it, so the link and the field description are finally
consistent.

Related to #153, the original dead-link fix that (unknowingly) swapped
in this still-incorrect replacement link.