### PR TITLE
Add agentic audiences field to proto spec

### DIFF
--- a/proto/src/main/com/iabtechlab/openrtb/v2/openrtb.proto
+++ b/proto/src/main/com/iabtechlab/openrtb/v2/openrtb.proto
@@ -2263,7 +2263,23 @@ message BidRequest {
     Ext ext = 99;
 
     message Ext {
+      // Agentic Audiences envelope containing the embedding and metadata.
+      Aa aa = 1;
+
       extensions 500 to max;
+
+      // This object carries the embedding vector and metadata so that buyers
+      // can interpret the segment (e.g., by model or signal type) validate
+      // compatibility, and use the vector for scoring or similarity operations.
+      // Detailed implementation examples can be found here:
+      // https://github.com/InteractiveAdvertisingBureau/openrtb/blob/main/extensions/community_extensions/agentic-audiences.md
+      message Aa {
+        string ver = 1;
+        string vector = 2;
+        int32 dimension = 3;
+        string model = 4;
+        repeated int32 type = 5;
+      }
     }
   }  // Segment
 


### PR DESCRIPTION
### Summary

Add support for the Agentic Audiences aa extension to the OpenRTB protobuf specification.

### Changes

- Add the aa extension under Segment.ext to align the protobuf representation with the existing Agentic Audiences OpenRTB extension.
- Add the Agentic Audiences envelope fields under BidRequest.user.data.segment.ext:
    - ver — Agentic Audiences specification version
    - vector — Base64-encoded Float32 embedding
    - dimension — Number of values in the embedding
    - model — Model identifier used to generate the embedding
    - type — Embedding signal types (identity, contextual, reinforcement)
- Maintain compatibility with the existing JSON/OpenRTB representation defined by the IAB Agentic Audiences extension.

### Motivation

The Agentic Audiences extension defines the aa object under Segment.ext.aa for carrying embedding data and associated metadata. The protobuf specification currently does not expose this extension, preventing Agentic Audiences data from being represented consistently when using the protobuf-based OpenRTB API.

This change brings the protobuf specification in alignment with the existing Agentic Audiences OpenRTB extension and enables downstream consumers to access the same embedding and metadata fields.

Reference: [Agentic Audiences OpenRTB Extension](https://github.com/InteractiveAdvertisingBureau/openrtb/blob/main/extensions/community_extensions/agentic-audiences.md)

### Scope

This MR is limited to adding the protobuf schema representation of the existing aa extension. It does not introduce new Agentic Audiences behavior or modify the semantics of the existing OpenRTB extension.